### PR TITLE
ci: fix merge-up step in automatic releases workflow

### DIFF
--- a/.github/workflows/release-on-milestone-closed.yml
+++ b/.github/workflows/release-on-milestone-closed.yml
@@ -34,6 +34,8 @@ jobs:
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v6.0.1"
+        with:
+          fetch-depth: 0
 
       - name: "Create Merge-Up Pull Request"
         uses: "laminas/automatic-releases@1.25.0"


### PR DESCRIPTION
## Summary

The \`Create Merge-Up Pull Request\` step in \`release-on-milestone-closed.yml\` has been failing on every release where a merge-up was needed (Aug 2025, Apr 2026, May 2026), because \`actions/checkout\` only fetches the triggering ref by default. When \`laminas/automatic-releases\` then runs \`git branch temporary-xxx <source-branch>\`, it fails with:

\`\`\`
fatal: not a valid object name: '4.5.x'
\`\`\`

Setting \`fetch-depth: 0\` on the checkout makes all branches and tags available, matching what the \`bump\` job in the same workflow already does.

Target branch: 4.5.x

- [x] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations