### PR TITLE
Update dependencies (brick/math 0.15-0.17)

### DIFF
--- a/.ci-tools/phpstan-baseline.neon
+++ b/.ci-tools/phpstan-baseline.neon
@@ -61,6 +61,12 @@ parameters:
 			path: ../src/Algorithm/Signature/ECDSA/ECDSA.php
 
 		-
+			rawMessage: "Strict comparison using === between '30' and '81' will always evaluate to false."
+			identifier: identical.alwaysFalse
+			count: 1
+			path: ../src/Algorithm/Signature/ECDSA/ECSignature.php
+
+		-
 			rawMessage: 'Method Cose\Algorithm\Signature\ECDSA\ECSignature::fromAsn1() should return string but returns string|false.'
 			identifier: return.type
 			count: 1
@@ -248,12 +254,6 @@ parameters:
 
 		-
 			rawMessage: 'Parameter #1 $array of function current expects array|object, array|false given.'
-			identifier: argument.type
-			count: 1
-			path: ../src/BigInteger.php
-
-		-
-			rawMessage: 'Parameter #1 $number of static method Brick\Math\BigInteger::fromBase() expects string, mixed given.'
 			identifier: argument.type
 			count: 1
 			path: ../src/BigInteger.php
@@ -534,11 +534,6 @@ parameters:
 			count: 1
 			path: ../src/Key/RsaKey.php
 
-		-
-			rawMessage: 'Parameter #1 $number of static method Brick\Math\BigInteger::fromBase() expects string, mixed given.'
-			identifier: argument.type
-			count: 1
-			path: ../src/Key/RsaKey.php
 
 		-
 			rawMessage: Cannot cast mixed to int.

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": ">=8.1",
         "ext-json": "*",
         "ext-openssl": "*",
