### PR TITLE
Fix ES256K ID in class constant and test

### DIFF
--- a/src/Algorithm/Signature/ECDSA/ES256K.php
+++ b/src/Algorithm/Signature/ECDSA/ES256K.php
@@ -9,7 +9,7 @@ use const OPENSSL_ALGO_SHA256;
 
 final class ES256K extends ECDSA
 {
-    public const ID = -46;
+    public const ID = -47;
 
     public static function create(): self
     {

--- a/tests/Algorithm/Signature/ECDSA/ECDSATest.php
+++ b/tests/Algorithm/Signature/ECDSA/ECDSATest.php
@@ -23,7 +23,7 @@ final class ECDSATest extends TestCase
     {
         // Then
         static::assertSame(-7, ES256::identifier());
-        static::assertSame(-46, ES256K::identifier());
+        static::assertSame(-47, ES256K::identifier());
         static::assertSame(-35, ES384::identifier());
         static::assertSame(-36, ES512::identifier());
     }


### PR DESCRIPTION
-47 is ES256K, and -46 is HSS-LMS
https://www.iana.org/assignments/cose/cose.xhtml

The library uses -47 in `src/Algorithms.php` (already fixed in #135), but the `ES256K` class constant and the corresponding test still used -46. This PR aligns them.

Reapplies the change originally proposed in #140 (closed).

Target branch: 4.5.x

- [x] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations