### PR TITLE
ci: run the whole release sequence in a single job

### DIFF
--- a/.github/workflows/release-on-milestone-closed.yml
+++ b/.github/workflows/release-on-milestone-closed.yml
@@ -1,5 +1,11 @@
 name: "Automatic Releases"
 
+# The five commands must stay steps of a single job: "release" runs
+# `git checkout <release branch>`, which is what makes that branch available
+# locally, and the following commands require it. Splitting them into separate
+# jobs gives each one a fresh checkout of the default branch, so every release
+# made from an older branch fails with "not a valid object name".
+
 on:
   milestone:
     types:
@@ -25,18 +31,6 @@ jobs:
           "GIT_AUTHOR_NAME": ${{ secrets.GIT_AUTHOR_NAME }}
           "GIT_AUTHOR_EMAIL": ${{ secrets.GIT_AUTHOR_EMAIL }}
 
-  merge-up:
-    name: "Create Merge-Up Pull Request"
-    runs-on: ubuntu-latest
-    if: ${{ always() }}
-    needs: "release"
-
-    steps:
-      - name: "Checkout"
-        uses: "actions/checkout@v7.0.1"
-        with:
-          fetch-depth: 0
-
       - name: "Create Merge-Up Pull Request"
         uses: "laminas/automatic-releases@1.26.2"
         with:
@@ -47,16 +41,6 @@ jobs:
           "SIGNING_SECRET_KEY": ${{ secrets.SIGNING_SECRET_KEY }}
           "GIT_AUTHOR_NAME": ${{ secrets.GIT_AUTHOR_NAME }}
           "GIT_AUTHOR_EMAIL": ${{ secrets.GIT_AUTHOR_EMAIL }}
-
-  switch:
-    name: "Create and/or Switch to new Release Branch"
-    runs-on: ubuntu-latest
-    if: ${{ always() }}
-    needs: "merge-up"
-
-    steps:
-      - name: "Checkout"
-        uses: "actions/checkout@v7.0.1"
 
       - name: "Create and/or Switch to new Release Branch"
         uses: "laminas/automatic-releases@1.26.2"
@@ -69,18 +53,6 @@ jobs:
           "GIT_AUTHOR_NAME": ${{ secrets.GIT_AUTHOR_NAME }}
           "GIT_AUTHOR_EMAIL": ${{ secrets.GIT_AUTHOR_EMAIL }}
 
-  bump:
-    name: "Bump Changelog Version On Originating Release Branch"
-    runs-on: ubuntu-latest
-    if: ${{ always() }}
-    needs: "switch"
-
-    steps:
-      - name: "Checkout"
-        uses: "actions/checkout@v7.0.1"
-        with:
-          fetch-depth: 0
-
       - name: "Bump Changelog Version On Originating Release Branch"
         uses: "laminas/automatic-releases@1.26.2"
         with:
@@ -91,16 +63,6 @@ jobs:
           "SIGNING_SECRET_KEY": ${{ secrets.SIGNING_SECRET_KEY }}
           "GIT_AUTHOR_NAME": ${{ secrets.GIT_AUTHOR_NAME }}
           "GIT_AUTHOR_EMAIL": ${{ secrets.GIT_AUTHOR_EMAIL }}
-
-  milestones:
-    name: "Create new milestones"
-    runs-on: ubuntu-latest
-    if: ${{ always() }}
-    needs: "bump"
-
-    steps:
-      - name: "Checkout"
-        uses: "actions/checkout@v7.0.1"
 
       - name: "Create new milestones"
         uses: "laminas/automatic-releases@1.26.2"


### PR DESCRIPTION
The `release` command runs `git checkout <release branch>`, which is what makes that branch available locally. The four commands that follow need it — `create-merge-up-pull-request` in particular runs `git branch <tmp> <release branch>`.

Running each command in its own job gave every one a fresh `actions/checkout` of the **default** branch, so any release cut from an older branch failed with:

```
Shell command "exec git 'branch' 'temporary-branchXXXXXXXX' '4.1.x'" returned an exit code of "128".
STDERR: fatal: not a valid object name: '4.1.x'
```

Making the five commands steps of a single job — which is what the [upstream reference workflow](https://github.com/laminas/workflow-automatic-releases/blob/1.x/.github/workflows/release-on-milestone-closed.yml) does — shares one workspace and fixes it. No merge-up pull request has been created automatically for a long time because of this.

Pinned versions of `laminas/automatic-releases` and `actions/checkout` are unchanged, and every command keeps the exact token it had (`ORGANIZATION_ADMIN_TOKEN` for `release` and `switch-default-branch-to-next-minor`, `GITHUB_TOKEN` for the rest).

Side effect, deliberate: the `if: always()` chain disappears with the jobs. A failing step no longer lets the following ones create the next release branch and bump the milestones for a release that never happened.