-        "brick/math": "^0.9|^0.10|^0.11|^0.12|^0.13|^0.14",
+        "brick/math": "^0.9|^0.10|^0.11|^0.12|^0.13|^0.14|^0.15|^0.16|^0.17",
         "spomky-labs/pki-framework": "^1.0"
     },
     "require-dev": {

--- a/src/Algorithm/Manager.php
+++ b/src/Algorithm/Manager.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Cose\Algorithm;
 
-use InvalidArgumentException;
 use function array_key_exists;
+use InvalidArgumentException;
 
 final class Manager
 {

--- a/src/Algorithm/ManagerFactory.php
+++ b/src/Algorithm/ManagerFactory.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Cose\Algorithm;
 
-use InvalidArgumentException;
 use function array_key_exists;
+use InvalidArgumentException;
 use function sprintf;
 
 final class ManagerFactory

--- a/src/Algorithm/Signature/ECDSA/ECSignature.php
+++ b/src/Algorithm/Signature/ECDSA/ECSignature.php
@@ -4,15 +4,15 @@ declare(strict_types=1);
 
 namespace Cose\Algorithm\Signature\ECDSA;
 
-use InvalidArgumentException;
 use function bin2hex;
 use function dechex;
 use function hex2bin;
 use function hexdec;
+use InvalidArgumentException;
 use function str_pad;
+use const STR_PAD_LEFT;
 use function strlen;
 use function substr;
-use const STR_PAD_LEFT;
 
 /**
  * @internal
@@ -67,7 +67,6 @@ final class ECSignature
             throw new InvalidArgumentException('Invalid data. Should start with a sequence.');
         }
 
-        // @phpstan-ignore-next-line
         if (self::readAsn1Content($message, $position, self::BYTE_SIZE) === self::ASN1_LENGTH_2BYTES) {
             $position += self::BYTE_SIZE;
         }

--- a/src/Algorithm/Signature/EdDSA/EdDSA.php
+++ b/src/Algorithm/Signature/EdDSA/EdDSA.php
@@ -9,9 +9,9 @@ use Cose\Algorithms;
 use Cose\Key\Key;
 use Cose\Key\OkpKey;
 use InvalidArgumentException;
-use Throwable;
 use function sodium_crypto_sign_detached;
 use function sodium_crypto_sign_verify_detached;
+use Throwable;
 
 /**
  * @see \Cose\Tests\Algorithm\Signature\EdDSA\EdDSATest

--- a/src/Algorithm/Signature/RSA/PSSRSA.php
+++ b/src/Algorithm/Signature/RSA/PSSRSA.php
@@ -4,23 +4,23 @@ declare(strict_types=1);
 
 namespace Cose\Algorithm\Signature\RSA;
 
+use function ceil;
+use function chr;
 use Cose\Algorithm\Signature\Signature;
 use Cose\BigInteger;
 use Cose\Hash;
 use Cose\Key\Key;
 use Cose\Key\RsaKey;
-use InvalidArgumentException;
-use RuntimeException;
-use function ceil;
-use function chr;
 use function hash_equals;
+use InvalidArgumentException;
 use function ord;
 use function pack;
 use function random_bytes;
+use RuntimeException;
 use function str_pad;
+use const STR_PAD_LEFT;
 use function str_repeat;
 use function strlen;
-use const STR_PAD_LEFT;
 
 /**
  * @internal

--- a/src/Algorithm/Signature/RSA/RSA.php
+++ b/src/Algorithm/Signature/RSA/RSA.php
@@ -8,9 +8,9 @@ use Cose\Algorithm\Signature\Signature;
 use Cose\Key\Key;
 use Cose\Key\RsaKey;
 use InvalidArgumentException;
-use Throwable;
 use function openssl_sign;
 use function openssl_verify;
+use Throwable;
 
 /**
  * @see \Cose\Tests\Algorithm\Signature\RSA\RSATest

--- a/src/Algorithms.php
+++ b/src/Algorithms.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Cose;
 
-use InvalidArgumentException;
 use function array_key_exists;
+use InvalidArgumentException;
 use const OPENSSL_ALGO_SHA1;
 use const OPENSSL_ALGO_SHA256;
 use const OPENSSL_ALGO_SHA384;

--- a/src/BigInteger.php
+++ b/src/BigInteger.php
@@ -23,6 +23,7 @@ final class BigInteger
     public static function createFromBinaryString(string $value): self
     {
         $res = unpack('H*', $value);
+        /** @var non-empty-string $data */
         $data = current($res);
 
         return new self(BrickBigInteger::fromBase($data, 16));

--- a/src/Key/Ec2Key.php
+++ b/src/Key/Ec2Key.php
@@ -4,16 +4,16 @@ declare(strict_types=1);
 
 namespace Cose\Key;
 
+use function array_key_exists;
+use function in_array;
 use InvalidArgumentException;
+use function is_int;
 use SpomkyLabs\Pki\ASN1\Type\Constructed\Sequence;
 use SpomkyLabs\Pki\ASN1\Type\Primitive\BitString;
 use SpomkyLabs\Pki\ASN1\Type\Primitive\Integer;
 use SpomkyLabs\Pki\ASN1\Type\Primitive\ObjectIdentifier;
 use SpomkyLabs\Pki\ASN1\Type\Primitive\OctetString;
 use SpomkyLabs\Pki\ASN1\Type\Tagged\ExplicitlyTaggedType;
-use function array_key_exists;
-use function in_array;
-use function is_int;
 use function sprintf;
 use function strlen;
 

--- a/src/Key/Key.php
+++ b/src/Key/Key.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Cose\Key;
 
-use InvalidArgumentException;
 use function array_key_exists;
+use InvalidArgumentException;
 use function sprintf;
 
 class Key

--- a/src/Key/OkpKey.php
+++ b/src/Key/OkpKey.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Cose\Key;
 
-use InvalidArgumentException;
 use function array_key_exists;
 use function in_array;
+use InvalidArgumentException;
 
 /**
  * @final

--- a/src/Key/RsaKey.php
+++ b/src/Key/RsaKey.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Cose\Key;
 
+use function array_key_exists;
 use Brick\Math\BigInteger;
+use function in_array;
 use InvalidArgumentException;
 use SpomkyLabs\Pki\CryptoTypes\Asymmetric\PublicKeyInfo;
 use SpomkyLabs\Pki\CryptoTypes\Asymmetric\RSA\RSAPrivateKey;
 use SpomkyLabs\Pki\CryptoTypes\Asymmetric\RSA\RSAPublicKey;
-use function array_key_exists;
-use function in_array;
 
 /**
  * @final
@@ -255,6 +255,7 @@ class RsaKey extends Key
     private function binaryToBigInteger(string $data): string
     {
         $res = unpack('H*', $data);
+        /** @var non-empty-string $res */
         $res = current($res);
 
         return BigInteger::fromBase($res, 16)->toBase(10);

--- a/tests/Algorithm/Mac/HS256Test.php
+++ b/tests/Algorithm/Mac/HS256Test.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Cose\Tests\Algorithm\Mac;
 
+use function base64_decode;
 use Cose\Algorithm\Mac\HS256;
 use Cose\Key\OkpKey;
 use Cose\Key\SymmetricKey;
@@ -11,7 +12,6 @@ use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
-use function base64_decode;
 
 final class HS256Test extends TestCase
 {

--- a/tests/Algorithm/Mac/HmacTest.php
+++ b/tests/Algorithm/Mac/HmacTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Cose\Tests\Algorithm\Mac;
 
+use function base64_decode;
 use Cose\Algorithm\Mac\Hmac;
 use Cose\Algorithm\Mac\HS256;
 use Cose\Algorithm\Mac\HS256Truncated64;
@@ -15,7 +16,6 @@ use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
-use function base64_decode;
 
 final class HmacTest extends TestCase
 {

--- a/tests/Signature/CoseSign1Test.php
+++ b/tests/Signature/CoseSign1Test.php
@@ -4,17 +4,17 @@ declare(strict_types=1);
 
 namespace Cose\Tests\Signature;
 
+use function base64_decode;
 use CBOR\Decoder;
 use CBOR\OtherObject\OtherObjectManager;
 use CBOR\StringStream;
 use CBOR\Tag\TagManager;
 use Cose\Signature\CoseSign1Tag;
 use Cose\Signature\Signature1;
+use function openssl_verify;
 use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
-use function base64_decode;
-use function openssl_verify;
 
 final class CoseSign1Test extends TestCase
 {

--- a/tests/Signature/ECSignature.php
+++ b/tests/Signature/ECSignature.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Cose\Tests\Signature;
 
-use InvalidArgumentException;
 use function hex2bin;
+use InvalidArgumentException;
 use function mb_strlen;
 use function mb_strpos;
 use function mb_substr;


### PR DESCRIPTION
## Summary
- Widen `brick/math` constraint to support `^0.15|^0.16|^0.17`
- Fix PHPStan errors caused by stricter type signatures (`non-empty-string`) in newer brick/math versions
- Update PHPStan baseline accordingly
- Apply ECS coding style fixes (import ordering)

## Test plan
- [x] `castor rector` — OK
- [x] `castor ecs` — OK
- [x] `castor phpstan` — OK
- [x] `castor phpunit` — 73 tests, 156 assertions passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)