### PR TITLE
fix(rsa): make RSASSA-PSS follow RFC 8017

### DIFF
--- a/.ci-tools/phpstan-baseline.neon
+++ b/.ci-tools/phpstan-baseline.neon
@@ -559,7 +559,7 @@ parameters:
 			path: ../src/Key/RsaKey.php
 
 		-
-			rawMessage: 'Method Cose\Key\RsaKey::other() should return array<mixed> but returns mixed.'
+			rawMessage: 'Method Cose\Key\RsaKey::other() should return array<int, array<int, string>> but returns mixed.'
 			identifier: return.type
 			count: 1
 			path: ../src/Key/RsaKey.php

--- a/src/Algorithm/Signature/RSA/PSSRSA.php
+++ b/src/Algorithm/Signature/RSA/PSSRSA.php
@@ -4,14 +4,15 @@ declare(strict_types=1);
 
 namespace Cose\Algorithm\Signature\RSA;
 
-use function ceil;
 use function chr;
 use Cose\Algorithm\Signature\Signature;
 use Cose\BigInteger;
 use Cose\Hash;
 use Cose\Key\Key;
 use Cose\Key\RsaKey;
+use Cose\Key\RsaKeyValidator;
 use function hash_equals;
+use function intdiv;
 use InvalidArgumentException;
 use function ord;
 use function pack;
@@ -23,6 +24,10 @@ use function str_repeat;
 use function strlen;
 
 /**
+ * RSASSA-PSS as defined by RFC 8017, section 8.1.
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc8017#section-8.1
+ *
  * @internal
  */
 abstract class PSSRSA implements Signature
