### PR TITLE
Fix ES256K algorithm value per RFC8812

### DIFF
--- a/src/Algorithms.php
+++ b/src/Algorithms.php
@@ -121,7 +121,7 @@ abstract class Algorithms
 
     final public const COSE_ALGORITHM_RSAES_OAEP_512 = -42;
 
-    final public const COSE_ALGORITHM_ES256K = -46;
+    final public const COSE_ALGORITHM_ES256K = -47;
 
     final public const COSE_ALGORITHM_RS256 = -257;
 


### PR DESCRIPTION
## Summary
- Fix ES256K algorithm value to `-47` as specified in [RFC8812](https://datatracker.ietf.org/doc/html/rfc8812)
- Cherry-picked from #131 (original author: @Jampire)

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)