### PR TITLE
Fix ES256K ID

### DIFF
--- a/src/Algorithm/Signature/ECDSA/ES256K.php
+++ b/src/Algorithm/Signature/ECDSA/ES256K.php
@@ -9,7 +9,7 @@ use const OPENSSL_ALGO_SHA256;
 
 final class ES256K extends ECDSA
 {
-    public const ID = -46;
+    public const ID = -47;
 
     public static function create(): self
     {

--- a/tests/Algorithm/Signature/ECDSA/ECDSATest.php
+++ b/tests/Algorithm/Signature/ECDSA/ECDSATest.php
@@ -23,7 +23,7 @@ final class ECDSATest extends TestCase
     {
         // Then
         static::assertSame(-7, ES256::identifier());
-        static::assertSame(-46, ES256K::identifier());
+        static::assertSame(-47, ES256K::identifier());
         static::assertSame(-35, ES384::identifier());
         static::assertSame(-36, ES512::identifier());
     }


### PR DESCRIPTION
-47 is ES256K, and -46 is HSS-LMS
https://www.iana.org/assignments/cose/cose.xhtml

The library uses -47 in other places

Target branch: 4.5.x
Resolves issue # <!-- #-prefixed issue number(s), if any -->

<!-- replace space with "x" in square brackets: [x] -->
- [x] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

<!--
Fill in this template according to the PR you're about to submit.
Replace this comment by a description of what your PR is solving.

Please consider the following requirement:
* Modification of existing tests should be avoided unless deemed necessary.
* You MUST never open a PR related to a security issue. Contact Spomky in private at https://gitter.im/Spomky/
-->

See also: https://github.com/web-auth/cose-lib/pull/137