### PR TITLE
fix(rsa): blind and harden the RSASSA-PSS private exponentiation

### DIFF
--- a/doc/Usage.md
+++ b/doc/Usage.md
@@ -280,6 +280,14 @@ $coseMac = CoseMacTag::create(
   - PS512 (-39): RSASSA-PSS with SHA-512
   - RS1 (-65535): RSASSA-PKCS1-v1_5 with SHA-1 — **not secure**, kept only for legacy authenticators
 
+PS256, PS384 and PS512 sign with a private key, so the exponentiation is a side-channel target. A two-prime key
+carrying the full CRT quintuple — the shape almost every key store produces — is exponentiated by OpenSSL, which
+blinds the base and runs `BN_mod_exp_mont_consttime`. Its CRT parameters are checked against the modulus first, so an
+inconsistent key is reported rather than silently repaired. Multi-prime keys ([RFC 8230 section 4](https://www.rfc-editor.org/rfc/rfc8230#section-4))
+and keys reduced to `(n, e, d)` have no PEM representation and keep the in-process exponentiation; their base is
+blinded, which hides it from an observer, but `gmp_powm()`, `bcpowmod()` and the native brick/math loop are not
+constant-time, so prefer a full two-prime key when signing with a long-lived key on a shared host.
+
 RS1 relies on SHA-1, which is no longer acceptable for digital signatures (see
 [RFC 6194](https://datatracker.ietf.org/doc/html/rfc6194) and NIST SP 800-131A). Creating the algorithm emits an
 `E_USER_WARNING` unless the risk is explicitly acknowledged:

--- a/src/Algorithm/Signature/RSA/PSSRSA.php
+++ b/src/Algorithm/Signature/RSA/PSSRSA.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Cose\Algorithm\Signature\RSA;
 
+use Brick\Math\Exception\MathException;
 use function chr;
 use Cose\Algorithm\Signature\Signature;
 use Cose\BigInteger;
@@ -14,6 +15,10 @@ use Cose\Key\RsaKeyValidator;
 use function hash_equals;
 use function intdiv;
 use InvalidArgumentException;
+use function is_string;
+use function openssl_error_string;
+use const OPENSSL_NO_PADDING;
+use function openssl_private_encrypt;
 use function ord;
 use function pack;
 use function random_bytes;
@@ -22,6 +27,7 @@ use function str_pad;
 use const STR_PAD_LEFT;
 use function str_repeat;
 use function strlen;
+use Throwable;
 
 /**
  * RSASSA-PSS as defined by RFC 8017, section 8.1.
@@ -108,20 +114,143 @@ abstract class PSSRSA implements Signature
         if ($m->compare(BigInteger::createFromDecimal(0)) < 0 || $m->compare($n) >= 0) {
             throw new RuntimeException('Message representative out of range');
         }
-        $signature = $key->hasPrimes() && $key->hasExponents() && $key->hasCoefficient()
-            ? $this->rsasp1WithCrt($key, $m)
-            // RFC 8017, section 5.2.1, step 2.a: first form (n, d).
-            : $m->modPow(BigInteger::createFromBinaryString($key->d()), $n);
+        $e = BigInteger::createFromBinaryString($key->e());
+        $hasCrtParameters = $key->hasPrimes() && $key->hasExponents() && $key->hasCoefficient();
+
+        if ($hasCrtParameters && ! $key->has(RsaKey::DATA_OTHER)) {
+            // A two-prime key with a complete CRT quintuple is the only shape RsaKey::asPem() can express, and the
+            // only one OpenSSL can therefore compute. Its exponentiation is blinded and runs in constant time, which
+            // neither gmp_powm() nor bcpowmod() nor the native brick/math loop does.
+            $this->checkCrtParameters($key, $n);
+            $signature = $this->rsasp1WithOpenSSL($key, $m);
+        } else {
+            // Multi-prime keys (RFC 8230, section 4) and (n, e, d) keys have no PEM representation, so they keep the
+            // in-process exponentiation. Blinding the base hides it from an attacker timing the operation or watching
+            // the cache while it runs; it does not make the exponentiation itself constant-time.
+            [$blindingFactor, $unblindingFactor] = $this->blindingFactors($n, $e);
+            $blinded = $m->multiply($blindingFactor)
+                ->mod($n)
+            ;
+            $signature = $hasCrtParameters
+                ? $this->rsasp1WithCrt($key, $blinded)
+                // RFC 8017, section 5.2.1, step 2.a: first form (n, d).
+                : $blinded->modPow(BigInteger::createFromBinaryString($key->d()), $n);
+            $signature = $signature->multiply($unblindingFactor)
+                ->mod($n)
+            ;
+        }
 
         // A wrong CRT result must never leave this class: it would be a silently invalid signature and, on faulty
         // hardware, a private key recovery oracle. OpenSSL applies the very same check.
-        if ($signature->modPow(BigInteger::createFromBinaryString($key->e()), $n)->compare($m) !== 0) {
+        if ($signature->modPow($e, $n)->compare($m) !== 0) {
             throw new RuntimeException(
                 'Inconsistent RSA private key: the CRT parameters do not describe the modulus'
             );
         }
 
         return $signature;
+    }
+
+    /**
+     * RSASP1 computed by OpenSSL: base blinding and BN_mod_exp_mont_consttime on the private exponent, plus its own
+     * check of the CRT result against the public operation.
+     */
+    private function rsasp1WithOpenSSL(RsaKey $key, BigInteger $m): BigInteger
+    {
+        $k = intdiv(RsaKeyValidator::modulusLength($key) + 7, 8);
+
+        try {
+            $computed = openssl_private_encrypt(
+                $this->convertIntegerToOctetString($m, $k),
+                $signature,
+                $key->asPem(),
+                OPENSSL_NO_PADDING
+            );
+        } catch (Throwable $throwable) {
+            $this->clearOpenSSLErrors();
+
+            throw new RuntimeException('Unable to compute the RSA signature primitive', 0, $throwable);
+        }
+        if (! $computed || ! is_string($signature)) {
+            $this->clearOpenSSLErrors();
+
+            throw new RuntimeException('Unable to compute the RSA signature primitive');
+        }
+
+        return BigInteger::createFromBinaryString($signature);
+    }
+
+    /**
+     * OpenSSL repairs a key whose CRT parameters do not describe the modulus instead of reporting it, so the
+     * consistency of the quintuple is established before the exponentiation rather than after it.
+     */
+    private function checkCrtParameters(RsaKey $key, BigInteger $n): void
+    {
+        $one = BigInteger::createFromDecimal(1);
+        [$pS, $qS] = $key->primes();
+        [$dPS, $dQS] = $key->exponents();
+        $p = BigInteger::createFromBinaryString($pS);
+        $q = BigInteger::createFromBinaryString($qS);
+        $e = BigInteger::createFromBinaryString($key->e());
+        // A prime of 0 or 1 would make the reductions below meaningless, and n = p * q rules it out on its own only
+        // for the other factor.
+        $this->assertCrtParameter($p->compare($one) > 0 && $q->compare($one) > 0);
+        $this->assertCrtParameter($this->isEqual($p->multiply($q), $n));
+        // e * dP = 1 mod (p - 1), e * dQ = 1 mod (q - 1) and q * qInv = 1 mod p (RFC 8017, section 3.2).
+        $this->assertCrtParameter(
+            $this->isEqual($e->multiply(BigInteger::createFromBinaryString($dPS))->mod($p->subtract($one)), $one)
+        );
+        $this->assertCrtParameter(
+            $this->isEqual($e->multiply(BigInteger::createFromBinaryString($dQS))->mod($q->subtract($one)), $one)
+        );
+        $this->assertCrtParameter(
+            $this->isEqual($q->multiply(BigInteger::createFromBinaryString($key->QInv()))->mod($p), $one)
+        );
+    }
+
+    private function assertCrtParameter(bool $isConsistent): void
+    {
+        if (! $isConsistent) {
+            throw new RuntimeException(
+                'Inconsistent RSA private key: the CRT parameters do not describe the modulus'
+            );
+        }
+    }
+
+    private function isEqual(BigInteger $left, BigInteger $right): bool
+    {
+        return $left->compare($right) === 0;
+    }
+
+    /**
+     * A random r coprime with n, returned as the pair (r^e mod n, r^-1 mod n): multiplying the message representative
+     * by the first before the exponentiation and the result by the second after it leaves the signature unchanged,
+     * while the value actually exponentiated is unpredictable.
+     *
+     * @return array{BigInteger, BigInteger}
+     */
+    private function blindingFactors(BigInteger $n, BigInteger $e): array
+    {
+        $two = BigInteger::createFromDecimal(2);
+        // Eight bytes beyond the modulus keep the bias of the reduction below negligible.
+        $length = strlen($n->toBytes()) + 8;
+        $upperBound = $n->subtract(BigInteger::createFromDecimal(3));
+
+        while (true) {
+            $r = BigInteger::createFromBinaryString(random_bytes($length))
+                ->mod($upperBound)
+                ->add($two)
+            ;
+
+            try {
+                // Drawing an r sharing a factor with n means having factored n, so this never loops in practice.
+                $unblindingFactor = $r->modInverse($n);
+            } catch (MathException) {
+                continue;
+            }
+
+            return [$r->modPow($e, $n), $unblindingFactor];
+        }
     }
 
     /**
@@ -160,6 +289,15 @@ abstract class PSSRSA implements Signature
         }
 
         return $signature;
+    }
+
+    /**
+     * Drains the OpenSSL error queue so that a failure here is not reported by an unrelated later call.
+     */
+    private function clearOpenSSLErrors(): void
+    {
+        while (openssl_error_string() !== false) {
+        }
     }
 
     private function convertIntegerToOctetString(BigInteger $x, int $xLen): string

--- a/src/BigInteger.php
+++ b/src/BigInteger.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Cose;
 
 use Brick\Math\BigInteger as BrickBigInteger;
+use Brick\Math\Exception\MathException;
 use function chr;
 use function hex2bin;
 use function strlen;
@@ -86,6 +87,18 @@ final class BigInteger
     public function modPow(self $e, self $n): self
     {
         $value = $this->value->modPow($e->value, $n->value);
+
+        return new self($value);
+    }
+
+    /**
+     * Returns the modular multiplicative inverse of this number modulo $m.
+     *
+     * @throws MathException if this number is not invertible modulo $m, i.e. if they are not coprime
+     */
+    public function modInverse(self $m): self
+    {
+        $value = $this->value->modInverse($m->value);
 
         return new self($value);
     }

--- a/tests/Algorithm/Signature/RSA/PSSRSATest.php
+++ b/tests/Algorithm/Signature/RSA/PSSRSATest.php
@@ -19,6 +19,7 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use PHPUnit\Framework\TestCase;
 use function restore_error_handler;
+use RuntimeException;
 use function set_error_handler;
 use function str_repeat;
 use function strlen;
@@ -336,6 +337,78 @@ final class PSSRSATest extends TestCase
             0,
             $algorithm->exponentiate(RsaKeys::privateKeyWithoutCrtParameters(), $message)->compare($signature)
         );
+    }
+
+    /**
+     * RSASP1 is a deterministic function of the key and the message representative. The private exponentiation of a
+     * multi-prime or (n, e, d) key is blinded with a random factor, which must leave the result untouched.
+     *
+     * @see https://github.com/web-auth/cose-lib/issues/172
+     */
+    #[Test]
+    #[DataProvider('getBlindedKeys')]
+    public function theBlindedSignaturePrimitiveIsDeterministic(RsaKey $key): void
+    {
+        // Given
+        $algorithm = PS256::create();
+        $message = BigInteger::createFromBinaryString(substr(self::MESSAGE, 0, 8));
+
+        // When
+        $first = $algorithm->exponentiate($key, $message);
+        $second = $algorithm->exponentiate($key, $message);
+
+        // Then
+        static::assertSame(0, $first->compare($second));
+        static::assertSame(0, $algorithm->exponentiate($key->toPublic(), $first)->compare($message));
+    }
+
+    /**
+     * A two-prime key is exponentiated by OpenSSL, which repairs an inconsistent CRT quintuple instead of reporting
+     * it. Every parameter of the quintuple must therefore be checked against the modulus beforehand.
+     *
+     * @see https://github.com/web-auth/cose-lib/issues/172
+     */
+    #[Test]
+    #[DataProvider('getCrtParameters')]
+    public function anInconsistentCrtParameterIsRejected(int $parameter): void
+    {
+        // Given
+        $data = RsaKeys::privateKey()
+            ->getData()
+        ;
+        $data[$parameter] = RsaKeys::nonByteAlignedPrivateKey()
+            ->getData()[$parameter]
+        ;
+
+        // Then
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Inconsistent RSA private key');
+
+        // When
+        PS256::create()
+            ->sign(self::MESSAGE, RsaKey::create($data))
+        ;
+    }
+
+    /**
+     * @return iterable<string, array{RsaKey}>
+     */
+    public static function getBlindedKeys(): iterable
+    {
+        yield 'without CRT parameters' => [RsaKeys::privateKeyWithoutCrtParameters()];
+        yield 'multi-prime' => [RsaKeys::multiPrimePrivateKey()];
+    }
+
+    /**
+     * @return iterable<string, array{int}>
+     */
+    public static function getCrtParameters(): iterable
+    {
+        yield 'p' => [RsaKey::DATA_P];
+        yield 'q' => [RsaKey::DATA_Q];
+        yield 'dP' => [RsaKey::DATA_DP];
+        yield 'dQ' => [RsaKey::DATA_DQ];
+        yield 'qInv' => [RsaKey::DATA_QI];
     }
 
     /**


### PR DESCRIPTION
Closes #172.

> Rebased on `4.7.x` after #178 was merged. That PR fixed the RFC 8017 conformance of `PSSRSA` and, in passing, everything this one originally carried (`toPublic()` on verify, the `isPrivate()` guard, the PHP 8.5 `chr()` deprecation, the CRT post-check, consistent fixtures, the PS* vectors). What it did not address is the finding of #172 itself, so this PR is now reduced to that single subject.

## What is left of #172

The private exponentiation is still a side-channel target. `Cose\BigInteger::modPow()` ends up in `gmp_powm()`, `bcpowmod()` or brick/math's native PHP loop; GMP reserves its side-channel statement to `mpz_powm_sec`, which ext-gmp does not bind, and the base was never blinded. The primitive is now chosen from the shape of the key.

| Key shape | Primitive | Why |
|---|---|---|
| Two primes + full CRT quintuple | `openssl_private_encrypt()` with `OPENSSL_NO_PADDING` | Base blinding and `BN_mod_exp_mont_consttime`, plus OpenSSL's own check of the CRT result. The only shape `RsaKey::asPem()` can express, and the one virtually every key store produces. |
| Multi-prime (RFC 8230 §4) | #178's in-process CRT, base blinded | No PEM representation: `asPem()` exports a two-prime `RSAPrivateKey` whose `p*q != n`, as its own docblock says. |
| `(n, e, d)` only | #178's `m^d mod n`, base blinded | Same, no PEM representation. |

Blinding is `c' = c · r^e mod n`, then `s = s' · r^-1 mod n`, with `r` drawn uniformly from `[2, n-2]` and coprime with `n`. It hides the base from an attacker timing the operation or watching the cache; it does **not** make the exponentiation constant-time. `doc/Usage.md` states that plainly and recommends a full two-prime key for long-lived signing keys on a shared host.

## Preserving what #178 decided

OpenSSL **repairs** a key whose CRT parameters do not describe the modulus rather than reporting it, so routing the two-prime path through it would have silently dropped the rejection #178 introduced — `aPrivateKeyWithInconsistentCrtParametersIsRejected` fails without a counter-measure, as do the five new cases.

The quintuple is therefore checked against the modulus *before* the exponentiation: `p, q > 1`, `p * q == n`, `e * dP == 1 mod (p - 1)`, `e * dQ == 1 mod (q - 1)`, `q * qInv == 1 mod p`. Same `RuntimeException`, same message, and now raised for **any** of the five parameters instead of only those the post-check happened to catch. #178's post-check is kept as is for the blinded paths.

Every behaviour #178 added is preserved: multi-prime signing, `(n, e, d)` signing, the zero-padded and 2050-bit moduli, the 1040-bit PS512 boundary, and the OpenSSL known answers.

## Changes

- `src/Algorithm/Signature/RSA/PSSRSA.php`: `rsasp1()` dispatches to `rsasp1WithOpenSSL()` or to the blinded in-process path; `checkCrtParameters()` and `blindingFactors()` added.
- `src/BigInteger.php`: `modInverse()`, needed to unblind. Available since brick/math 0.9, so the lowest-deps job is fine — verified by running the suite against brick/math 0.10 (the lowest the current constraints resolve to).
- `doc/Usage.md`: which key shapes get which guarantee.

## Tests

Added to `tests/Algorithm/Signature/RSA/PSSRSATest.php`:

- `theBlindedSignaturePrimitiveIsDeterministic` — RSASP1 is a deterministic function of the key and the message representative, so the random blinding factor must cancel exactly. Run for the multi-prime and the `(n, e, d)` key, checking both that two calls agree and that the public primitive recovers the message.
- `anInconsistentCrtParameterIsRejected` — one case per parameter of the quintuple (`p`, `q`, `dP`, `dQ`, `qInv`), each corrupted from another key.

Verified as genuine regression tests: with `checkCrtParameters()` removed, all five fail **and so does #178's own** `aPrivateKeyWithInconsistentCrtParametersIsRejected` — OpenSSL repairs every one of those keys. Separately checked out of the suite that the blinding factors differ on every draw, that `blind · unblind^e == 1 mod n`, and that both blinded paths return exactly `m^d mod n`.

## Backward compatibility

No BC break. `exponentiate()` keeps its signature and its behaviour; #178's `theExponentiationPrimitiveRoundTrips`, which asserts that the CRT path and the `(n, e, d)` path return the same value, still passes and now covers the OpenSSL path against the blinded one. The only behaviour change is that an inconsistent CRT quintuple is rejected earlier and more thoroughly.

## Verification

Full suite on PHP 8.2, 8.3, 8.4 and 8.5: 302 tests, 714 assertions, green (the 5 skips on 8.2/8.3 are the pre-existing Ed448 cases). Also green on PHP 8.2 with the lowest resolvable dependencies. ECS, PHPStan (level max), Rector, Deptrac and parallel-lint clean — run on PHP 8.4, the version the CI jobs use.