@@ -30,62 +35,48 @@ abstract class PSSRSA implements Signature
     public function sign(string $data, Key $key): string
     {
         $key = $this->handleKey($key);
-        $modulusLength = strlen($key->n());
+        if (! $key->isPrivate()) {
+            throw new InvalidArgumentException('The key is not private.');
+        }
+        // RFC 8017, section 3.1: modBits is the length in bits of the modulus and k its length in octets. Both are
+        // derived from the integer value of n, not from the number of octets used to encode it.
+        $modBits = RsaKeyValidator::modulusLength($key);
+        $k = intdiv($modBits + 7, 8);
 
-        $em = $this->encodeEMSAPSS($data, 8 * $modulusLength - 1, $this->getHashAlgorithm());
-        $message = BigInteger::createFromBinaryString($em);
-        $signature = $this->exponentiate($key, $message);
+        // RFC 8017, section 8.1.1, steps 1 and 2.
+        $em = $this->encodeEMSAPSS($data, $modBits - 1, $this->getHashAlgorithm());
+        $signature = $this->rsasp1($key, BigInteger::createFromBinaryString($em));
 
-        return $this->convertIntegerToOctetString($signature, $modulusLength);
+        return $this->convertIntegerToOctetString($signature, $k);
     }
 
     public function verify(string $data, Key $key, string $signature): bool
     {
-        $key = $this->handleKey($key);
-        $modulusLength = strlen($key->n());
-        if (strlen($signature) !== $modulusLength) {
-            throw new InvalidArgumentException('Invalid modulus length');
+        // RFC 8017, section 8.1.2: the verification operation uses the public key (n, e) only.
+        $key = $this->handleKey($key)
+            ->toPublic();
+        $modBits = RsaKeyValidator::modulusLength($key);
+        $k = intdiv($modBits + 7, 8);
+        if (strlen($signature) !== $k) {
+            throw new InvalidArgumentException('Invalid signature length');
         }
-        $s2 = BigInteger::createFromBinaryString($signature);
-        $m2 = $this->exponentiate($key, $s2);
-        $em = $this->convertIntegerToOctetString($m2, $modulusLength);
-        $modBits = 8 * $modulusLength;
+        $m = $this->rsavp1($key, BigInteger::createFromBinaryString($signature));
+        // RFC 8017, section 8.1.2, step 2.c: emLen = ceil((modBits - 1) / 8).
+        $emLen = intdiv($modBits - 1 + 7, 8);
+        $em = $this->convertIntegerToOctetString($m, $emLen);
 
         return $this->verifyEMSAPSS($data, $em, $modBits - 1, $this->getHashAlgorithm());
     }
 
     /**
      * Exponentiate with or without Chinese Remainder Theorem. Operation with primes 'p' and 'q' is appox. 2x faster.
+     *
+     * The operation is selected from the key: RSASP1 (RFC 8017, section 5.2.1) for a private key, RSAVP1 (section
+     * 5.2.2) for a public one.
      */
     public function exponentiate(RsaKey $key, BigInteger $c): BigInteger
     {
-        if ($c->compare(BigInteger::createFromDecimal(0)) < 0 || $c->compare(
-            BigInteger::createFromBinaryString($key->n())
-        ) > 0) {
-            throw new RuntimeException();
-        }
-        if ($key->isPublic() || ! $key->hasPrimes() || ! $key->hasExponents() || ! $key->hasCoefficient()) {
-            return $c->modPow(
-                BigInteger::createFromBinaryString($key->e()),
-                BigInteger::createFromBinaryString($key->n())
-            );
-        }
-
-        [$pS, $qS] = $key->primes();
-        [$dPS, $dQS] = $key->exponents();
-        $qInv = BigInteger::createFromBinaryString($key->QInv());
-        $p = BigInteger::createFromBinaryString($pS);
-        $q = BigInteger::createFromBinaryString($qS);
-        $dP = BigInteger::createFromBinaryString($dPS);
-        $dQ = BigInteger::createFromBinaryString($dQS);
-
-        $m1 = $c->modPow($dP, $p);
-        $m2 = $c->modPow($dQ, $q);
-        $h = $qInv->multiply($m1->subtract($m2)->add($p))
-            ->mod($p)
-        ;
-
-        return $m2->add($h->multiply($q));
+        return $key->isPrivate() ? $this->rsasp1($key, $c) : $this->rsavp1($key, $c);
     }
 
     abstract protected function getHashAlgorithm(): Hash;
@@ -93,6 +84,82 @@ abstract class PSSRSA implements Signature
     private function handleKey(Key $key): RsaKey
     {
         return RsaKey::create($key->getData());
+    }
+
+    /**
+     * RSAVP1 (RFC 8017, section 5.2.2).
+     */
+    private function rsavp1(RsaKey $key, BigInteger $s): BigInteger
+    {
+        $n = BigInteger::createFromBinaryString($key->n());
+        if ($s->compare(BigInteger::createFromDecimal(0)) < 0 || $s->compare($n) >= 0) {
+            throw new RuntimeException('Signature representative out of range');
+        }
+
+        return $s->modPow(BigInteger::createFromBinaryString($key->e()), $n);
+    }
+
+    /**
+     * RSASP1 (RFC 8017, section 5.2.1).
+     */
+    private function rsasp1(RsaKey $key, BigInteger $m): BigInteger
+    {
+        $n = BigInteger::createFromBinaryString($key->n());
+        if ($m->compare(BigInteger::createFromDecimal(0)) < 0 || $m->compare($n) >= 0) {
+            throw new RuntimeException('Message representative out of range');
+        }
+        $signature = $key->hasPrimes() && $key->hasExponents() && $key->hasCoefficient()
+            ? $this->rsasp1WithCrt($key, $m)
+            // RFC 8017, section 5.2.1, step 2.a: first form (n, d).
+            : $m->modPow(BigInteger::createFromBinaryString($key->d()), $n);
+
+        // A wrong CRT result must never leave this class: it would be a silently invalid signature and, on faulty
+        // hardware, a private key recovery oracle. OpenSSL applies the very same check.
+        if ($signature->modPow(BigInteger::createFromBinaryString($key->e()), $n)->compare($m) !== 0) {
+            throw new RuntimeException(
+                'Inconsistent RSA private key: the CRT parameters do not describe the modulus'
+            );
+        }
+
+        return $signature;
+    }
+
+    /**
+     * RFC 8017, section 5.2.1, step 2.b.
+     */
+    private function rsasp1WithCrt(RsaKey $key, BigInteger $m): BigInteger
+    {
+        [$pS, $qS] = $key->primes();
+        [$dPS, $dQS] = $key->exponents();
+        $p = BigInteger::createFromBinaryString($pS);
+        $q = BigInteger::createFromBinaryString($qS);
+
+        // Steps 2.b.1, 2.b.3 and 2.b.4.
+        $s1 = $m->modPow(BigInteger::createFromBinaryString($dPS), $p);
+        $s2 = $m->modPow(BigInteger::createFromBinaryString($dQS), $q);
+        $h = $s1->subtract($s2)
+            ->multiply(BigInteger::createFromBinaryString($key->QInv()))
+            ->mod($p)
+        ;
+        $signature = $s2->add($h->multiply($q));
+        if (! $key->has(RsaKey::DATA_OTHER)) {
+            return $signature;
+        }
+
+        // Steps 2.b.2 and 2.b.5, for the third to u-th primes of a multi-prime key (RFC 8230, section 4).
+        $r = $p->multiply($q);
+        foreach ($key->other() as $primeInfo) {
+            $rI = BigInteger::createFromBinaryString($primeInfo[RsaKey::DATA_RI]);
+            $sI = $m->modPow(BigInteger::createFromBinaryString($primeInfo[RsaKey::DATA_DI]), $rI);
+            $h = $sI->subtract($signature)
+                ->multiply(BigInteger::createFromBinaryString($primeInfo[RsaKey::DATA_TI]))
+                ->mod($rI)
+            ;
+            $signature = $signature->add($r->multiply($h));
+            $r = $r->multiply($rI);
+        }
+
+        return $signature;
     }
 
     private function convertIntegerToOctetString(BigInteger $x, int $xLen): string
@@ -111,7 +178,7 @@ abstract class PSSRSA implements Signature
     private function getMGF1(string $mgfSeed, int $maskLen, Hash $mgfHash): string
     {
         $t = '';
-        $count = ceil($maskLen / $mgfHash->getLength());
+        $count = intdiv($maskLen + $mgfHash->getLength() - 1, $mgfHash->getLength());
         for ($i = 0; $i < $count; ++$i) {
             $c = pack('N', $i);
             $t .= $mgfHash->hash($mgfSeed . $c);
@@ -121,57 +188,77 @@ abstract class PSSRSA implements Signature
     }
 
     /**
-     * EMSA-PSS-ENCODE.
+     * The mask of the leftmost 8emLen - emBits bits of the leftmost octet of maskedDB (RFC 8017, section 9.1.1, step
+     * 11 and section 9.1.2, steps 6 and 9). It is 0x00 when the encoded message is byte aligned and nothing has to be
+     * cleared.
      */
-    private function encodeEMSAPSS(string $message, int $modulusLength, Hash $hash): string
+    private function leftmostBitsMask(int $emBits): string
     {
-        $emLen = ($modulusLength + 1) >> 3;
-        $sLen = $hash->getLength();
+        $bitsToClear = 8 * intdiv($emBits + 7, 8) - $emBits;
+
+        return chr((0xFF << (8 - $bitsToClear)) & 0xFF);
+    }
+
+    /**
+     * EMSA-PSS-ENCODE (RFC 8017, section 9.1.1).
+     */
+    private function encodeEMSAPSS(string $message, int $emBits, Hash $hash): string
+    {
+        $emLen = intdiv($emBits + 7, 8);
+        $hLen = $hash->getLength();
+        $sLen = $hLen;
         $mHash = $hash->hash($message);
-        if ($emLen <= $hash->getLength() + $sLen + 2) {
-            throw new RuntimeException();
+        if ($emLen < $hLen + $sLen + 2) {
+            throw new RuntimeException(
+                'Encoding error: the modulus is too short for this hash and salt length'
+            );
         }
         $salt = random_bytes($sLen);
         $m2 = "\0\0\0\0\0\0\0\0" . $mHash . $salt;
         $h = $hash->hash($m2);
-        $ps = str_repeat(chr(0), $emLen - $sLen - $hash->getLength() - 2);
+        $ps = str_repeat(chr(0), $emLen - $sLen - $hLen - 2);
         $db = $ps . chr(1) . $salt;
-        $dbMask = $this->getMGF1($h, $emLen - $hash->getLength() - 1, $hash);
+        $dbMask = $this->getMGF1($h, $emLen - $hLen - 1, $hash);
         $maskedDB = $db ^ $dbMask;
-        $maskedDB[0] = ~chr(0xFF << ($modulusLength & 7)) & $maskedDB[0];
+        $maskedDB[0] = ~$this->leftmostBitsMask($emBits) & $maskedDB[0];
 
         return $maskedDB . $h . chr(0xBC);
     }
 
     /**
-     * EMSA-PSS-VERIFY.
+     * EMSA-PSS-VERIFY (RFC 8017, section 9.1.2).
      */
     private function verifyEMSAPSS(string $m, string $em, int $emBits, Hash $hash): bool
     {
-        $emLen = ($emBits + 1) >> 3;
-        $sLen = $hash->getLength();
+        $emLen = intdiv($emBits + 7, 8);
+        $hLen = $hash->getLength();
+        $sLen = $hLen;
         $mHash = $hash->hash($m);
-        if ($emLen < $hash->getLength() + $sLen + 2) {
-            throw new InvalidArgumentException();
+        if ($emLen < $hLen + $sLen + 2) {
+            throw new InvalidArgumentException(
+                'Inconsistent signature: the modulus is too short for this hash and salt length'
+            );
         }
         if ($em[strlen($em) - 1] !== chr(0xBC)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException('Inconsistent signature: the trailer field is not 0xBC');
         }
-        $maskedDB = substr($em, 0, -$hash->getLength() - 1);
-        $h = substr($em, -$hash->getLength() - 1, $hash->getLength());
-        $temp = chr(0xFF << ($emBits & 7));
-        if ((~$maskedDB[0] & $temp) !== $temp) {
-            throw new InvalidArgumentException();
+        $maskedDB = substr($em, 0, -$hLen - 1);
+        $h = substr($em, -$hLen - 1, $hLen);
+        $mask = $this->leftmostBitsMask($emBits);
+        if (($maskedDB[0] & $mask) !== chr(0)) {
+            throw new InvalidArgumentException(
+                'Inconsistent signature: the leftmost bits of maskedDB are not zero'
+            );
         }
-        $dbMask = $this->getMGF1($h, $emLen - $hash->getLength() - 1, $hash/* MGF */);
+        $dbMask = $this->getMGF1($h, $emLen - $hLen - 1, $hash/* MGF */);
         $db = $maskedDB ^ $dbMask;
-        $db[0] = ~chr(0xFF << ($emBits & 7)) & $db[0];
-        $temp = $emLen - $hash->getLength() - $sLen - 2;
+        $db[0] = ~$mask & $db[0];
+        $temp = $emLen - $hLen - $sLen - 2;
         if (! str_starts_with($db, str_repeat(chr(0), $temp))) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException('Inconsistent signature: the padding string is not zero');
         }
         if (ord($db[$temp]) !== 1) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException('Inconsistent signature: the separator octet is not 0x01');
         }
         $salt = substr($db, $temp + 1); // should be $sLen long
         $m2 = "\0\0\0\0\0\0\0\0" . $mHash . $salt;

--- a/src/Key/RsaKey.php
+++ b/src/Key/RsaKey.php
@@ -122,7 +122,10 @@ class RsaKey extends Key
     }
 
     /**
-     * @return array<mixed>
+     * The "other prime infos" of a multi-prime key (RFC 8230, section 4): one map per prime from the third one on,
+     * each holding the DATA_RI, DATA_DI and DATA_TI entries.
+     *
+     * @return array<int, array<int, string>>
      */
     public function other(): array
     {
@@ -193,6 +196,13 @@ class RsaKey extends Key
         return array_key_exists(self::DATA_D, $this->getData());
     }
 
+    /**
+     * A key carrying "other prime infos" (RFC 8230, section 4) is exported as a version 0, two-prime RSAPrivateKey in
+     * which p*q is not the modulus: spomky-labs/pki-framework does not model OtherPrimeInfos yet. RS1, RS256, RS384
+     * and RS512 keep working with such a key only because OpenSSL checks its CRT result against s^e mod n and falls
+     * back to m^d mod n when the two disagree. RSASSA-PSS does not go through this method and handles the additional
+     * primes itself.
+     */
     public function asPem(): string
     {
         if ($this->isPrivate()) {

--- a/tests/Algorithm/Signature/RSA/PSSRSATest.php
+++ b/tests/Algorithm/Signature/RSA/PSSRSATest.php
@@ -1,0 +1,350 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cose\Tests\Algorithm\Signature\RSA;
+
+use function base64_decode;
+use Cose\Algorithm\Signature\RSA\PS256;
+use Cose\Algorithm\Signature\RSA\PS384;
+use Cose\Algorithm\Signature\RSA\PS512;
+use Cose\Algorithm\Signature\RSA\PSSRSA;
+use Cose\BigInteger;
+use Cose\Key\RsaKey;
+use const E_DEPRECATED;
+use const E_USER_DEPRECATED;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\WithoutErrorHandler;
+use PHPUnit\Framework\TestCase;
+use function restore_error_handler;
+use function set_error_handler;
+use function str_repeat;
+use function strlen;
+use function substr;
+
+/**
+ * RSASSA-PSS conformance to RFC 8017, section 8.1.
+ *
+ * The known answer signatures below were produced by OpenSSL 3 with
+ * "openssl dgst -<hash> -sigopt rsa_padding_mode:pss -sigopt rsa_pss_saltlen:digest -sign <key>", the salt length
+ * RFC 8230 section 2 mandates for PS256, PS384 and PS512.
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc8017#section-8.1
+ * @see https://github.com/web-auth/cose-lib/issues/173
+ */
+final class PSSRSATest extends TestCase
+{
+    private const MESSAGE = 'Live long and Prosper.';
+
+    #[Test]
+    #[DataProvider('getAlgorithms')]
+    public function signingWithAPublicKeyIsRejected(PSSRSA $algorithm): void
+    {
+        // Given
+        $key = RsaKeys::publicKey();
+
+        // Then
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The key is not private.');
+
+        // When
+        $algorithm->sign(self::MESSAGE, $key);
+    }
+
+    #[Test]
+    #[DataProvider('getAlgorithms')]
+    public function aSignatureIsVerifiedWhateverTheKeyObjectItIsGiven(PSSRSA $algorithm): void
+    {
+        // Given
+        $privateKey = RsaKeys::privateKey();
+
+        // When
+        $signature = $algorithm->sign(self::MESSAGE, $privateKey);
+
+        // Then
+        static::assertTrue($algorithm->verify(self::MESSAGE, $privateKey, $signature));
+        static::assertTrue($algorithm->verify(self::MESSAGE, $privateKey->toPublic(), $signature));
+    }
+
+    /**
+     * RFC 8017 section 3.2 admits the (n, e, d) representation of a private key. The signature operation must then use
+     * d and never fall back to e.
+     */
+    #[Test]
+    #[DataProvider('getAlgorithms')]
+    public function aKeyWithoutCrtParametersCanSign(PSSRSA $algorithm): void
+    {
+        // Given
+        $key = RsaKeys::privateKeyWithoutCrtParameters();
+
+        // When
+        $signature = $algorithm->sign(self::MESSAGE, $key);
+
+        // Then
+        static::assertSame(256, strlen($signature));
+        static::assertTrue($algorithm->verify(self::MESSAGE, RsaKeys::publicKey(), $signature));
+    }
+
+    /**
+     * RFC 8017 section 5.2.2, step 1: the signature representative shall be between 0 and n - 1.
+     */
+    #[Test]
+    public function aSignatureRepresentativeOutOfRangeIsRejected(): void
+    {
+        // Given
+        $key = RsaKeys::publicKey();
+        $modulus = $key->n();
+
+        // Then
+        $this->expectExceptionMessage('Signature representative out of range');
+
+        // When
+        PS256::create()
+            ->verify(self::MESSAGE, $key, $modulus)
+        ;
+    }
+
+    #[Test]
+    public function aSignatureOfTheWrongLengthIsRejected(): void
+    {
+        // Given
+        $key = RsaKeys::publicKey();
+
+        // Then
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid signature length');
+
+        // When
+        PS256::create()
+            ->verify(self::MESSAGE, $key, str_repeat("\x01", 255))
+        ;
+    }
+
+    #[Test]
+    #[DataProvider('getAlgorithms')]
+    public function aTamperedSignatureIsRejected(PSSRSA $algorithm): void
+    {
+        // Given
+        $key = RsaKeys::privateKey();
+        $signature = $algorithm->sign(self::MESSAGE, $key);
+
+        // When
+        $isValid = $algorithm->verify(self::MESSAGE . '!', $key, $signature);
+
+        // Then
+        static::assertFalse($isValid);
+    }
+
+    /**
+     * A modulus carrying the leading zero octet of a DER INTEGER is 2048 bits long, not 2056: RFC 8017 section 3.1
+     * defines both k and modBits from the integer value of n.
+     */
+    #[Test]
+    public function aZeroPaddedModulusIsHandledLikeItsMinimalEncoding(): void
+    {
+        // Given
+        $algorithm = PS256::create();
+        $paddedKey = RsaKeys::privateKeyWithPaddedModulus();
+        static::assertSame(257, strlen($paddedKey->n()));
+
+        // When
+        $signature = $algorithm->sign(self::MESSAGE, $paddedKey);
+
+        // Then
+        static::assertSame(256, strlen($signature));
+        static::assertTrue($algorithm->verify(self::MESSAGE, $paddedKey, $signature));
+        static::assertTrue($algorithm->verify(self::MESSAGE, RsaKeys::publicKey(), $signature));
+        static::assertTrue(
+            $algorithm->verify(self::MESSAGE, $paddedKey, $algorithm->sign(self::MESSAGE, RsaKeys::privateKey()))
+        );
+    }
+
+    /**
+     * With a 2050 bit modulus EMSA-PSS has to clear the six leftmost bits of maskedDB. Deriving modBits from the octet
+     * length of n instead cleared a single bit, which made roughly half of the operations fail in both directions.
+     */
+    #[Test]
+    public function aNonByteAlignedModulusIsHandled(): void
+    {
+        // Given
+        $algorithm = PS256::create();
+        $key = RsaKeys::nonByteAlignedPrivateKey();
+
+        // When
+        for ($i = 0; $i < 25; ++$i) {
+            $signature = $algorithm->sign(self::MESSAGE, $key);
+
+            // Then
+            static::assertSame(257, strlen($signature));
+            static::assertTrue($algorithm->verify(self::MESSAGE, $key->toPublic(), $signature));
+        }
+    }
+
+    #[Test]
+    public function aSignatureOfANonByteAlignedModulusProducedByOpensslIsAccepted(): void
+    {
+        // Given
+        $signature = base64_decode(
+            'Ad0jf/IO+yMI17DFMKAgAKwPt1Opcz9hUFELDnuk9Uj54xGLVgjwd0ocB/t5jnkqlj/PRwJ8bTDDOoyLlzHcmaFE8BPzGdGz' .
+            'WlzqnoBXtDNdjdH4MIoeQN7tm/S+D22JUU482JbrYpVtjrmJ1uetwRF7cipXjA0fYkOQ3ITfWW/SXuWl4bd00NSVvlGYkL9F' .
+            '5Ty61phKy0DdTR50FWFrdAhUste1xOXxjpFIQnGel/7RXTfjL+pzmbWgpL1OYLB9YJ9lvMLyNbLhu+jlP+/2ZUWUVnzdrNuN' .
+            'cuP4rnkKLDZlyLlJ8eHwiQMH0ju0QmgCzz7BKQU5SsN+JY/ROl4xH+U=',
+            true
+        );
+
+        // When
+        $isValid = PS256::create()
+            ->verify(self::MESSAGE, RsaKeys::nonByteAlignedPrivateKey()->toPublic(), $signature)
+        ;
+
+        // Then
+        static::assertTrue($isValid);
+    }
+
+    /**
+     * RFC 8017 section 5.2.1, step 2.b sub-steps 2 and 5, i.e. the third to u-th primes of a multi-prime key.
+     */
+    #[Test]
+    #[DataProvider('getAlgorithms')]
+    public function aMultiPrimeKeyProducesAValidSignature(PSSRSA $algorithm): void
+    {
+        // Given
+        $key = RsaKeys::multiPrimePrivateKey();
+
+        // When
+        $signature = $algorithm->sign(self::MESSAGE, $key);
+
+        // Then
+        static::assertSame(256, strlen($signature));
+        static::assertTrue($algorithm->verify(self::MESSAGE, $key->toPublic(), $signature));
+    }
+
+    /**
+     * RFC 8017 section 9.1.1, step 3: the encoding fails when emLen < hLen + sLen + 2, hence a 1040 bit modulus is the
+     * smallest one PS512 can encode. Both keys are far below the RFC 8230 section 6.1 minimum and only exercise that
+     * boundary.
+     */
+    #[Test]
+    public function theSmallestModulusPs512CanEncodeIsAccepted(): void
+    {
+        // Given
+        $algorithm = PS512::create();
+        $key = RsaKeys::shortPrivateKey();
+        $opensslSignature = base64_decode(
+            'Oy42J6jxml86dEe/FiZIm9gDfMOfuTslnxxgilfSISCc25xDwiy7VQlddqljAwh7BsO9INIXl/Aeu2RztLIEYobHQbJXvyuf' .
+            'Xuzwz1+76N80NxHijh88wnt+i7us/2ErX9TOx8dOwqijcxpf2FWXFW3y6URdbpMX081e7hBMLpxUjQ==',
+            true
+        );
+
+        // When
+        $signature = $algorithm->sign(self::MESSAGE, $key);
+
+        // Then
+        static::assertSame(130, strlen($signature));
+        static::assertTrue($algorithm->verify(self::MESSAGE, $key->toPublic(), $signature));
+        static::assertTrue($algorithm->verify(self::MESSAGE, $key->toPublic(), $opensslSignature));
+    }
+
+    #[Test]
+    public function aModulusTooShortForTheHashAndSaltLengthIsRejected(): void
+    {
+        // Given
+        $key = RsaKeys::tooShortPrivateKey();
+
+        // Then
+        $this->expectExceptionMessage('the modulus is too short for this hash and salt length');
+
+        // When
+        PS512::create()
+            ->sign(self::MESSAGE, $key)
+        ;
+    }
+
+    /**
+     * A key whose CRT parameters do not describe the modulus used to leave the class as a silently invalid signature.
+     */
+    #[Test]
+    public function aPrivateKeyWithInconsistentCrtParametersIsRejected(): void
+    {
+        // Given
+        $data = RsaKeys::privateKey()
+            ->getData()
+        ;
+        $data[RsaKey::DATA_Q] = RsaKeys::nonByteAlignedPrivateKey()
+            ->q()
+        ;
+
+        // Then
+        $this->expectExceptionMessage('Inconsistent RSA private key');
+
+        // When
+        PS256::create()
+            ->sign(self::MESSAGE, RsaKey::create($data))
+        ;
+    }
+
+    /**
+     * The class used to build the EMSA-PSS bit mask with chr(0xFF << 7), i.e. chr(32640), which PHP 8.5 deprecates.
+     */
+    #[Test]
+    #[WithoutErrorHandler]
+    public function noDeprecationIsEmitted(): void
+    {
+        // Given
+        $deprecations = [];
+        set_error_handler(static function (int $severity, string $message) use (&$deprecations): bool {
+            if ($severity === E_DEPRECATED || $severity === E_USER_DEPRECATED) {
+                $deprecations[] = $message;
+            }
+
+            return true;
+        }, E_DEPRECATED | E_USER_DEPRECATED);
+
+        // When
+        foreach ([PS256::create(), PS512::create()] as $algorithm) {
+            foreach ([RsaKeys::privateKey(), RsaKeys::nonByteAlignedPrivateKey()] as $key) {
+                $algorithm->verify(self::MESSAGE, $key->toPublic(), $algorithm->sign(self::MESSAGE, $key));
+            }
+        }
+        restore_error_handler();
+
+        // Then
+        static::assertSame([], $deprecations);
+    }
+
+    /**
+     * exponentiate() is kept for backward compatibility. It now applies RSASP1 to a private key and RSAVP1 to a public
+     * one, so that the operation and not the shape of the key selects the exponent.
+     */
+    #[Test]
+    public function theExponentiationPrimitiveRoundTrips(): void
+    {
+        // Given
+        $algorithm = PS256::create();
+        $privateKey = RsaKeys::privateKey();
+        $message = BigInteger::createFromBinaryString(substr(self::MESSAGE, 0, 8));
+
+        // When
+        $signature = $algorithm->exponentiate($privateKey, $message);
+        $recovered = $algorithm->exponentiate($privateKey->toPublic(), $signature);
+
+        // Then
+        static::assertSame(0, $recovered->compare($message));
+        static::assertSame(
+            0,
+            $algorithm->exponentiate(RsaKeys::privateKeyWithoutCrtParameters(), $message)->compare($signature)
+        );
+    }
+
+    /**
+     * @return iterable<string, array{PSSRSA}>
+     */
+    public static function getAlgorithms(): iterable
+    {
+        yield 'PS256' => [PS256::create()];
+        yield 'PS384' => [PS384::create()];
+        yield 'PS512' => [PS512::create()];
+    }
+}

--- a/tests/Algorithm/Signature/RSA/RSATest.php
+++ b/tests/Algorithm/Signature/RSA/RSATest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Cose\Tests\Algorithm\Signature\RSA;
 
+use function base64_decode;
 use Cose\Algorithm\Signature\RSA\PS256;
 use Cose\Algorithm\Signature\RSA\PS384;
 use Cose\Algorithm\Signature\RSA\PS512;
@@ -46,7 +47,7 @@ final class RSATest extends TestCase
         // When
         $computedSignature = $algorithm->sign($data, $key);
         $computedSignatureIsValid = $algorithm->verify($data, $key, $computedSignature);
-        $signatureIsValid = $algorithm->verify($data, $key, $computedSignature);
+        $signatureIsValid = $algorithm->verify($data, $key, $signature);
 
         // Then
         static::assertTrue($computedSignatureIsValid);
@@ -66,71 +67,155 @@ final class RSATest extends TestCase
         static::assertTrue($isValid);
     }
 
+    #[Test]
+    #[DataProvider('getVectors')]
+    public function aSignatureCanBeVerifiedWithThePublicKey(
+        RSA|PSSRSA $algorithm,
+        RsaKey $key,
+        string $data,
+        string $signature
+    ): void {
+        // Given
+        $publicKey = $key->toPublic();
+
+        // When
+        $isValid = $algorithm->verify($data, $publicKey, $signature);
+
+        // Then
+        static::assertTrue($isValid);
+    }
+
+    #[Test]
+    #[DataProvider('getVectors')]
+    public function aTamperedMessageIsRejected(
+        RSA|PSSRSA $algorithm,
+        RsaKey $key,
+        string $data,
+        string $signature
+    ): void {
+        // Given
+        $tampered = $data . '.';
+
+        // When
+        $isValid = $algorithm->verify($tampered, $key, $signature);
+
+        // Then
+        static::assertFalse($isValid);
+    }
+
     /**
-     * @return array<string>[]
+     * @return array<array{RSA|PSSRSA, RsaKey, string, string}>
      */
     public static function getVectors(): iterable
     {
-        $key1 = RsaKeys::privateKey();
+        $key = RsaKeys::privateKey();
 
         yield [
             RS256::create(),
-            $key1,
-            'eyJhbGciOiJSUzI1NiIsImp3ayI6eyJrdHkiOiJSU0EiLCJuIjoidHBTMVptZlZLVlA1S29mSWhNQlAwdFNXYzRxbGg2Zm0ybHJaU2t1S3hVakVhV2p6WlN6czcyZ0VJR3hyYVd1c01kb1J1VjU0eHNXUnlmNUtlWlQwUy1JNVBybGUzSWRpM2dJQ2lPNE53dk1rNkp3U0JjSld3bVNMRkVLeVVTbkIyQ3RmaUdjMF81clFDcGNFdF9EbjVpTS1CTm43ZnFwb0xJYmtzOHJYS1VJajgtcU1WcWtUWHNFS2VLaW5FMjN0MXlrTWxkc05hYU9ILWh2R3RpNUp0MkRNbkgxSmpvWGREWGZ4dlNQXzBnalVZYjBla3R1ZFlGWG9BNndla21ReUplSW12Z3g0TXl6MUk0aUh0a1lfQ3A3SjRNbjFlalo2SE5teXZvVEVfNE91WTF1Q2VZdjRVeVhGYzFzMXVVeVl0ajR6NTdxc0hHc1M0ZFEzQTJNSnN3IiwiZSI6IkFRQUIifX0.TGl2ZSBsb25nIGFuZCBQcm9zcGVyLg',
+            $key,
+            'eyJhbGciOiJSUzI1NiIsImp3ayI6eyJrdHkiOiJSU0EiLCJuIjoibldzNEIzQ2VaaWpxdnV3anplRDBnRFU1WnpRcW1sOGND' .
+                'RUNmc0g1SkpPdjRrU2NtOGFiazhtX0otdkxTNE80R2JUcnpTZFgzam9JaGp2SUxoQ3dVUkJmc0FrRVlpUUdCejZPa3hWWTg0' .
+                'UFVSVVh5RG5SbmhpaVdIU3pyQTNUUEsxN1RYMEtTZlBabDRCcHRpbTZySnhablN5aVdqNnBwbHBybGdMXzEtMlZTaWZwUEZs' .
+                'RHNlNEpGUkJBQm9IS3hCaWNnekVrZElacV9iMVNpM0pYTmdLRmRBUFBKUXlwN0lKdE1ZdVAtUmJ1WW4wMjF5YmVkSXFicktp' .
+                'VzhBaHFxQ093bjE3OHphenhUMHlwVjdTQ3lBTmxvZUJTTk5QSkdVT0V3cXZwcTkwVllPNzNWZkFjdWdtT1pfVTdEZzVIR20t' .
+                'V2NTeU9ZZXBxMkNFSFYyVEpmNEJRIiwiZSI6IkFRQUIifX0.TGl2ZSBsb25nIGFuZCBQcm9zcGVyLg',
             base64_decode(
-                'QyRlOCcNBMvCEkJRCQA71y2bVX690g0A6wsC2YXf9/VxOYK+g9+xy+1KjghVXkDPe1gDvYSYnL9oWs1PaFKV0/+ijvvJQE6/5pheKTfIVN3Qbkzjxsm4qXTeChBI5MKeBR8z8iWLFT4xPO8NkelwbS2tSUCHrejio6lDDlWhsqSUP8NjHJhqCSZuCDGu3fMMA24cZrYev3tQRc7HHjyi3q/17NZri7feBd7w3NEDkJp7wT/ZclJrYoucHIo1ypaDPJtM+W1+W+lAVREka6Xq4Bg60zdSZ83ODRQTP/IwQrv7hrIcbrRwn1Za/ORZPRPQDP0CMgkb7TkWDZnbPsAzlQ',
+                'mU7xRSbu6YjWaeQ0vhfqc/8gZYlmKCwejqLiTz/T0W9FROLkuezn6DxSz+g2XG3u0MI6uWvXktpOxrQzlCzrJABNB2Bjhb+j' .
+                    'lFnqZcykz0JaoNyWC5BzmmrA6haHpKeV33EkVdCNmV7pPAyyc4fZgPBGyoD/6BnnbaIqKllpylNFUseXrSsR68UomYvQU3ZC' .
+                    'De2sVcopBnUIxaW4b1IoSmyqnNSvpWeQ0GaCrvDJ9n8l/5wtVuuJKNhWROpkStWzIMcI9yKnIijGLvdWlCCv5SQwG2wEaklF' .
+                    'efEccW4Gg0kJUb3xhFS9Fsw0FSJkkQjKel6OlE4NZSY8bRwb3sei7w==',
                 true
             ),
         ];
 
         yield [
             RS384::create(),
-            $key1,
-            'eyJhbGciOiJSUzM4NCIsImp3ayI6eyJrdHkiOiJSU0EiLCJuIjoidHBTMVptZlZLVlA1S29mSWhNQlAwdFNXYzRxbGg2Zm0ybHJaU2t1S3hVakVhV2p6WlN6czcyZ0VJR3hyYVd1c01kb1J1VjU0eHNXUnlmNUtlWlQwUy1JNVBybGUzSWRpM2dJQ2lPNE53dk1rNkp3U0JjSld3bVNMRkVLeVVTbkIyQ3RmaUdjMF81clFDcGNFdF9EbjVpTS1CTm43ZnFwb0xJYmtzOHJYS1VJajgtcU1WcWtUWHNFS2VLaW5FMjN0MXlrTWxkc05hYU9ILWh2R3RpNUp0MkRNbkgxSmpvWGREWGZ4dlNQXzBnalVZYjBla3R1ZFlGWG9BNndla21ReUplSW12Z3g0TXl6MUk0aUh0a1lfQ3A3SjRNbjFlalo2SE5teXZvVEVfNE91WTF1Q2VZdjRVeVhGYzFzMXVVeVl0ajR6NTdxc0hHc1M0ZFEzQTJNSnN3IiwiZSI6IkFRQUIifX0.TGl2ZSBsb25nIGFuZCBQcm9zcGVyLg',
+            $key,
+            'eyJhbGciOiJSUzM4NCIsImp3ayI6eyJrdHkiOiJSU0EiLCJuIjoibldzNEIzQ2VaaWpxdnV3anplRDBnRFU1WnpRcW1sOGND' .
+                'RUNmc0g1SkpPdjRrU2NtOGFiazhtX0otdkxTNE80R2JUcnpTZFgzam9JaGp2SUxoQ3dVUkJmc0FrRVlpUUdCejZPa3hWWTg0' .
+                'UFVSVVh5RG5SbmhpaVdIU3pyQTNUUEsxN1RYMEtTZlBabDRCcHRpbTZySnhablN5aVdqNnBwbHBybGdMXzEtMlZTaWZwUEZs' .
+                'RHNlNEpGUkJBQm9IS3hCaWNnekVrZElacV9iMVNpM0pYTmdLRmRBUFBKUXlwN0lKdE1ZdVAtUmJ1WW4wMjF5YmVkSXFicktp' .
+                'VzhBaHFxQ093bjE3OHphenhUMHlwVjdTQ3lBTmxvZUJTTk5QSkdVT0V3cXZwcTkwVllPNzNWZkFjdWdtT1pfVTdEZzVIR20t' .
+                'V2NTeU9ZZXBxMkNFSFYyVEpmNEJRIiwiZSI6IkFRQUIifX0.TGl2ZSBsb25nIGFuZCBQcm9zcGVyLg',
             base64_decode(
-                'gsBhyBOEDPpHBR8OM2Xb5tybKGeijREZN+smEkvI2188pytujFevbDQJ10afbcdjh5LNKO7U/VD3hGPrC7MIkdtJw4c2d0JnVyhiZT5sFnncnCFjll+Y9GkK7a7jWJJTgF/5LmVEeJSFEEgwT1Stxb+TtZCGqc5ExYizLiuQ2IGB6Sq+hTkpWAXJfmHchE/TxV9A4iLWCMTVM6LsLV6NzDtf2a0iu9XvN1MEdzqM7FNdqNCGN43FveTA0hX8OoFfB2ZjYAjbixUCT4VVI2PuuRyu/Lr8cA73eisolBQLQemPyrCo1s560v2tKD7ICS8Teo1PCJ4HnCuO8bvufI2dKA',
+                'gnd9RzAtF6lST+/OElTx01vKTYCZwRah34R8A4jvcu3FXcZI4tRjscpj1cpkz83tN/fyNQASDSkHpyBRssRnMHDcUiUDdyGk' .
+                    'iik4hvSiLSr0dCTwbJSGBmfArRSjYFsVHlG5lqI47J72DyPGC+p8xUXFhVWP82lTPDDyFTfLnkX3Le9rplPm2aml+f/HGrhg' .
+                    'yz82JM7Nt+0UQ1gkOB4tktpJO/S8PiolHO/uwH+tX0GeljhtX9hyS6GUsUsk8eWUn/6eugnbQ913jY97Weu33exncXPh0/BF' .
+                    '56quDaHchcVyq1WlOQ9HFzZBDxS+LQ0hBwM0XHBmjJFKpR2uPYA/eA==',
                 true
             ),
         ];
 
         yield [
             RS512::create(),
-            $key1,
-            'eyJhbGciOiJSUzUxMiIsImp3ayI6eyJrdHkiOiJSU0EiLCJuIjoidHBTMVptZlZLVlA1S29mSWhNQlAwdFNXYzRxbGg2Zm0ybHJaU2t1S3hVakVhV2p6WlN6czcyZ0VJR3hyYVd1c01kb1J1VjU0eHNXUnlmNUtlWlQwUy1JNVBybGUzSWRpM2dJQ2lPNE53dk1rNkp3U0JjSld3bVNMRkVLeVVTbkIyQ3RmaUdjMF81clFDcGNFdF9EbjVpTS1CTm43ZnFwb0xJYmtzOHJYS1VJajgtcU1WcWtUWHNFS2VLaW5FMjN0MXlrTWxkc05hYU9ILWh2R3RpNUp0MkRNbkgxSmpvWGREWGZ4dlNQXzBnalVZYjBla3R1ZFlGWG9BNndla21ReUplSW12Z3g0TXl6MUk0aUh0a1lfQ3A3SjRNbjFlalo2SE5teXZvVEVfNE91WTF1Q2VZdjRVeVhGYzFzMXVVeVl0ajR6NTdxc0hHc1M0ZFEzQTJNSnN3IiwiZSI6IkFRQUIifX0.TGl2ZSBsb25nIGFuZCBQcm9zcGVyLg',
+            $key,
+            'eyJhbGciOiJSUzUxMiIsImp3ayI6eyJrdHkiOiJSU0EiLCJuIjoibldzNEIzQ2VaaWpxdnV3anplRDBnRFU1WnpRcW1sOGND' .
+                'RUNmc0g1SkpPdjRrU2NtOGFiazhtX0otdkxTNE80R2JUcnpTZFgzam9JaGp2SUxoQ3dVUkJmc0FrRVlpUUdCejZPa3hWWTg0' .
+                'UFVSVVh5RG5SbmhpaVdIU3pyQTNUUEsxN1RYMEtTZlBabDRCcHRpbTZySnhablN5aVdqNnBwbHBybGdMXzEtMlZTaWZwUEZs' .
+                'RHNlNEpGUkJBQm9IS3hCaWNnekVrZElacV9iMVNpM0pYTmdLRmRBUFBKUXlwN0lKdE1ZdVAtUmJ1WW4wMjF5YmVkSXFicktp' .
+                'VzhBaHFxQ093bjE3OHphenhUMHlwVjdTQ3lBTmxvZUJTTk5QSkdVT0V3cXZwcTkwVllPNzNWZkFjdWdtT1pfVTdEZzVIR20t' .
+                'V2NTeU9ZZXBxMkNFSFYyVEpmNEJRIiwiZSI6IkFRQUIifX0.TGl2ZSBsb25nIGFuZCBQcm9zcGVyLg',
             base64_decode(
-                'OMttEbx9fWoJl4gJwp8m249P87nNENhy5RzH84S1iR8b+upQNy8dqHoIVsQ6qINDjDL5YTl4UWvChIr5AO433LjNUimIeEp2cfiqrszTTwhv+EF3Lp3Ft9NmTb+3ZWvDo1WwwUrD0qro7bynaz5O06DxQfTROcrC6hNX05y6nW/+21exs2/w2OoOWA0Ebx9ev1ayZJh1AQ6q18Ajb0Gk1RST1PFjz0Sk/YiUIYRSVJzgv2Lf7R/Lyi5A5OkIfLOyJmKBi6m0FOLoynq/fT96wCbf5Nkhx+RiuFEcefGhgDav7Wfim3zA3ZAHeNWe58BZOf+8v1kXsV+yd6zQlVa8iw',
+                'S1ws65KhsCzthoKh1TsoK5VUqMZhvDdyJoQnt/6W18uAbnGi1OF5GJRyeo9aWC68Y93C81oBu/Yz1EbWaLFg7et6pHlfNVv5' .
+                    'whaRvWzh92w7JuBt9wxPwCEFYWTqmw6BRfsbduSSn8n7ORlb/h+lD3zXOuJLZGCnY0hqLPW2k33KO/hUKkKClW1D/Z8olzS0' .
+                    'hjk+FmCgiAugJ1Zki5nA/FPMBRj3Y8wnfDlW7oxyo00syr3H14vH8NruAGselhBvKWpEiH8y6KNWvbrjebziU/P4AHC+3q2h' .
+                    'w8bIGwXU9AO1EMlzZDNMw+xKYtbIkwJcJeMwZ854ZWal4bfz46JPWA==',
                 true
             ),
         ];
 
-        /*
-         * yield [
-         * 'algorithm' => PS256::create(),
-         * 'key' => $key1,
-         * 'data' => 'eyJhbGciOiJQUzI1NiIsImp3ayI6eyJrdHkiOiJSU0EiLCJrZXlfb3BzIjpbInZlcmlmeSJdLCJuIjoidHBTMVptZlZLVlA1S29mSWhNQlAwdFNXYzRxbGg2Zm0ybHJaU2t1S3hVakVhV2p6WlN6czcyZ0VJR3hyYVd1c01kb1J1VjU0eHNXUnlmNUtlWlQwUy1JNVBybGUzSWRpM2dJQ2lPNE53dk1rNkp3U0JjSld3bVNMRkVLeVVTbkIyQ3RmaUdjMF81clFDcGNFdF9EbjVpTS1CTm43ZnFwb0xJYmtzOHJYS1VJajgtcU1WcWtUWHNFS2VLaW5FMjN0MXlrTWxkc05hYU9ILWh2R3RpNUp0MkRNbkgxSmpvWGREWGZ4dlNQXzBnalVZYjBla3R1ZFlGWG9BNndla21ReUplSW12Z3g0TXl6MUk0aUh0a1lfQ3A3SjRNbjFlalo2SE5teXZvVEVfNE91WTF1Q2VZdjRVeVhGYzFzMXVVeVl0ajR6NTdxc0hHc1M0ZFEzQTJNSnN3IiwiZSI6IkFRQUIifX0.TGl2ZSBsb25nIGFuZCBQcm9zcGVyLg',
-         * 'signature' => base64_decode(
-         * 'NTHE3+OfgBuZclNFsolgYuOd+aNUB5FKQL68MwL/EGsb3hTgbiU1A/6QOdQq6DCQ36gs8nSFWpEyM77TyoDWG0t8ctZlqdrjVSSZrbzrBY0iukeAG0NqVaZlKbRiyuIwvRY4nJBCK6BWmHb4ewXOI/3m8hNVmQajcnHy+xEKm2wla0mZizPN44C/NFmbbX1MKbNRIl5wQz+ILyUOqYb3PRdJSTKCkitLYQX6qLgonlFkIHyY0TsainHJaR09SAzdk3XsDAfYBg/RXvz2lW8+IlxIy+FuLB4HrjgpAq2fRDfRtRyfnI2A1rsMJyDaMVjQniTj1fYg/0hm+7v4HLclV0UzQU3Y2zyG7zsoWDqp9b0/fZGZJydVvuPpOYIN7UlLeFbAVBmRBI09uQs3+VDh8GRtpqno7kIt5W3IiD9a6C0btKlb9yLCXdQqCQBkLX++g7B3GiPW99R/4B2WFMo8BKUbSHxrFZzyYGlGCQ/YjxKz6RPcjR2A2RPWpJfDeXzj',
-         * true
-         * ),
-         * ];
-         * yield [
-         * 'algorithm' => PS384::create(),
-         * 'key' => $key1,
-         * 'data' => 'eyJhbGciOiJQUzM4NCIsImp3ayI6eyJrdHkiOiJSU0EiLCJuIjoidHBTMVptZlZLVlA1S29mSWhNQlAwdFNXYzRxbGg2Zm0ybHJaU2t1S3hVakVhV2p6WlN6czcyZ0VJR3hyYVd1c01kb1J1VjU0eHNXUnlmNUtlWlQwUy1JNVBybGUzSWRpM2dJQ2lPNE53dk1rNkp3U0JjSld3bVNMRkVLeVVTbkIyQ3RmaUdjMF81clFDcGNFdF9EbjVpTS1CTm43ZnFwb0xJYmtzOHJYS1VJajgtcU1WcWtUWHNFS2VLaW5FMjN0MXlrTWxkc05hYU9ILWh2R3RpNUp0MkRNbkgxSmpvWGREWGZ4dlNQXzBnalVZYjBla3R1ZFlGWG9BNndla21ReUplSW12Z3g0TXl6MUk0aUh0a1lfQ3A3SjRNbjFlalo2SE5teXZvVEVfNE91WTF1Q2VZdjRVeVhGYzFzMXVVeVl0ajR6NTdxc0hHc1M0ZFEzQTJNSnN3IiwiZSI6IkFRQUIifX0.TGl2ZSBsb25nIGFuZCBQcm9zcGVyLg',
-         * 'signature' => base64_decode(
-         * 'VGUibk9r/WDX/K2H4MAsN1oi5oOKWRElPFvcVtPP5hIzDqB0K3S40b+WoFplSbPTtQQKA0W9hqzdQPmpIC4yqrtKrOWF+WmyIfNl1zAnHeNJGw85L/k56BU8T1Wa5qGVf7osA8MPSvw9dnPq0DMRArqiCUipoAUzCS18dmUTH0KIMuyebxMLZHm0c0HJ2n91BxXDrET9ycYxaMPEvIvBu9dIgXwwZiPu65xz6zYgLdfbhSKjc5KJc66JLVwI6j8Q7bmlJ0ChtQtf5f65uslRoR2K3Ezn3MR074EtlCt3KjP9BtdS18Kpxu7uYT5L7OYKJutso/hPNDgUnED4QruZjA',
-         * true
-         * ),
-         * ];
-         * yield [
-         * 'algorithm' => PS512::create(),
-         * 'key' => $key1,
-         * 'data' => 'eyJhbGciOiJQUzUxMiIsImp3ayI6eyJrdHkiOiJSU0EiLCJuIjoidHBTMVptZlZLVlA1S29mSWhNQlAwdFNXYzRxbGg2Zm0ybHJaU2t1S3hVakVhV2p6WlN6czcyZ0VJR3hyYVd1c01kb1J1VjU0eHNXUnlmNUtlWlQwUy1JNVBybGUzSWRpM2dJQ2lPNE53dk1rNkp3U0JjSld3bVNMRkVLeVVTbkIyQ3RmaUdjMF81clFDcGNFdF9EbjVpTS1CTm43ZnFwb0xJYmtzOHJYS1VJajgtcU1WcWtUWHNFS2VLaW5FMjN0MXlrTWxkc05hYU9ILWh2R3RpNUp0MkRNbkgxSmpvWGREWGZ4dlNQXzBnalVZYjBla3R1ZFlGWG9BNndla21ReUplSW12Z3g0TXl6MUk0aUh0a1lfQ3A3SjRNbjFlalo2SE5teXZvVEVfNE91WTF1Q2VZdjRVeVhGYzFzMXVVeVl0ajR6NTdxc0hHc1M0ZFEzQTJNSnN3IiwiZSI6IkFRQUIifX0.TGl2ZSBsb25nIGFuZCBQcm9zcGVyLg',
-         * 'signature' => base64_decode(
-         * 'bBsgpFWir0MvWmgCZ8CVCGTcHm4C9FgTty8NvtyRHAvpTlL8NCbcZ2VNJWKPpCjge/Rv29jguivUHFgudlBYY6LKJd5xUt12uZQL//Jc8Z1YCNq6BDFtH09HMKRAkePLkRXv05DdoL20eOpZGJMITn0LK5STC+c7YNjlwjppclFfEf0Arl8Er3LvPlyoBMJRd1X7osMFamdEDAoqPM/JTVMQMNI/kXv+P42iePERixvX1MDeF/KUfgWwzfYYUltrpG+JPh05iqwlKTsUchqDTdo8l2phEa5qq6MCQemzvKBMFb2u/B4+VXTD60vJVLSrionHncU1jyOwSIgAKPipxQ',
-         * true
-         * ),
-         * ];
-         */
+        yield [
+            PS256::create(),
+            $key,
+            'eyJhbGciOiJQUzI1NiIsImp3ayI6eyJrdHkiOiJSU0EiLCJuIjoibldzNEIzQ2VaaWpxdnV3anplRDBnRFU1WnpRcW1sOGND' .
+                'RUNmc0g1SkpPdjRrU2NtOGFiazhtX0otdkxTNE80R2JUcnpTZFgzam9JaGp2SUxoQ3dVUkJmc0FrRVlpUUdCejZPa3hWWTg0' .
+                'UFVSVVh5RG5SbmhpaVdIU3pyQTNUUEsxN1RYMEtTZlBabDRCcHRpbTZySnhablN5aVdqNnBwbHBybGdMXzEtMlZTaWZwUEZs' .
+                'RHNlNEpGUkJBQm9IS3hCaWNnekVrZElacV9iMVNpM0pYTmdLRmRBUFBKUXlwN0lKdE1ZdVAtUmJ1WW4wMjF5YmVkSXFicktp' .
+                'VzhBaHFxQ093bjE3OHphenhUMHlwVjdTQ3lBTmxvZUJTTk5QSkdVT0V3cXZwcTkwVllPNzNWZkFjdWdtT1pfVTdEZzVIR20t' .
+                'V2NTeU9ZZXBxMkNFSFYyVEpmNEJRIiwiZSI6IkFRQUIifX0.TGl2ZSBsb25nIGFuZCBQcm9zcGVyLg',
+            base64_decode(
+                'nMKu0GYzZkH1u7EjLE1uPuNZfjSReec26IvLNRnze+adhSlMr7bz+EsOeP/OVqq5Guk9P+KW8WHq83HoJvIeU2nHsvetJvno' .
+                    'VlysUg4g4TJPuHUmINv6jaErmKFr4XmOU0LWgvSZ4LD1VGt7IGOfwRoED5697NnZSL5R3A5A+VW5+oWZoZLWf09sZsLwr2X+' .
+                    'y9q6Z4gvG4YuAldUSSQJGNg3RmvWQIWEmkF59h5GTLVCfgCi7CVGfXCGjNeNGlC4/nxWPK7hb2SOwL+B/uuKStIaKPPO0+lr' .
+                    'b5ejCHi/xaFWEYpRm9WEkfnQ+ECA2L8am0h2AJpnzT1sZGAwMquL2Q==',
+                true
+            ),
+        ];
+
+        yield [
+            PS384::create(),
+            $key,
+            'eyJhbGciOiJQUzM4NCIsImp3ayI6eyJrdHkiOiJSU0EiLCJuIjoibldzNEIzQ2VaaWpxdnV3anplRDBnRFU1WnpRcW1sOGND' .
+                'RUNmc0g1SkpPdjRrU2NtOGFiazhtX0otdkxTNE80R2JUcnpTZFgzam9JaGp2SUxoQ3dVUkJmc0FrRVlpUUdCejZPa3hWWTg0' .
+                'UFVSVVh5RG5SbmhpaVdIU3pyQTNUUEsxN1RYMEtTZlBabDRCcHRpbTZySnhablN5aVdqNnBwbHBybGdMXzEtMlZTaWZwUEZs' .
+                'RHNlNEpGUkJBQm9IS3hCaWNnekVrZElacV9iMVNpM0pYTmdLRmRBUFBKUXlwN0lKdE1ZdVAtUmJ1WW4wMjF5YmVkSXFicktp' .
+                'VzhBaHFxQ093bjE3OHphenhUMHlwVjdTQ3lBTmxvZUJTTk5QSkdVT0V3cXZwcTkwVllPNzNWZkFjdWdtT1pfVTdEZzVIR20t' .
+                'V2NTeU9ZZXBxMkNFSFYyVEpmNEJRIiwiZSI6IkFRQUIifX0.TGl2ZSBsb25nIGFuZCBQcm9zcGVyLg',
+            base64_decode(
+                'dUW/GJ9EcZzvEzFqPyvZejO4vsZ7lHkuWb/CrR/DqG/Rnvpg0CQ62OGKMmTzJ/Q2czoLjI27pSlh7PA7O5wL5WlrlWos5WW/' .
+                    'Iu6xdCDNXVMZSVg01lryHyWNj8826BTcbQ2YxfQLNlAtOgq2Y/cAtboOQUJEZmxqIZRIM5JptOOFqnSTy9FwwJxWxDsY3v9D' .
+                    '/i3s2qRYZ9sdFR5Si4y0M/u/vNaIu4xTvYCoEKLNDHIyfa9ZLVKdKsCXm0k4/qm/MPRek7CXLjNQsx88lH6zTTs83u634IMP' .
+                    'wYslXx16X8zTe1+wB976gaKJpB95EBwlkbwVjl2+2ThCYademsgwcQ==',
+                true
+            ),
+        ];
+
+        yield [
+            PS512::create(),
+            $key,
+            'eyJhbGciOiJQUzUxMiIsImp3ayI6eyJrdHkiOiJSU0EiLCJuIjoibldzNEIzQ2VaaWpxdnV3anplRDBnRFU1WnpRcW1sOGND' .
+                'RUNmc0g1SkpPdjRrU2NtOGFiazhtX0otdkxTNE80R2JUcnpTZFgzam9JaGp2SUxoQ3dVUkJmc0FrRVlpUUdCejZPa3hWWTg0' .
+                'UFVSVVh5RG5SbmhpaVdIU3pyQTNUUEsxN1RYMEtTZlBabDRCcHRpbTZySnhablN5aVdqNnBwbHBybGdMXzEtMlZTaWZwUEZs' .
+                'RHNlNEpGUkJBQm9IS3hCaWNnekVrZElacV9iMVNpM0pYTmdLRmRBUFBKUXlwN0lKdE1ZdVAtUmJ1WW4wMjF5YmVkSXFicktp' .
+                'VzhBaHFxQ093bjE3OHphenhUMHlwVjdTQ3lBTmxvZUJTTk5QSkdVT0V3cXZwcTkwVllPNzNWZkFjdWdtT1pfVTdEZzVIR20t' .
+                'V2NTeU9ZZXBxMkNFSFYyVEpmNEJRIiwiZSI6IkFRQUIifX0.TGl2ZSBsb25nIGFuZCBQcm9zcGVyLg',
+            base64_decode(
+                'E6+yfXmGPSneTk5iwzq9iSY1AQU/ZeDDvxPAXe5Osz96sf+wAVnIgu2fHkA9vvcQUaACzYcQJtQ8mOhAxkh9mUp7ZDKeiyxH' .
+                    '1bBUQEPmfO7+KDI66Ga3B6JWP7iEJeB0lKyc/e6jbhNSH0ghmRxSVCH/y3HgSdVvq9NRETrOTsTPrKvjKXPY0ckJYnY5WBwR' .
+                    'LPMdak9Bt6XiDwXVNMiYrX0kQ+54TbgTh0zuUhPY1GkocGrwadiH0EL4knMF/NFf3wc5j++6axhCT7R6ZuGw5/zxg4sHZL13' .
+                    'L3rbYHPNYguDKsSSg51ZjZR6IuvRVYkQ9oepXTcwd0LBimrMvXbnZw==',
+                true
+            ),
+        ];
     }
 }

--- a/tests/Algorithm/Signature/RSA/RsaKeys.php
+++ b/tests/Algorithm/Signature/RSA/RsaKeys.php
@@ -9,42 +9,268 @@ use Cose\Key\RsaKey;
 
 /**
  * Test vectors shared by the RSA based algorithm test cases.
+ *
+ * Every private key below is internally consistent: n = p*q (or p*q*r for the multi-prime one),
+ * e*dP = 1 mod (p-1), e*dQ = 1 mod (q-1) and q*qInv = 1 mod p, as RFC 8017 section 3.2 requires.
+ * RsaKeysTest asserts these relations so that the fixtures cannot silently rot.
  */
 final class RsaKeys
 {
+    /**
+     * A 2048 bit key whose modulus uses the minimum number of octets, as RFC 8230 section 4 requires.
+     */
     public static function privateKey(): RsaKey
     {
         return RsaKey::create([
             RsaKey::TYPE => RsaKey::TYPE_RSA,
             RsaKey::DATA_N => base64_decode(
-                'tpS1ZmfVKVP5KofIhMBP0tSWc4qlh6fm2lrZSkuKxUjEaWjzZSzs72gEIGxraWusMdoRuV54xsWRyf5KeZT0S+I5Prle3Idi3gICiO4NwvMk6JwSBcJWwmSLFEKyUSnB2CtfiGc0/5rQCpcEt/Dn5iM+BNn7fqpoLIbks8rXKUIj8+qMVqkTXsEKeKinE23t1ykMldsNaaOH+hvGti5Jt2DMnH1JjoXdDXfxvSP/0gjUYb0ektudYFXoA6wekmQyJeImvgx4Myz1I4iHtkY/Cp7J4Mn1ejZ6HNmyvoTE/4OuY1uCeYv4UyXFc1s1uUyYtj4z57qsHGsS4dQ3A2MJsw',
+                'nWs4B3CeZijqvuwjzeD0gDU5ZzQqml8cCECfsH5JJOv4kScm8abk8m/J+vLS4O4GbTrzSdX3joIhjvILhCwURBfsAkEYiQGB' .
+                'z6OkxVY84PURUXyDnRnhiiWHSzrA3TPK17TX0KSfPZl4Bptim6rJxZnSyiWj6pplprlgL/1+2VSifpPFlDse4JFRBABoHKxB' .
+                'icgzEkdIZq/b1Si3JXNgKFdAPPJQyp7IJtMYuP+RbuYn021ybedIqbrKiW8AhqqCOwn178zazxT0ypV7SCyANloeBSNNPJGU' .
+                'OEwqvpq90VYO73VfAcugmOZ/U7Dg5HGm+WcSyOYepq2CEHV2TJf4BQ==',
                 true
             ),
             RsaKey::DATA_E => base64_decode('AQAB', true),
             RsaKey::DATA_D => base64_decode(
-                'Kp0KuZwCZGL1BLgsVM+N0edMNitl9wN5Hf2WOYDoIqOZNAEKzdJuenIMhITJjRFUX05GVL138uyp2js/pqDdY9ipA7rAKThwGuDdNphZHech9ih3DGEPXs+YpmHqvIbCd3GoGm38MKwxYkddEpFnjo8rKna1/BpJthrFxjDRhw9DxJBycOdH2yWTyp62ZENPvneK40H2a57W4QScTgfecZqD59m2fGUaWaX5uUmIxaEmtGoJnd9RE4oywKhgN7/TK7wXRlqA4UoRPiH2ACrdU+/cLQL9Jc0u0GqZJK31LDbOeN95QgtSCc72k3Vtzy3CrVpp5TAA67s1Gj9Skn+CAQ',
+                'Azr9WHW9fAMDi9Oq8Ae/3/B3rM0B9M7WQFSz+KC9N1NAwH9pSeGiM1fYJFy4UO8n7zTolwLOxKKaArKn46Ut7ONnlfioNfBa' .
+                'FBzbfd5rrs6IqPK644Ek9jtLH/mYL9HnLAilIL4U5uQ2QnIM330gcxW/7bynaC778aRxocdJEGrad7YSJ889r+LyVQcVnMzN' .
+                '+IO9bFxtg0H0b7K3sWYJmAWoUPlcP6WkGXIHYReCuwitmxBsqWA3vuVqn1LZvYH7xs9Rcgs655Yc0GEj+IYm/xAF+kOrK3rF' .
+                'owOTYBIQozY4ikOh24hh5NQ0A82ZFyZRWjn11PfJZ9HbeJZKPQXu3w==',
                 true
             ),
             RsaKey::DATA_P => base64_decode(
-                'zPD+B+nrngwF+O99BHvb47XGKR7ON8JCI6JxavzIkusMXCB8rMyYW8zLs68L8JLAzWZ34oMq0FPUnysBxc5nTF8Nb4BZxTZ5+9cHfoKrYTI3YWsmVW2FpCJFEjMs4NXZ28PBkS9b4zjfS2KhNdkmCeOYU0tJpNfwmOTI90qeUdU',
+                '0FUhP8CrZSokkpjxG28cK4L2QzYuLQ4ouvVlM6kVOp+5wB7vy5119NBcpUft9y1XBJfepVnN20a1BXsJ+JQz4I2s0l72AR66' .
+                '4x1qdSd62pxhhKCtl39qwCcbmeAVwrcLJ9azRWI+7cRMNq3k5Ujh4NJ4PqPslYzd5TSCtZFiz+s=',
                 true
             ),
             RsaKey::DATA_Q => base64_decode(
-                'bWUC9B+EFRIo8kpGfh0ZuyGPvMNKvYWNtB/ikiH9k20eT+O1q/I78eiZkpXxXQ0UTEs2LsNRS+8uJbvQ+A1irkwMSMkK1J3XTGgdrhCku9gRldY7sNA/AKZGh+Q661/42rINLRCe8W+nZ34ui/qOfkLnK9QWDDqpaIsA+bMwWWSDFu2MUBYwkHTMEzLYGqOe04noqeq1hExBTHBOBdkMXiuFhUq1BU6l+DqEiWxqg82sXt2h+LMnT3046AOYJoRioz75tSUQfGCshWTBnP5uDjd18kKhyv07lhfSJdrPdM5Plyl21hsFf4L/mHCuoFau7gdsPfHPxxjVOcOpBrQzwQ',
+                'wW/eedGyWbvJRM8uFx3nRXU4ZPssG84wRgBD2TJfmD7YZ/S6R0/JL3z3Af1qL8Q7W4x9BIIMdd+rinpxFkTv3h07lsWlinGN' .
+                'cbCaXk3SOw94OGl+yHXDT5srzylbXnz6L1seeOFiNSj8HVxz94GO9IM7CIEGGoao0kgXwHZYS88=',
                 true
             ),
             RsaKey::DATA_DP => base64_decode(
-                'aJrzw/kjWK9uDlTeaES2e4muv6bWbopYfrPHVWG7NPGoGdhnBnd70+jhgMEiTZSNU8VXw2u7prAR3kZ+kAp1DdwlqedYOzFsOJcPA0UZhbORyrBy30kbll/7u6CanFm6X4VyJxCpejd7jKNw6cCTFP1sfhWg5NVJ5EUTkPwE66M',
+                'Xx7vbm9nEmq6hiDEvXTu1MMX87oyPSog2LQgwASsh7bUFe9KJ5q+d8gG9QQxl9Eg0R0ScEbfogXXsyfpdpEcWqP1S5xGEF7a' .
+                'j8YnjFQ5WMVcFTVT7T8lG5T/mjNhXCU9N7Rk6AIin2coMTMWtsWfNIqEkn1AEUxfKD7gi0xVZH8=',
                 true
             ),
             RsaKey::DATA_DQ => base64_decode(
-                'Swz1+m/vmTFN/pu1bK7vF7S5nNVrL4A0OFiEsGliCmuJWzOKdL14DiYxctvnw3H6qT2dKZZfV2tbse5N9+JecdldUjfuqAoLIe7dD7dKi42YOlTC9QXmqvTh1ohnJu8pmRFXEZQGUm/BVhoIb2/WPkjav6YSkguCUHt4HRd2YwE',
+                'UX7rMVGqnWmjW00aMv0TQc0oDEtSAwj0h5l2/FvfsInRrMKLdJ3lug8hFgKJKUS4aVKgHTUZQNQSNo5tdJ9om6CfSV9N5iz/' .
+                'FYX9E3wf9WgIE2RG2PfcaH6Mj4PyDbYDxc3S4cS7FoCE723TIdTAwL1FMskBJE3VdHqRHzH88zs=',
                 true
             ),
             RsaKey::DATA_QI => base64_decode(
-                'BocuCOEOq+oyLDALwzMXU8gOf3IL1Q1/BWwsdoANoh6i179psxgE4JXToWcpXZQQqub8ngwE6uR9fpd3m6N/PL4T55vbDDyjPKmrL2ttC2gOtx9KrpPh+Z7LQRo4BE48nHJJrystKHfFlaH2G7JxHNgMBYVADyttN09qEoav8Os',
+                'Z7gHmrXezlIxetYyYdc/kBRTPAi96hnT8jHSAOoZtYXzEbFfHkPNRCQBTwDPKZiOWrghb4fOnEAcnHZ1nwEPdae514ySt7vJ' .
+                'qGLOjY8B3UtniwnaW0fRd3pplbksdbGxxK1FldgAsQUZRVy7uDQlxtyZ7cFmQlIKV3ZeXVmVXb0=',
                 true
             ),
+        ]);
+    }
+
+    public static function publicKey(): RsaKey
+    {
+        return self::privateKey()
+            ->toPublic()
+        ;
+    }
+
+    /**
+     * The same key reduced to the first private key representation of RFC 8017 section 3.2: (n, e, d).
+     */
+    public static function privateKeyWithoutCrtParameters(): RsaKey
+    {
+        $data = self::privateKey()
+            ->getData()
+        ;
+        foreach ([RsaKey::DATA_P, RsaKey::DATA_Q, RsaKey::DATA_DP, RsaKey::DATA_DQ, RsaKey::DATA_QI] as $parameter) {
+            unset($data[$parameter]);
+        }
+
+        return RsaKey::create($data);
+    }
+
+    /**
+     * The same key with a modulus carrying the leading zero octet a DER INTEGER would add. The key is still 2048 bits
+     * long; only its encoding is not minimal.
+     */
+    public static function privateKeyWithPaddedModulus(): RsaKey
+    {
+        $data = self::privateKey()
+            ->getData()
+        ;
+        $data[RsaKey::DATA_N] = "\x00" . $data[RsaKey::DATA_N];
+
+        return RsaKey::create($data);
+    }
+
+    /**
+     * A 2050 bit key: its modulus is not byte aligned, so EMSA-PSS has to clear six leftmost bits.
+     */
+    public static function nonByteAlignedPrivateKey(): RsaKey
+    {
+        return RsaKey::create([
+            RsaKey::TYPE => RsaKey::TYPE_RSA,
+            RsaKey::DATA_N => base64_decode(
+                'AwF33jtlGCN7zLPIbbb5yVKwsEyTYSFbNAbRAUbpqlE/IjIxUvKGQCzQUZX3zeuIJ1Rdkm15f9RuWfu54Q2JkOA69m5ODb2g' .
+                'AgPFtOXVYOss6l1/Z6wDcdPql5bC5SNEfkIENjAMuloVMf+ax3tpQY4MjyOxnOAieXmkSS0e/1Q/a3nAdfy1QAUCSZl3G7YN' .
+                'ybB0KnIFpxsO7Xux3DVAz2z3MtnH/dB3vTLz6EgYjZsyjAT3Wfd10up7bQ0qN+xfypfwmjBlHiwIZONgfMevT0q2DqOH/2Wu' .
+                '1ArTaz5OHs4+2HQGkQdz3nKBOty0Zlxl0ZaiP+H9iP6fUHdRqQRzDuU=',
+                true
+            ),
+            RsaKey::DATA_E => base64_decode('AQAB', true),
+            RsaKey::DATA_D => base64_decode(
+                'XF9C9vdiZ/QXNWf0v9gJspsSdwbkTKhRvRW/JP+tGhbNqJ/iOMokDx0tBida+ZD9Q7P9/ZVt4pcix0TfvwvKMBjz93b4UFDS' .
+                'nRhRaJvuiBz6v6GpVO2O7yVE8GzSLCMvUwaFaMxGXMUZnPk8RFT08TQRxPOwBPouggtWW4vSlA6jj+HtKpGNMfR1r01x38zL' .
+                'QANpH8jjlmeL/5CGQwDpeGNMe39GtNbK32EhXhPB9Y+3n2vnrLj1KDxQHOUKaUhv8cR0bDEXPje3JCpWBs1QXr2blEFl3rZF' .
+                'lcyTMRBQedmDHbbatVgt00mljpSJUbtuyKjsDzY8GsebQVWPx6EOKw==',
+                true
+            ),
+            RsaKey::DATA_P => base64_decode(
+                'AfgMVIlGBKXEAvxoCgaPe2QV3b2E2C3oKHufH6CdUIjoeQDds2aQqSyCbIoGd7ibn5HnDqMzArFhUlNF8FrXTueTQ0v4aKMQ' .
+                '7pRtJwxGJAQxbjL6oekbQ+8jJeKyc7Bj2wotFoEuUDg21a/Xtz710RNbjoHwtS4xObETwiCChdFf',
+                true
+            ),
+            RsaKey::DATA_Q => base64_decode(
+                'AYbNvLecOobHdZeeCW0pFpGBUN57INYSVzIAFjM2vTkFOXYDkn5abHxph1wzHKAMEDaeUrCphPuGJtPxZDgl8Tw7vHI8CXMj' .
+                '2uvQjZyG1j29YA59cZwi0CVH7Dx3PVktuK9Gwn5gX+wUN7F5HgWAr3DVe+ArSjtN3rs6Vv4+UPI7',
+                true
+            ),
+            RsaKey::DATA_DP => base64_decode(
+                'AWBxNrcZx2wlR7U4BjKaJzxPcdHvzr0ixRPTqujCtypT6zAo1SWVZ0VhGQXWCeaCoqwBdSG2LF7dXxQtJihOvrR8KyU21+uV' .
+                'jk0omZIihVKNQbHRwF7fmrvexsHh57Thzaoq5r6DJMJ5zSb8XfxfI8c2UMoZBob7Eoz39NiIi4tf',
+                true
+            ),
+            RsaKey::DATA_DQ => base64_decode(
+                'cQTEw/DZeCrs1gktPrV4QmI8ierf5yjssJgX033MIVZidL+5uPLblutJ6x8Y8ywp8DG/RjnwLHFyfy67RgWrCzlXWU4FiZff' .
+                '8vygR5kzEi3XPrmGhpoGyhFPv3jYdBbl50K2cqfadcKvDJMzXHIHysDij0TVteriNBE+IU7SSAs=',
+                true
+            ),
+            RsaKey::DATA_QI => base64_decode(
+                'Ae7QEeQChIcK5DgrPishwcVd+jnylR0GDGL00Rb+ZW0V0nB/Q2yUmATYluGT7MEeqUlJ+IIOrkQ7HhUb0oWKB82J6hvXnVaH' .
+                '3p/TbUMMmLxqsDOQnpU1wHGb76EeAYCm5gD8nPK56Tq8nabTD+PWb3lC4Gl+ChC3R6ROsx5a9T+E',
+                true
+            ),
+        ]);
+    }
+
+    /**
+     * A 2048 bit key with three primes, as modelled by RFC 8230 section 4.
+     */
+    public static function multiPrimePrivateKey(): RsaKey
+    {
+        $data = [
+            RsaKey::TYPE => RsaKey::TYPE_RSA,
+            RsaKey::DATA_N => base64_decode(
+                'pC2wVYlRpd5B5jgOy4vxVHp0I4Q+lwRoxP93qbiFLuMHXYRPMyYdD6iduB3JV2b8tRXrgq6B5++o7KFsxafkCKmeqeiDwtNC' .
+                'hynJiIOHh1nhb5Gm8AyADsMRi/cwsZXG7TYmXNl2qB/O5XrCNdsS4jwh3VFujdowFVCtD2z+Zo3kEAXhsuu7Gdf0X5IZG41b' .
+                '4npu1x6LfQLEDXKFJhtu0SnCgi76KbPi9+eTH9W0jZy82UKAR74KGuSy8/KBrYVmgQi4hnoXIogtPatXghhLIImvWc5irf+A' .
+                'vHGDrSNeP30j4MePcLjxtguDOeQ0zbwQFbeIJdkHKC1e3y3Yoommdw==',
+                true
+            ),
+            RsaKey::DATA_E => base64_decode('AQAB', true),
+            RsaKey::DATA_D => base64_decode(
+                'dtxZGGQ1R2e0wA7/rx+e1XFeGcSJZ94aV904bhiX240j7PF4QWiri4WgwgZWmT+HXzcCbXcXt6pL2x03WZYmQptCsnISyn8W' .
+                'YDLBpGLNQRGyY4rIlyx/542p62VDjVv+R7SIKKefdegLdYSl8oIfqE8CT4CpI0BB3hps8yngzShVy+Cq6aY9wkzVzgVnuo27' .
+                'r0FxsjDkc9tpIEnn0YuajRUGuPGMlzc2yraMEruGa9B8StQpPC9aweVZbyZ0y7nf5B2YS50Dma25E/5FzgWrHLCHo6nhTvam' .
+                '+E9fFI68tTdsrNh7ukD5FEG2vpXOAMJfbPfK5ulyMkkmeuwaB4qwgQ==',
+                true
+            ),
+            RsaKey::DATA_P => base64_decode(
+                'tNHgR1Wfjg/oP3Lr0shAFJokR0b7aFKtWNjkXCMgEqy348dGwgB9GgxN9gnQZ1WLZNzoz/vCsfChKtPksmJKyDUNP0+v/THZ' .
+                '0TFCG+45MT2pUxUNXz0=',
+                true
+            ),
+            RsaKey::DATA_Q => base64_decode(
+                'AfnwTwluDoPVXqPOdoFJEh9HWzDmXOMedVyLNrOlKV9kG6oWL3La/4w2EMJC6T7RsMWraU52+5y4QMDteWIm16w/3tDFK0fj' .
+                'guiOoKbQqO0uQttLnpM=',
+                true
+            ),
+            RsaKey::DATA_DP => base64_decode(
+                'iKZz0HUs97ed1RWMkuczRl6XPCawqM6SoqqHKfqBqptM/Z8EImksIhtab65LCUzk43zvlP62zLMFmdA47XbK/TLaqBYY8khS' .
+                'TH3lcCZAoq3u4RLv4CE=',
+                true
+            ),
+            RsaKey::DATA_DQ => base64_decode(
+                'Abau2Ekr5WgIBTRxW62EJzN50qcWxymjCk4A46Bmr/XnPll/PQsQuo3ffy6Bh+6RMP5kPz3qywY7eOIPxrUFSvIuu0s3+uwt' .
+                'aB+vM7sQp7hn6U5uRgM=',
+                true
+            ),
+            RsaKey::DATA_QI => base64_decode(
+                'dccbWUhgh6J2DAVLNMtz100+ipVgN/MOZWzjojFrzeQfW46bAT9acv5w9ML2TnrFTIuYhAeksGS5bXJ3nu6qoZut7IBLju1S' .
+                'AzS59ZL+m1dkAPrfPns=',
+                true
+            ),
+            RsaKey::DATA_OTHER => [[
+                RsaKey::DATA_RI => base64_decode(
+                    'dZy1uIISM4KqwEqHqiLYcqVoMMekMlcBajur7wPACz5ufias+9lV9frMSHSKpoCf4iGnNKXm05eR2rH3cWUqzBH8qMD1CuZ0' .
+                '1rvt0M3xFAnOURSQEQ==',
+                    true
+                ),
+                RsaKey::DATA_DI => base64_decode(
+                    'FMCuH/xzkbtAveVowtCbOL+O/ux7QJaxnTkiQW57+H/vpzrT0yyqSlkSqsZFoNOZYqFli5iqfjOEfP5iFxQu1Qtnda92jZHU' .
+                'k/9dGzb7jvmb+hqSwQ==',
+                    true
+                ),
+                RsaKey::DATA_TI => base64_decode(
+                    'EbLEwojeaVH7lY0BtAm0bmeyRKoULSwsU1WgXi+pw5B1qgfuSruR7pf95rxYQtDs9QWFuWCRQFPjBwKrnGXNBx5V5o/eNdro' .
+                'CTAI+34R2eh66QQcaA==',
+                    true
+                ),
+            ]],
+        ];
+
+        return RsaKey::create($data);
+    }
+
+    /**
+     * A 1040 bit key: the smallest modulus PS512 can encode (emLen == hLen + sLen + 2). Far below the RFC 8230
+     * section 6.1 minimum, and only used to exercise that boundary.
+     */
+    public static function shortPrivateKey(): RsaKey
+    {
+        return RsaKey::create([
+            RsaKey::TYPE => RsaKey::TYPE_RSA,
+            RsaKey::DATA_N => base64_decode(
+                '91p/phyrbdrrG182PL+5Jzg9GuEq06WImXrmLBBKv+fD3HQIUBD1iGMKij6BERM3Crm8KWEoxlx0GTyHndwFigdPaZ9Zwtrn' .
+                'S8ipMpj/aLcP+i5xe0yLFQ1sA3TIs2XRWesfCx4sTeJ9ThD9Q5Zf/iwcFZD9bef0uGAYP/GhTm5wzQ==',
+                true
+            ),
+            RsaKey::DATA_E => base64_decode('AQAB', true),
+            RsaKey::DATA_D => base64_decode(
+                'GFn8fyoLZoFK7CLvgAOQAuByg5bvVG7Th+iliGkCMupqSeXSe69vvMGjZADLTBcMMC4g7CH4la68b0+aOlxS30evaQrGLV3a' .
+                'HLMm3p+wywtIgo42Y0hObs65XGn7LXS6yKfVlyjgZICDC55Tzu5+stdQZVask+oPB35kjN9Y6iXGAQ==',
+                true
+            ),
+            RsaKey::DATA_P => base64_decode('/eckwW8Sof6YRmt87BD3c8i5uiQ7Hhf/iLyV/maVrNmQY/R8C9NFWBE1hbWnY4d3Zkv9J0wG/+pC4cgmDDyS0aE=', true),
+            RsaKey::DATA_Q => base64_decode('+WWBxJoXAwSbsPObESvIW13Jbh2CCsgoYsFrvcjFBflYvLcmglk/rtWkGYxBStBMJnIqN8uYJmt/nIxF4I5/Z60=', true),
+            RsaKey::DATA_DP => base64_decode('B1J9Kt7rKKTQ+2bqKVyr5jjpskaNNeb3RZg6syV+N4fmtBs+4JBtNYb5hiug8ivb86VJXbLBmOvGlgBRqJSun0E=', true),
+            RsaKey::DATA_DQ => base64_decode('rFJB5vldex1dAlhgRe4No2vbOXW0HAUPOqVQ77JgyG7wrHyUZC6MvR4rI+fwWWQxqcLqfuDzQWC3rRCTW8S6LYU=', true),
+            RsaKey::DATA_QI => base64_decode('7V0Y0KbokK3DJDR0/bX4T30Jdp/izDqRodUuoFUuC32E91NASWmX69LvxIEaTUufFfseeDkKZsDt86bJd+jVbCw=', true),
+        ]);
+    }
+
+    /**
+     * A 1032 bit key: one octet below what PS512 can encode.
+     */
+    public static function tooShortPrivateKey(): RsaKey
+    {
+        return RsaKey::create([
+            RsaKey::TYPE => RsaKey::TYPE_RSA,
+            RsaKey::DATA_N => base64_decode(
+                'pYAL5CbIyjdpyYlvdloijtpngb9PHLASgg4nLWRThi7wCXxaAetrSX1qS2vtavYaYko5t3SPyxsvlJJw8WOye+aj2Y9RbONi' .
+                'VTC05qrFXeJO1AjtXOJWusvy67e3yA0oE6Nvjd9jVctYzUpF68nna/4HlyL3ZG2e6+jKtxJLQm6h',
+                true
+            ),
+            RsaKey::DATA_E => base64_decode('AQAB', true),
+            RsaKey::DATA_D => base64_decode(
+                'TPfrD9VVxm3U/gyz0NgEgGlkf/wH//CG+wM4By1EhwAnVFIHziK9h7UTDTaJeRgxlwqsIvzLrwraqv8cFbdnF5pjw/i3s5T2' .
+                'He8wMi+D+vwnJlD/PgE7tPaZxuZOrg9kzAmvCj+oO+IsxK87uekThS4NuBzYM7y4mKqxpXpOxacB',
+                true
+            ),
+            RsaKey::DATA_P => base64_decode('DbIp9Gk1mPiAlkkR60/lfQTIXAVn0nhmkDfrMfEVWaTLckGIpRTxOsW/BT9UZec4KyR/uKSME3LLGbas1ZVdL9E=', true),
+            RsaKey::DATA_Q => base64_decode('DBV41o2Ad7I3RC9t186MXAg71dj9Zf8eMtIyTddCG+ZL/i/6Xr8UqNNv3l3xLhUhk2o7ze+Pt2SAIRgWQ+XuVdE=', true),
+            RsaKey::DATA_DP => base64_decode('BIBC7YIODUHN8JX+/5h4UQfbWPKl1jOfcVIPR5B1dcqE2f3TjH0/chM+3dicQgklGniaSPI63sFhIgg48NBvmaE=', true),
+            RsaKey::DATA_DQ => base64_decode('C+ff/iy+5bAeybydUiK8ojSul51K1YLOAy6cx5sOFKUMPK6S1WUY+toP/5y5czj4suDZeabOB9gqcfDkhxN1hvE=', true),
+            RsaKey::DATA_QI => base64_decode('A042Nryl4pq/C53imTBKSNsnys6JW95kudsevvSwXT3DN0ZVcnGGpVQ6/FRbzApn43ebSTgDqoQyLMycaKJPA0Q=', true),
         ]);
     }
 }

--- a/tests/Algorithm/Signature/RSA/RsaKeysTest.php
+++ b/tests/Algorithm/Signature/RSA/RsaKeysTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cose\Tests\Algorithm\Signature\RSA;
+
+use function bin2hex;
+use Brick\Math\BigInteger;
+use Cose\Key\RsaKey;
+use Cose\Key\RsaKeyValidator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The RSA fixtures used to be internally inconsistent (p*q != n), which hid every RSASSA-PSS defect reported in
+ * https://github.com/web-auth/cose-lib/issues/173. These assertions make sure they cannot rot again.
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc8017#section-3.2
+ */
+final class RsaKeysTest extends TestCase
+{
+    #[Test]
+    #[DataProvider('getPrivateKeys')]
+    public function thePrivateKeyIsInternallyConsistent(RsaKey $key, int $modulusLength): void
+    {
+        // Given
+        $n = self::toBigInteger($key->n());
+        $e = self::toBigInteger($key->e());
+        $d = self::toBigInteger($key->d());
+        $p = self::toBigInteger($key->p());
+        $q = self::toBigInteger($key->q());
+        $primesProduct = $p->multipliedBy($q);
+        if ($key->has(RsaKey::DATA_OTHER)) {
+            foreach ($key->other() as $primeInfo) {
+                $primesProduct = $primesProduct->multipliedBy(self::toBigInteger($primeInfo[RsaKey::DATA_RI]));
+            }
+        }
+
+        // Then
+        static::assertSame($modulusLength, RsaKeyValidator::modulusLength($key));
+        static::assertTrue($primesProduct->isEqualTo($n), 'The product of the primes is not the modulus');
+        static::assertTrue(
+            $e->multipliedBy($d)
+                ->mod($p->minus(1))
+                ->isEqualTo(1),
+            'e*d is not 1 modulo p - 1'
+        );
+        static::assertTrue(
+            $e->multipliedBy($d)
+                ->mod($q->minus(1))
+                ->isEqualTo(1),
+            'e*d is not 1 modulo q - 1'
+        );
+        static::assertTrue(
+            $e->multipliedBy(self::toBigInteger($key->dP()))->mod($p->minus(1))->isEqualTo(1),
+            'e*dP is not 1 modulo p - 1'
+        );
+        static::assertTrue(
+            $e->multipliedBy(self::toBigInteger($key->dQ()))->mod($q->minus(1))->isEqualTo(1),
+            'e*dQ is not 1 modulo q - 1'
+        );
+        static::assertTrue(
+            $q->multipliedBy(self::toBigInteger($key->QInv()))->mod($p)->isEqualTo(1),
+            'q*qInv is not 1 modulo p'
+        );
+    }
+
+    #[Test]
+    public function theMultiPrimeKeyCarriesConsistentOtherPrimeInfos(): void
+    {
+        // Given
+        $key = RsaKeys::multiPrimePrivateKey();
+        $e = self::toBigInteger($key->e());
+        $d = self::toBigInteger($key->d());
+        $r = self::toBigInteger($key->p())->multipliedBy(self::toBigInteger($key->q()));
+
+        // When
+        $otherPrimeInfos = $key->other();
+
+        // Then
+        static::assertCount(1, $otherPrimeInfos);
+        foreach ($otherPrimeInfos as $primeInfo) {
+            $rI = self::toBigInteger($primeInfo[RsaKey::DATA_RI]);
+            static::assertTrue(
+                $e->multipliedBy(self::toBigInteger($primeInfo[RsaKey::DATA_DI]))->mod($rI->minus(1))->isEqualTo(1),
+                'e*d_i is not 1 modulo r_i - 1'
+            );
+            static::assertTrue(
+                $e->multipliedBy($d)
+                    ->mod($rI->minus(1))
+                    ->isEqualTo(1),
+                'e*d is not 1 modulo r_i - 1'
+            );
+            static::assertTrue(
+                $r->multipliedBy(self::toBigInteger($primeInfo[RsaKey::DATA_TI]))->mod($rI)->isEqualTo(1),
+                'R*t_i is not 1 modulo r_i'
+            );
+        }
+    }
+
+    #[Test]
+    public function theModulusOfTheMainKeyUsesTheMinimumNumberOfOctets(): void
+    {
+        // Given
+        $key = RsaKeys::privateKey();
+
+        // Then
+        static::assertSame("\x00", RsaKeys::privateKeyWithPaddedModulus()->n()[0]);
+        static::assertNotSame("\x00", $key->n()[0]);
+        static::assertSame(
+            RsaKeyValidator::modulusLength($key),
+            RsaKeyValidator::modulusLength(RsaKeys::privateKeyWithPaddedModulus())
+        );
+    }
+
+    /**
+     * @return iterable<string, array{RsaKey, int}>
+     */
+    public static function getPrivateKeys(): iterable
+    {
+        yield 'main' => [RsaKeys::privateKey(), 2048];
+        yield 'padded modulus' => [RsaKeys::privateKeyWithPaddedModulus(), 2048];
+        yield 'not byte aligned' => [RsaKeys::nonByteAlignedPrivateKey(), 2050];
+        yield 'multi-prime' => [RsaKeys::multiPrimePrivateKey(), 2048];
+        yield 'short' => [RsaKeys::shortPrivateKey(), 1040];
+        yield 'too short' => [RsaKeys::tooShortPrivateKey(), 1032];
+    }
+
+    private static function toBigInteger(string $value): BigInteger
+    {
+        return BigInteger::fromBase(bin2hex($value), 16);
+    }
+}


### PR DESCRIPTION
Closes #173.

## What

`Cose\Algorithm\Signature\RSA\PSSRSA` — the hand-written RSASSA-PSS primitive behind `PS256`, `PS384` and `PS512` — deviated from RFC 8017 in nine places. None of them let an invalid signature through (every deviation on the verify path is fail-closed), but legitimate keys failed and generic signers got silently wrong results. The PS* test vectors were commented out and the shared fixture had `p*q != n`, so nothing caught it.

## Changes

`src/Algorithm/Signature/RSA/PSSRSA.php`

| # | Deviation | Fix |
|---|---|---|
| 1 | `verify()` ran the CRT private branch with a private-key object, rejecting every genuine signature | `verify()` calls `toPublic()` first, as RFC 8017 §8.1.2 and `RSA::verify()` do |
| 2 | `sign()` accepted a public or `d`-only key and returned `EM^e mod n` | `isPrivate()` guard (`The key is not private.`, like `RSA::sign()`); the operation, not the shape of the key, selects the exponent, so a `(n, e, d)` key (RFC 8017 §3.2) signs with `d` |
| 3 | `modBits` from `strlen($key->n())` | `modBits` and `k` from the integer value of `n`, via `RsaKeyValidator::modulusLength()`; `emLen = ceil((modBits - 1) / 8)` per §8.1.2 step 2.c |
| 4 | `chr(0xFF << 7)`, i.e. `chr(32640)`, deprecated on PHP 8.5 | one `leftmostBitsMask()` helper building the mask within `[0, 255]`, also handling the `8emLen - emBits == 0` case |
| 5 | RSAVP1 accepted `s == n` | `0 <= s <= n - 1` per §5.2.2 step 1 |
| 6 | `encodeEMSAPSS()` rejected `emLen == hLen + sLen + 2` | `<` per §9.1.1 step 3, matching `verifyEMSAPSS()` |
| 7 | Multi-prime keys returned a residue modulo `p*q` | §5.2.1 steps 2.b.2 and 2.b.5 implemented; a CRT result inconsistent with `s^e mod n` is refused rather than emitted |
| 8 | Seven message-less exceptions | RFC-aligned messages on all of them |
| 9 | No active PSS test, inconsistent fixture | see below |

`src/Key/RsaKey.php`: `other()` gets a precise return type and a docblock; `asPem()` documents that a key carrying `other` is exported as a two-prime `RSAPrivateKey` whose `p*q != n` and that RS* signing with it relies on OpenSSL's CRT-consistency fallback (`OtherPrimeInfos` support in spomky-labs/pki-framework is a separate follow-up).

## Tests

- `tests/Algorithm/Signature/RSA/RsaKeys.php`: the fixture is replaced by internally consistent keys — a 2048-bit key with a minimal-encoded modulus, the same key without CRT parameters, the same key with a zero-padded modulus, a 2050-bit (not byte-aligned) key, a three-prime key, and 1040/1032-bit keys for the PS512 encoding boundary.
- `tests/Algorithm/Signature/RSA/RsaKeysTest.php` (new): asserts `n = p*q` (or `p*q*r`), `e*dP = 1 mod (p-1)`, `e*dQ = 1 mod (q-1)`, `q*qInv = 1 mod p` and `R*t_i = 1 mod r_i`, so the fixtures cannot rot again.
- `tests/Algorithm/Signature/RSA/RSATest.php`: PS256/PS384/PS512 vectors are back — the RS* and PS* known answers are regenerated for the new key, the PSS ones with `openssl dgst -sigopt rsa_padding_mode:pss -sigopt rsa_pss_saltlen:digest` (the salt length RFC 8230 §2 mandates). The duplicated assertion in `aSignatureCanBeComputedAndVerified()` is fixed, and public-key verification plus tampered-message cases are added.
- `tests/Algorithm/Signature/RSA/PSSRSATest.php` (new): one case per item above, including OpenSSL cross-checks for the 2050-bit and 1040-bit keys and an assertion that no deprecation is emitted.

Against the previous implementation the new tests produce 26 errors and 8 failures; on this branch the suite is green (171 tests, 444 assertions) on PHP 8.5 with `error_reporting=-1`. ECS, Rector, PHPStan and Deptrac all pass.

## Backward compatibility

No BC break. Exception classes are unchanged (only messages are added), `exponentiate()` keeps its public signature and now delegates to RSASP1 or RSAVP1 depending on the key. The behaviour changes are all cases that previously threw or produced a value no conforming verifier accepts.