### PR TITLE
fix(signature): make verify() total for every invalid signature outcome

### DIFF
--- a/.ci-tools/phpstan-baseline.neon
+++ b/.ci-tools/phpstan-baseline.neon
@@ -91,12 +91,6 @@ parameters:
 			path: ../src/Key/Ec2Key.php
 
 		-
-			rawMessage: Possibly invalid array key type mixed.
-			identifier: offsetAccess.invalidOffset
-			count: 2
-			path: ../src/Key/Ec2Key.php
-
-		-
 			rawMessage: Cannot cast mixed to int.
 			identifier: cast.int
 			count: 1

--- a/README.md
+++ b/README.md
@@ -202,6 +202,36 @@ the key. They live in the `Cose\Algorithm\Signature\FullySpecified` namespace.
 | HS512 | 7 | HMAC with SHA-512 |
 | HS256/64 | 4 | HMAC with SHA-256 truncated to 64 bits |
 
+## Signature Verification Contract
+
+`Cose\Algorithm\Signature\Signature::verify()` is total for every condition the governing specifications define as an
+"invalid signature" outcome. A malformed, truncated, over-long or out-of-range signature, and key material that the
+crypto layer cannot decode — a point that is not on the named curve, a public key that is not a valid group element —
+all return `false`. No PHP warning is raised on the way.
+
+It throws an `InvalidArgumentException` in one case only: the key cannot be used with the algorithm at all, i.e. its
+key type or its curve does not match. Structurally invalid key components — an empty or zero RSA modulus, an `x`, `y`
+or `d` whose length does not fit the curve — are rejected earlier, by the `Key` constructors, so the exception is
+raised when the key is first seen rather than at every verification.
+
+```php
+use Cose\Key\Key;
+use InvalidArgumentException;
+
+try {
+    // Throws only when $key is an RSA key, an EC key on another curve, …
+    $key = Key::createFromData($credentialPublicKey);
+} catch (InvalidArgumentException $e) {
+    // The credential cannot be used with this algorithm: reject it at registration.
+}
+
+// From here on, verification is a plain boolean, whatever the client sent.
+$isValid = $algorithm->verify($data, $key, $signature);
+```
+
+`sign()` throws an `InvalidArgumentException` when the key is public, when the crypto layer cannot load it, or when the
+signature operation itself fails, for instance for an RSA modulus too short for the digest.
+
 ## Validating RSA Keys
 
 [RFC 8812](https://datatracker.ietf.org/doc/html/rfc8812) defers to

--- a/doc/Usage.md
+++ b/doc/Usage.md
@@ -17,6 +17,7 @@ This library provides full support for COSE (CBOR Object Signing and Encryption)
   - [COSE_Mac (With Recipients)](#cose_mac-with-recipients)
 - [Supported Algorithms](#supported-algorithms)
   - [Fully-Specified Algorithms](#fully-specified-algorithms)
+  - [Signature Verification Contract](#signature-verification-contract)
   - [Validating RSA Keys](#validating-rsa-keys)
 
 ## Installation
@@ -331,6 +332,36 @@ PHP 8.4. Call `Ed448::isSupported()` when the platform is not known in advance; 
 
 The brainpool curves are also available on `Cose\Key\Ec2Key` as `CURVE_BP256`, `CURVE_BP320`, `CURVE_BP384` and
 `CURVE_BP512` (values 256 to 259 of the COSE Elliptic Curves registry).
+
+### Signature Verification Contract
+
+`Cose\Algorithm\Signature\Signature::verify()` is total for every condition the governing specifications define as an
+"invalid signature" outcome. A malformed, truncated, over-long or out-of-range signature, and key material that the
+crypto layer cannot decode — a point that is not on the named curve, a public key that is not a valid group element —
+all return `false`. No PHP warning is raised on the way.
+
+It throws an `InvalidArgumentException` in one case only: the key cannot be used with the algorithm at all, i.e. its
+key type or its curve does not match. Structurally invalid key components — an empty or zero RSA modulus, an `x`, `y`
+or `d` whose length does not fit the curve — are rejected earlier, by the `Key` constructors, so the exception is
+raised when the key is first seen rather than at every verification.
+
+```php
+use Cose\Key\Key;
+use InvalidArgumentException;
+
+try {
+    // Throws only when $key is an RSA key, an EC key on another curve, …
+    $key = Key::createFromData($credentialPublicKey);
+} catch (InvalidArgumentException $e) {
+    // The credential cannot be used with this algorithm: reject it at registration.
+}
+
+// From here on, verification is a plain boolean, whatever the client sent.
+$isValid = $algorithm->verify($data, $key, $signature);
+```
+
+`sign()` throws an `InvalidArgumentException` when the key is public, when the crypto layer cannot load it, or when the
+signature operation itself fails, for instance for an RSA modulus too short for the digest.
 
 ### Validating RSA Keys
 

--- a/src/Algorithm/Signature/ECDSA/ECDSA.php
+++ b/src/Algorithm/Signature/ECDSA/ECDSA.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Cose\Algorithm\Signature\ECDSA;
 
+use Cose\Algorithm\Signature\OpenSslError;
 use Cose\Algorithm\Signature\Signature;
 use Cose\Key\Ec2Key;
 use Cose\Key\Key;
 use InvalidArgumentException;
+use function openssl_pkey_get_private;
+use function openssl_pkey_get_public;
 use function openssl_sign;
 use function openssl_verify;
 use function strlen;
@@ -20,7 +23,19 @@ abstract class ECDSA implements Signature
     public function sign(string $data, Key $key): string
     {
         $key = $this->handleKey($key);
-        openssl_sign($data, $signature, $key->asPEM(), $this->getHashAlgorithm());
+        if (! $key->isPrivate()) {
+            throw new InvalidArgumentException('The key is not private.');
+        }
+        $privateKey = openssl_pkey_get_private($key->asPEM());
+        if ($privateKey === false) {
+            throw new InvalidArgumentException('Unable to load the EC private key');
+        }
+        OpenSslError::clear();
+        // openssl_sign() reports failure with a boolean and never throws: an unusable key would otherwise leave
+        // $signature null and raise a TypeError inside ECSignature::fromAsn1().
+        if (! openssl_sign($data, $signature, $privateKey, $this->getHashAlgorithm())) {
+            throw new InvalidArgumentException('Unable to sign the data: ' . OpenSslError::lastMessage());
+        }
 
         return ECSignature::fromAsn1($signature, $this->getSignaturePartLength());
     }
@@ -28,11 +43,11 @@ abstract class ECDSA implements Signature
     public function verify(string $data, Key $key, string $signature): bool
     {
         $key = $this->handleKey($key);
-        $publicKey = $key->toPublic();
         $length = $this->getSignaturePartLength();
+        // A signature that does not hold exactly the two coordinates of this curve is an invalid signature, not a
+        // caller error: webauthn-lib hands the bytes of an assertion straight to verify().
         if (strlen($signature) !== $length) {
-            // A signature of the wrong size is a caller error, not attacker input: the exception is kept.
-            throw new InvalidArgumentException('Invalid signature length.');
+            return false;
         }
 
         try {
@@ -41,8 +56,14 @@ abstract class ECDSA implements Signature
             // A well-formed but invalid signature (e.g. R = 0) is a verification failure, not an error.
             return false;
         }
+        // The key is loaded before use: openssl_verify() would raise an E_WARNING for key material OpenSSL cannot
+        // coerce into a public key, e.g. a point that is not on the named curve.
+        $publicKey = openssl_pkey_get_public($key->toPublic()->asPEM());
+        if ($publicKey === false) {
+            return false;
+        }
 
-        return openssl_verify($data, $signature, $publicKey->asPEM(), $this->getHashAlgorithm()) === 1;
+        return openssl_verify($data, $signature, $publicKey, $this->getHashAlgorithm()) === 1;
     }
 
     abstract protected function getCurve(): int;

--- a/src/Algorithm/Signature/FullySpecified/Ed448.php
+++ b/src/Algorithm/Signature/FullySpecified/Ed448.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Cose\Algorithm\Signature\FullySpecified;
 
+use Cose\Algorithm\Signature\OpenSslError;
 use Cose\Algorithm\Signature\Signature;
 use Cose\Key\Key;
 use Cose\Key\OkpKey;
@@ -64,8 +65,9 @@ final class Ed448 implements Signature
             throw new InvalidArgumentException('Unable to load the Ed448 private key');
         }
 
+        OpenSslError::clear();
         if (! openssl_sign($data, $signature, $privateKey, self::NO_DIGEST)) {
-            throw new InvalidArgumentException('Unable to sign the data');
+            throw new InvalidArgumentException('Unable to sign the data: ' . OpenSslError::lastMessage());
         }
 
         return $signature;
@@ -75,9 +77,11 @@ final class Ed448 implements Signature
     {
         $key = $this->handleKey($key);
 
+        // RFC 8032 section 5.2.7: a public key that cannot be decoded as a point makes the signature invalid; it is
+        // a verification outcome, not an error.
         $publicKey = openssl_pkey_get_public($key->toPublic()->asPEM());
         if ($publicKey === false) {
-            throw new InvalidArgumentException('Unable to load the Ed448 public key');
+            return false;
         }
 
         return openssl_verify($data, $signature, $publicKey, self::NO_DIGEST) === 1;

--- a/src/Algorithm/Signature/OpenSslError.php
+++ b/src/Algorithm/Signature/OpenSslError.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cose\Algorithm\Signature;
+
+use function openssl_error_string;
+
+/**
+ * Reads the OpenSSL error queue so that a failed signature operation can say why it failed.
+ *
+ * @internal
+ */
+final class OpenSslError
+{
+    /**
+     * Empties the queue, so that lastMessage() reports the errors of the next operation only. The queue is
+     * process-wide and is not cleared by successful calls.
+     */
+    public static function clear(): void
+    {
+        while (openssl_error_string() !== false) {
+            // Nothing to do: the call itself pops one entry off the queue.
+        }
+    }
+
+    /**
+     * Returns the most recent message of the queue, emptying it.
+     */
+    public static function lastMessage(): string
+    {
+        $message = false;
+        while (($entry = openssl_error_string()) !== false) {
+            $message = $entry;
+        }
+
+        return $message === false ? 'unknown OpenSSL error' : $message;
+    }
+}

--- a/src/Algorithm/Signature/RSA/PSSRSA.php
+++ b/src/Algorithm/Signature/RSA/PSSRSA.php
@@ -57,12 +57,23 @@ abstract class PSSRSA implements Signature
             ->toPublic();
         $modBits = RsaKeyValidator::modulusLength($key);
         $k = intdiv($modBits + 7, 8);
+        // RFC 8017, section 8.1.2, step 1: "If the length of the signature S is not k octets, output 'invalid
+        // signature' and stop."
         if (strlen($signature) !== $k) {
-            throw new InvalidArgumentException('Invalid signature length');
+            return false;
         }
-        $m = $this->rsavp1($key, BigInteger::createFromBinaryString($signature));
-        // RFC 8017, section 8.1.2, step 2.c: emLen = ceil((modBits - 1) / 8).
+        $s = BigInteger::createFromBinaryString($signature);
+        // Step 2.b: "If RSAVP1 output 'signature representative out of range', output 'invalid signature' and stop."
+        if ($s->compare(BigInteger::createFromBinaryString($key->n())) >= 0) {
+            return false;
+        }
+        $m = $this->rsavp1($key, $s);
+        // RFC 8017, section 8.1.2, step 2.c: emLen = ceil((modBits - 1) / 8). "If I2OSP outputs 'integer too large',
+        // output 'invalid signature' and stop."
         $emLen = intdiv($modBits - 1 + 7, 8);
+        if (strlen($m->toBytes()) > $emLen) {
+            return false;
+        }
         $em = $this->convertIntegerToOctetString($m, $emLen);
 
         return $this->verifyEMSAPSS($data, $em, $modBits - 1, $this->getHashAlgorithm());
@@ -234,31 +245,33 @@ abstract class PSSRSA implements Signature
         $hLen = $hash->getLength();
         $sLen = $hLen;
         $mHash = $hash->hash($m);
+        // Every check below is a step whose failure RFC 8017, section 9.1.2 defines as "output 'inconsistent' and
+        // stop", i.e. an invalid signature rather than an error.
+        // Step 3: the modulus is too short for this hash and salt length.
         if ($emLen < $hLen + $sLen + 2) {
-            throw new InvalidArgumentException(
-                'Inconsistent signature: the modulus is too short for this hash and salt length'
-            );
+            return false;
         }
+        // Step 4: the trailer field is not 0xBC.
         if ($em[strlen($em) - 1] !== chr(0xBC)) {
-            throw new InvalidArgumentException('Inconsistent signature: the trailer field is not 0xBC');
+            return false;
         }
         $maskedDB = substr($em, 0, -$hLen - 1);
         $h = substr($em, -$hLen - 1, $hLen);
         $mask = $this->leftmostBitsMask($emBits);
+        // Step 6: the leftmost bits of maskedDB are not zero.
         if (($maskedDB[0] & $mask) !== chr(0)) {
-            throw new InvalidArgumentException(
-                'Inconsistent signature: the leftmost bits of maskedDB are not zero'
-            );
+            return false;
         }
         $dbMask = $this->getMGF1($h, $emLen - $hLen - 1, $hash/* MGF */);
         $db = $maskedDB ^ $dbMask;
         $db[0] = ~$mask & $db[0];
         $temp = $emLen - $hLen - $sLen - 2;
+        // Step 10: the padding string is not zero, or the separator octet is not 0x01.
         if (! str_starts_with($db, str_repeat(chr(0), $temp))) {
-            throw new InvalidArgumentException('Inconsistent signature: the padding string is not zero');
+            return false;
         }
         if (ord($db[$temp]) !== 1) {
-            throw new InvalidArgumentException('Inconsistent signature: the separator octet is not 0x01');
+            return false;
         }
         $salt = substr($db, $temp + 1); // should be $sLen long
         $m2 = "\0\0\0\0\0\0\0\0" . $mHash . $salt;

--- a/src/Algorithm/Signature/RSA/RSA.php
+++ b/src/Algorithm/Signature/RSA/RSA.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace Cose\Algorithm\Signature\RSA;
 
+use Cose\Algorithm\Signature\OpenSslError;
 use Cose\Algorithm\Signature\Signature;
 use Cose\Key\Key;
 use Cose\Key\RsaKey;
 use InvalidArgumentException;
+use function openssl_pkey_get_private;
+use function openssl_pkey_get_public;
 use function openssl_sign;
 use function openssl_verify;
-use Throwable;
 
 /**
  * @see \Cose\Tests\Algorithm\Signature\RSA\RSATest
@@ -23,11 +25,15 @@ abstract class RSA implements Signature
         if (! $key->isPrivate()) {
             throw new InvalidArgumentException('The key is not private.');
         }
-
-        try {
-            openssl_sign($data, $signature, $key->asPem(), $this->getHashAlgorithm());
-        } catch (Throwable $e) {
-            throw new InvalidArgumentException('Unable to sign the data', 0, $e);
+        $privateKey = openssl_pkey_get_private($key->asPem());
+        if ($privateKey === false) {
+            throw new InvalidArgumentException('Unable to load the RSA private key');
+        }
+        OpenSslError::clear();
+        // openssl_sign() reports failure with a boolean and never throws: a modulus too short for the digest would
+        // otherwise leave $signature null and raise a TypeError on the way out.
+        if (! openssl_sign($data, $signature, $privateKey, $this->getHashAlgorithm())) {
+            throw new InvalidArgumentException('Unable to sign the data: ' . OpenSslError::lastMessage());
         }
 
         return $signature;
@@ -36,8 +42,14 @@ abstract class RSA implements Signature
     public function verify(string $data, Key $key, string $signature): bool
     {
         $key = $this->handleKey($key);
+        // The key is loaded before use so that key material OpenSSL cannot decode yields false instead of an
+        // E_WARNING raised from inside openssl_verify().
+        $publicKey = openssl_pkey_get_public($key->toPublic()->asPem());
+        if ($publicKey === false) {
+            return false;
+        }
 
-        return openssl_verify($data, $signature, $key->toPublic()->asPem(), $this->getHashAlgorithm()) === 1;
+        return openssl_verify($data, $signature, $publicKey, $this->getHashAlgorithm()) === 1;
     }
 
     abstract protected function getHashAlgorithm(): int;

--- a/src/Algorithm/Signature/Signature.php
+++ b/src/Algorithm/Signature/Signature.php
@@ -6,10 +6,24 @@ namespace Cose\Algorithm\Signature;
 
 use Cose\Algorithm\Algorithm;
 use Cose\Key\Key;
+use InvalidArgumentException;
 
 interface Signature extends Algorithm
 {
+    /**
+     * @throws InvalidArgumentException when the key cannot be used to sign with this algorithm (wrong key type, wrong
+     *                                  curve, public key, or key material the crypto layer refuses)
+     */
     public function sign(string $data, Key $key): string;
 
+    /**
+     * Verification is total for every condition the underlying specification defines as an "invalid signature"
+     * outcome: a malformed, truncated, over-long or out-of-range signature, and key material that the crypto layer
+     * cannot decode (an off-curve point, a public key that is not a valid group element, …) all yield false.
+     *
+     * @throws InvalidArgumentException when $key cannot be used with this algorithm at all, i.e. its key type or its
+     *                                  curve does not match. Structurally invalid key components are rejected earlier,
+     *                                  by the Key constructors.
+     */
     public function verify(string $data, Key $key, string $signature): bool;
 }

--- a/src/Key/Ec2Key.php
+++ b/src/Key/Ec2Key.php
@@ -8,6 +8,7 @@ use function array_key_exists;
 use function in_array;
 use InvalidArgumentException;
 use function is_int;
+use function is_string;
 use SpomkyLabs\Pki\ASN1\Type\Constructed\Sequence;
 use SpomkyLabs\Pki\ASN1\Type\Primitive\BitString;
 use SpomkyLabs\Pki\ASN1\Type\Primitive\Integer;
@@ -147,18 +148,25 @@ class Ec2Key extends Key
         if (! isset($data[self::DATA_CURVE], $data[self::DATA_X], $data[self::DATA_Y])) {
             throw new InvalidArgumentException('Invalid EC2 key. The curve or the "x/y" coordinates are missing');
         }
-        if (strlen((string) $data[self::DATA_X]) !== self::CURVE_KEY_LENGTH[$data[self::DATA_CURVE]]) {
-            throw new InvalidArgumentException('Invalid length for x coordinate');
-        }
-        if (strlen((string) $data[self::DATA_Y]) !== self::CURVE_KEY_LENGTH[$data[self::DATA_CURVE]]) {
-            throw new InvalidArgumentException('Invalid length for y coordinate');
-        }
+        // The curve is checked first: the coordinate lengths below are read from a table indexed by the curve.
         if (is_int($data[self::DATA_CURVE])) {
             if (! in_array($data[self::DATA_CURVE], self::SUPPORTED_CURVES_INT, true)) {
                 throw new InvalidArgumentException('The curve is not supported');
             }
         } elseif (! in_array($data[self::DATA_CURVE], self::SUPPORTED_CURVES_NAMES, true)) {
             throw new InvalidArgumentException('The curve is not supported');
+        }
+        $length = self::CURVE_KEY_LENGTH[$data[self::DATA_CURVE]];
+        if (strlen((string) $data[self::DATA_X]) !== $length) {
+            throw new InvalidArgumentException('Invalid length for x coordinate');
+        }
+        if (strlen((string) $data[self::DATA_Y]) !== $length) {
+            throw new InvalidArgumentException('Invalid length for y coordinate');
+        }
+        // RFC 5915 section 3: the private key is "an octet string of length ceiling (log2(n)/8)".
+        if (array_key_exists(self::DATA_D, $data)
+            && (! is_string($data[self::DATA_D]) || strlen($data[self::DATA_D]) !== $length)) {
+            throw new InvalidArgumentException('Invalid length for d');
         }
     }
 

--- a/src/Key/OkpKey.php
+++ b/src/Key/OkpKey.php
@@ -7,11 +7,13 @@ namespace Cose\Key;
 use function array_key_exists;
 use function in_array;
 use InvalidArgumentException;
+use function is_string;
 use SpomkyLabs\Pki\ASN1\Type\Constructed\Sequence;
 use SpomkyLabs\Pki\ASN1\Type\Primitive\BitString;
 use SpomkyLabs\Pki\ASN1\Type\Primitive\Integer;
 use SpomkyLabs\Pki\ASN1\Type\Primitive\ObjectIdentifier;
 use SpomkyLabs\Pki\ASN1\Type\Primitive\OctetString;
+use function strlen;
 
 /**
  * @final
@@ -55,6 +57,21 @@ class OkpKey extends Key
         self::CURVE_NAME_ED448,
     ];
 
+    /**
+     * RFC 8032 section 5.1.5 / 5.2.5 for the Edwards curves and RFC 7748 section 5 for the Montgomery ones: the
+     * public key and the private scalar are byte strings of exactly this length.
+     */
+    private const CURVE_KEY_LENGTH = [
+        self::CURVE_X25519 => 32,
+        self::CURVE_X448 => 56,
+        self::CURVE_ED25519 => 32,
+        self::CURVE_ED448 => 57,
+        self::CURVE_NAME_X25519 => 32,
+        self::CURVE_NAME_X448 => 56,
+        self::CURVE_NAME_ED25519 => 32,
+        self::CURVE_NAME_ED448 => 57,
+    ];
+
     private const CURVE_OID = [
         self::CURVE_X25519 => '1.3.101.110',
         self::CURVE_X448 => '1.3.101.111',
@@ -89,6 +106,14 @@ class OkpKey extends Key
             }
         } elseif (! in_array($data[self::DATA_CURVE], self::SUPPORTED_CURVES_NAME, true)) {
             throw new InvalidArgumentException('The curve is not supported');
+        }
+        $length = self::CURVE_KEY_LENGTH[$data[self::DATA_CURVE]];
+        if (! is_string($data[self::DATA_X]) || strlen($data[self::DATA_X]) !== $length) {
+            throw new InvalidArgumentException('Invalid length for x coordinate');
+        }
+        if (array_key_exists(self::DATA_D, $data)
+            && (! is_string($data[self::DATA_D]) || strlen($data[self::DATA_D]) !== $length)) {
+            throw new InvalidArgumentException('Invalid length for d');
         }
     }
 

--- a/src/Key/RsaKey.php
+++ b/src/Key/RsaKey.php
@@ -8,6 +8,8 @@ use function array_key_exists;
 use Brick\Math\BigInteger;
 use function in_array;
 use InvalidArgumentException;
+use function is_string;
+use function ltrim;
 use SpomkyLabs\Pki\CryptoTypes\Asymmetric\PublicKeyInfo;
 use SpomkyLabs\Pki\CryptoTypes\Asymmetric\RSA\RSAPrivateKey;
 use SpomkyLabs\Pki\CryptoTypes\Asymmetric\RSA\RSAPublicKey;
@@ -43,6 +45,18 @@ class RsaKey extends Key
     final public const DATA_TI = -12;
 
     /**
+     * @var array<int>
+     */
+    private const PRIVATE_PARAMETERS = [
+        self::DATA_D,
+        self::DATA_P,
+        self::DATA_Q,
+        self::DATA_DP,
+        self::DATA_DQ,
+        self::DATA_QI,
+    ];
+
+    /**
      * @param array<int|string, mixed> $data
      */
     public function __construct(array $data)
@@ -58,6 +72,21 @@ class RsaKey extends Key
         }
         if (! isset($data[self::DATA_N], $data[self::DATA_E])) {
             throw new InvalidArgumentException('Invalid RSA key. The modulus or the exponent is missing');
+        }
+        $modulus = $data[self::DATA_N];
+        $exponent = $data[self::DATA_E];
+        if (! is_string($modulus) || $modulus === '' || ! is_string($exponent) || $exponent === '') {
+            throw new InvalidArgumentException(
+                'Invalid RSA key. The modulus and the exponent shall be non-empty byte strings'
+            );
+        }
+        if (ltrim($modulus, "\0") === '') {
+            throw new InvalidArgumentException('Invalid RSA key. The modulus shall not be zero');
+        }
+        foreach (self::PRIVATE_PARAMETERS as $parameter) {
+            if (array_key_exists($parameter, $data) && ! is_string($data[$parameter])) {
+                throw new InvalidArgumentException('Invalid RSA key. The private parameters shall be byte strings');
+            }
         }
     }
 

--- a/tests/Algorithm/Mac/HS256Test.php
+++ b/tests/Algorithm/Mac/HS256Test.php
@@ -54,7 +54,7 @@ final class HS256Test extends TestCase
         $key = OkpKey::create([
             OkpKey::TYPE => SymmetricKey::TYPE_OKP,
             OkpKey::DATA_CURVE => OkpKey::CURVE_X25519,
-            OkpKey::DATA_X => '',
+            OkpKey::DATA_X => str_repeat("\0", 32),
         ]);
         $algorithm->hash(
             'eyJhbGciOiJIUzI1NiIsImtpZCI6IjAxOGMwYWU1LTRkOWItNDcxYi1iZmQ2LWVlZjMxNGJjNzAzNyJ9.SXTigJlzIGEgZGFuZ2Vyb3VzIGJ1c2luZXNzLCBGcm9kbywgZ29pbmcgb3V0IHlvdXIgZG9vci4gWW91IHN0ZXAgb250byB0aGUgcm9hZCwgYW5kIGlmIHlvdSBkb24ndCBrZWVwIHlvdXIgZmVldCwgdGhlcmXigJlzIG5vIGtub3dpbmcgd2hlcmUgeW91IG1pZ2h0IGJlIHN3ZXB0IG9mZiB0by4',

--- a/tests/Algorithm/Mac/HmacTest.php
+++ b/tests/Algorithm/Mac/HmacTest.php
@@ -77,7 +77,7 @@ final class HmacTest extends TestCase
         $key = OkpKey::create([
             OkpKey::TYPE => SymmetricKey::TYPE_OKP,
             OkpKey::DATA_CURVE => OkpKey::CURVE_X25519,
-            OkpKey::DATA_X => '',
+            OkpKey::DATA_X => str_repeat("\0", 32),
         ]);
 
         // When

--- a/tests/Algorithm/Signature/ECDSA/ECDSATest.php
+++ b/tests/Algorithm/Signature/ECDSA/ECDSATest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Cose\Tests\Algorithm\Signature\ECDSA;
 
+use function chr;
 use Cose\Algorithm\Signature\ECDSA\ECDSA;
 use Cose\Algorithm\Signature\ECDSA\ES256;
 use Cose\Algorithm\Signature\ECDSA\ES256K;
@@ -11,10 +12,17 @@ use Cose\Algorithm\Signature\ECDSA\ES384;
 use Cose\Algorithm\Signature\ECDSA\ES512;
 use Cose\Key\Ec2Key;
 use Cose\Key\OkpKey;
+use ErrorException;
+use function hex2bin;
 use InvalidArgumentException;
+use function ord;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use function random_bytes;
+use function restore_error_handler;
+use function set_error_handler;
+use function str_repeat;
 
 final class ECDSATest extends TestCase
 {
@@ -97,7 +105,7 @@ final class ECDSATest extends TestCase
         $key = OkpKey::create([
             OkpKey::TYPE => Ec2Key::TYPE_OKP,
             OkpKey::DATA_CURVE => OkpKey::CURVE_X25519,
-            OkpKey::DATA_X => '',
+            OkpKey::DATA_X => str_repeat("\0", 32),
         ]);
 
         // When
@@ -129,6 +137,121 @@ final class ECDSATest extends TestCase
             'eyJhbGciOiJIUzI1NiIsImtpZCI6IjAxOGMwYWU1LTRkOWItNDcxYi1iZmQ2LWVlZjMxNGJjNzAzNyJ9.SXTigJlzIGEgZGFuZ2Vyb3VzIGJ1c2luZXNzLCBGcm9kbywgZ29pbmcgb3V0IHlvdXIgZG9vci4gWW91IHN0ZXAgb250byB0aGUgcm9hZCwgYW5kIGlmIHlvdSBkb24ndCBrZWVwIHlvdXIgZmVldCwgdGhlcmXigJlzIG5vIGtub3dpbmcgd2hlcmUgeW91IG1pZ2h0IGJlIHN3ZXB0IG9mZiB0by4',
             $key
         );
+    }
+
+    /**
+     * ECSignature::toAsn1() strips the leading zero bytes of r and s before writing their DER length. A stripped
+     * coordinate shorter than 16 octets used to be prefixed with a single hex digit, which made hex2bin() fail and
+     * the string return type raise a TypeError.
+     */
+    #[Test]
+    public function aSignatureWhoseCoordinatesAreAlmostEntirelyZeroIsRejected(): void
+    {
+        // Given
+        $algorithm = ES256::create();
+        $key = self::sampleP256Key();
+        // r has 17 leading zero bytes, so only 15 octets are left once they are stripped.
+        $signature = str_repeat("\x00", 17) . random_bytes(15) . random_bytes(32);
+
+        // When
+        $isValid = $algorithm->verify('sample', $key, $signature);
+
+        // Then
+        static::assertFalse($isValid);
+    }
+
+    #[Test]
+    #[DataProvider('getInvalidSignatureLengths')]
+    public function aSignatureOfTheWrongLengthIsRejected(int $length): void
+    {
+        // Given
+        $algorithm = ES256::create();
+        $key = self::sampleP256Key();
+
+        // When
+        $isValid = $algorithm->verify('sample', $key, $length === 0 ? '' : random_bytes($length));
+
+        // Then
+        static::assertFalse($isValid);
+    }
+
+    /**
+     * Nothing checks that (x, y) is a point of the named curve, so OpenSSL is the one that refuses the key. It used
+     * to do so from inside openssl_verify(), with an E_WARNING that a Symfony style error handler turns into an
+     * ErrorException.
+     */
+    #[Test]
+    public function aPublicKeyThatIsNotOnTheCurveIsRejectedWithoutRaisingAWarning(): void
+    {
+        // Given
+        $algorithm = ES256::create();
+        $y = hex2bin('7903FE1008B8BC99A41AE9E95628BC64F2F1B20C2D7E9F5177A3C294D4462299');
+        // chr()/ord() rather than the shorthand operator: PHP does not allow "^=" on a string offset.
+        $y[31] = chr(ord($y[31]) ^ 0x01);
+        $key = Ec2Key::create([
+            Ec2Key::TYPE => Ec2Key::TYPE_EC2,
+            Ec2Key::DATA_CURVE => Ec2Key::CURVE_P256,
+            Ec2Key::DATA_X => hex2bin('60FED4BA255A9D31C961EB74C6356D68C049B8923B61FA6CE669622E60F29FB6'),
+            Ec2Key::DATA_Y => $y,
+        ]);
+
+        // When
+        $isValid = self::withoutErrorHandler(
+            static fn (): bool => $algorithm->verify('sample', $key, random_bytes(64))
+        );
+
+        // Then
+        static::assertFalse($isValid);
+    }
+
+    /**
+     * A genuine P-256 point, but labelled with the P-256K curve identifier: OpenSSL cannot decode it either.
+     */
+    #[Test]
+    public function aPointLabelledWithAnotherCurveIsRejectedWithoutRaisingAWarning(): void
+    {
+        // Given
+        $algorithm = ES256K::create();
+        $key = Ec2Key::create([
+            Ec2Key::TYPE => Ec2Key::TYPE_EC2,
+            Ec2Key::DATA_CURVE => Ec2Key::CURVE_P256K,
+            Ec2Key::DATA_X => hex2bin('60FED4BA255A9D31C961EB74C6356D68C049B8923B61FA6CE669622E60F29FB6'),
+            Ec2Key::DATA_Y => hex2bin('7903FE1008B8BC99A41AE9E95628BC64F2F1B20C2D7E9F5177A3C294D4462299'),
+        ]);
+
+        // When
+        $isValid = self::withoutErrorHandler(
+            static fn (): bool => $algorithm->verify('sample', $key, random_bytes(64))
+        );
+
+        // Then
+        static::assertFalse($isValid);
+    }
+
+    #[Test]
+    public function aSignatureCannotBeComputedWithAPublicKey(): void
+    {
+        // Given
+        $algorithm = ES256::create();
+        $key = self::sampleP256Key();
+
+        // Then
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The key is not private.');
+
+        // When
+        $algorithm->sign('sample', $key);
+    }
+
+    /**
+     * @return iterable<string, array{int}>
+     */
+    public static function getInvalidSignatureLengths(): iterable
+    {
+        yield 'empty' => [0];
+        yield 'one byte short' => [63];
+        yield 'one byte too long' => [65];
+        yield 'the length of another curve' => [96];
     }
 
     /**
@@ -283,5 +406,40 @@ final class ECDSATest extends TestCase
         $isValid = $algorithm->verify($data, $key, $invalidSignature);
         // Then
         static::assertFalse($isValid);
+    }
+
+    private static function sampleP256Key(): Ec2Key
+    {
+        return Ec2Key::create([
+            Ec2Key::TYPE => Ec2Key::TYPE_EC2,
+            Ec2Key::DATA_CURVE => Ec2Key::CURVE_P256,
+            Ec2Key::DATA_X => hex2bin('60FED4BA255A9D31C961EB74C6356D68C049B8923B61FA6CE669622E60F29FB6'),
+            Ec2Key::DATA_Y => hex2bin('7903FE1008B8BC99A41AE9E95628BC64F2F1B20C2D7E9F5177A3C294D4462299'),
+        ]);
+    }
+
+    /**
+     * Runs the callback with an error handler that turns any PHP error into an exception, so that a stray E_WARNING
+     * fails the test instead of being swallowed.
+     *
+     * @param callable(): bool $callback
+     */
+    private static function withoutErrorHandler(callable $callback): bool
+    {
+        set_error_handler(
+            static fn (int $severity, string $message, string $file, int $line): bool => throw new ErrorException(
+                $message,
+                0,
+                $severity,
+                $file,
+                $line
+            )
+        );
+
+        try {
+            return $callback();
+        } finally {
+            restore_error_handler();
+        }
     }
 }

--- a/tests/Algorithm/Signature/ECDSA/ECSignatureTest.php
+++ b/tests/Algorithm/Signature/ECDSA/ECSignatureTest.php
@@ -160,18 +160,35 @@ final class ECSignatureTest extends TestCase
     }
 
     /**
-     * The wrong-length signature has always been reported with an exception; the behaviour is kept.
+     * The encoder keeps reporting a wrong-length input with an exception: it is reached from sign() and from
+     * callers that already know the shape of what they pass.
      */
     #[Test]
-    public function aSignatureOfTheWrongLengthIsRejected(): void
+    public function encodingASignatureOfTheWrongLengthIsRejected(): void
     {
         // Then
         static::expectException(InvalidArgumentException::class);
         static::expectExceptionMessage('Invalid signature length.');
 
         // When
-        ES256::create()
+        ECSignature::toAsn1(str_repeat("\0", 63), 64);
+    }
+
+    /**
+     * verify(), on the other hand, is handed attacker-controlled bytes: webauthn-lib passes the signature of an
+     * assertion straight through. A wrong length is an invalid signature, not an error.
+     *
+     * @see https://github.com/web-auth/cose-lib/issues/175
+     */
+    #[Test]
+    public function verifyingASignatureOfTheWrongLengthReturnsFalse(): void
+    {
+        // When
+        $isValid = ES256::create()
             ->verify('sample', self::p256Key(), str_repeat("\0", 63));
+
+        // Then
+        static::assertFalse($isValid);
     }
 
     #[Test]

--- a/tests/Algorithm/Signature/FullySpecified/FullySpecifiedEdDsaTest.php
+++ b/tests/Algorithm/Signature/FullySpecified/FullySpecifiedEdDsaTest.php
@@ -14,6 +14,8 @@ use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use function random_bytes;
+use function str_repeat;
 
 /**
  * @see https://www.rfc-editor.org/rfc/rfc9864.html#section-2.2
@@ -199,6 +201,32 @@ final class FullySpecifiedEdDsaTest extends TestCase
 
         // When
         $algorithm->verify('Live long and Prosper.', $key, 'whatever');
+    }
+
+    /**
+     * RFC 8032 section 5.2.7: "Decode the public key A as point A\'. If any of the decodings fail (including S being
+     * out of range), the signature is invalid." A public key OpenSSL refuses to load used to throw instead.
+     */
+    #[Test]
+    public function anEd448PublicKeyThatIsNotAPointIsRejected(): void
+    {
+        if (! Ed448::isSupported()) {
+            static::markTestSkipped('Ed448 requires PHP 8.4 or later.');
+        }
+
+        // Given
+        $algorithm = Ed448::create();
+        $key = OkpKey::create([
+            OkpKey::TYPE => OkpKey::TYPE_OKP,
+            OkpKey::DATA_CURVE => OkpKey::CURVE_ED448,
+            OkpKey::DATA_X => str_repeat("\xff", 57),
+        ]);
+
+        // When
+        $isValid = $algorithm->verify('Live long and Prosper.', $key, random_bytes(114));
+
+        // Then
+        static::assertFalse($isValid);
     }
 
     /**

--- a/tests/Algorithm/Signature/RSA/PSSRSATest.php
+++ b/tests/Algorithm/Signature/RSA/PSSRSATest.php
@@ -19,6 +19,7 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use PHPUnit\Framework\TestCase;
 use function restore_error_handler;
+use RuntimeException;
 use function set_error_handler;
 use function str_repeat;
 use function strlen;
@@ -88,7 +89,8 @@ final class PSSRSATest extends TestCase
     }
 
     /**
-     * RFC 8017 section 5.2.2, step 1: the signature representative shall be between 0 and n - 1.
+     * RFC 8017 section 8.1.2, step 2.b: "If RSAVP1 output \'signature representative out of range\', output
+     * \'invalid signature\' and stop." The representative is out of range here because it is the modulus itself.
      */
     #[Test]
     public function aSignatureRepresentativeOutOfRangeIsRejected(): void
@@ -97,29 +99,52 @@ final class PSSRSATest extends TestCase
         $key = RsaKeys::publicKey();
         $modulus = $key->n();
 
+        // When
+        $isValid = PS256::create()
+            ->verify(self::MESSAGE, $key, $modulus)
+        ;
+
         // Then
+        static::assertFalse($isValid);
+    }
+
+    /**
+     * The primitive itself keeps refusing an out of range representative: it is also reachable through the public
+     * exponentiate(), where there is no "invalid signature" outcome to fall back on.
+     */
+    #[Test]
+    public function theExponentiationPrimitiveRefusesARepresentativeOutOfRange(): void
+    {
+        // Given
+        $key = RsaKeys::publicKey();
+
+        // Then
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Signature representative out of range');
 
         // When
         PS256::create()
-            ->verify(self::MESSAGE, $key, $modulus)
+            ->exponentiate($key, BigInteger::createFromBinaryString($key->n()))
         ;
     }
 
+    /**
+     * RFC 8017 section 8.1.2, step 1: "If the length of the signature S is not k octets, output \'invalid
+     * signature\' and stop."
+     */
     #[Test]
     public function aSignatureOfTheWrongLengthIsRejected(): void
     {
         // Given
         $key = RsaKeys::publicKey();
 
-        // Then
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid signature length');
-
         // When
-        PS256::create()
+        $isValid = PS256::create()
             ->verify(self::MESSAGE, $key, str_repeat("\x01", 255))
         ;
+
+        // Then
+        static::assertFalse($isValid);
     }
 
     #[Test]

--- a/tests/Algorithm/Signature/RSA/RSATest.php
+++ b/tests/Algorithm/Signature/RSA/RSATest.php
@@ -15,6 +15,10 @@ use Cose\Algorithm\Signature\RSA\RS384;
 use Cose\Algorithm\Signature\RSA\RS512;
 use Cose\Algorithm\Signature\RSA\RSA;
 use Cose\Key\RsaKey;
+use InvalidArgumentException;
+use const OPENSSL_KEYTYPE_RSA;
+use function openssl_pkey_get_details;
+use function openssl_pkey_new;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -101,6 +105,62 @@ final class RSATest extends TestCase
 
         // Then
         static::assertFalse($isValid);
+    }
+
+    /**
+     * openssl_sign() reports a modulus too short for the digest with a boolean; the return value used to be ignored,
+     * so $signature stayed null and the string return type raised a TypeError instead of the intended exception.
+     *
+     * @see https://www.rfc-editor.org/rfc/rfc8017#section-8.2.1
+     */
+    #[Test]
+    public function signingWithAModulusTooShortForTheDigestIsRejected(): void
+    {
+        // Given
+        $algorithm = RS512::create();
+        $key = self::generatedKey(512);
+
+        // Then
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unable to sign the data');
+
+        // When
+        $algorithm->sign('Live long and Prosper.', $key);
+    }
+
+    #[Test]
+    public function signingWithAPublicKeyIsRejected(): void
+    {
+        // Given
+        $algorithm = RS256::create();
+        $key = RsaKeys::publicKey();
+
+        // Then
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The key is not private.');
+
+        // When
+        $algorithm->sign('Live long and Prosper.', $key);
+    }
+
+    private static function generatedKey(int $bits): RsaKey
+    {
+        $details = openssl_pkey_get_details(openssl_pkey_new([
+            'private_key_type' => OPENSSL_KEYTYPE_RSA,
+            'private_key_bits' => $bits,
+        ]))['rsa'];
+
+        return RsaKey::create([
+            RsaKey::TYPE => RsaKey::TYPE_RSA,
+            RsaKey::DATA_N => $details['n'],
+            RsaKey::DATA_E => $details['e'],
+            RsaKey::DATA_D => $details['d'],
+            RsaKey::DATA_P => $details['p'],
+            RsaKey::DATA_Q => $details['q'],
+            RsaKey::DATA_DP => $details['dmp1'],
+            RsaKey::DATA_DQ => $details['dmq1'],
+            RsaKey::DATA_QI => $details['iqmp'],
+        ]);
     }
 
     /**

--- a/tests/Algorithm/Signature/VerificationContractTest.php
+++ b/tests/Algorithm/Signature/VerificationContractTest.php
@@ -1,0 +1,225 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cose\Tests\Algorithm\Signature;
+
+use function base64_decode;
+use function chr;
+use Cose\Algorithm\Signature\ECDSA\ES256;
+use Cose\Algorithm\Signature\ECDSA\ES256K;
+use Cose\Algorithm\Signature\ECDSA\ES384;
+use Cose\Algorithm\Signature\ECDSA\ES512;
+use Cose\Algorithm\Signature\EdDSA\Ed25519 as PolymorphicEd25519;
+use Cose\Algorithm\Signature\EdDSA\EdDSA;
+use Cose\Algorithm\Signature\FullySpecified\Ed25519;
+use Cose\Algorithm\Signature\FullySpecified\Ed448;
+use Cose\Algorithm\Signature\FullySpecified\ESB256;
+use Cose\Algorithm\Signature\FullySpecified\ESB320;
+use Cose\Algorithm\Signature\FullySpecified\ESB384;
+use Cose\Algorithm\Signature\FullySpecified\ESB512;
+use Cose\Algorithm\Signature\FullySpecified\ESP256;
+use Cose\Algorithm\Signature\FullySpecified\ESP384;
+use Cose\Algorithm\Signature\FullySpecified\ESP512;
+use Cose\Algorithm\Signature\RSA\PS256;
+use Cose\Algorithm\Signature\RSA\PS384;
+use Cose\Algorithm\Signature\RSA\PS512;
+use Cose\Algorithm\Signature\RSA\RS1;
+use Cose\Algorithm\Signature\RSA\RS256;
+use Cose\Algorithm\Signature\RSA\RS384;
+use Cose\Algorithm\Signature\RSA\RS512;
+use Cose\Algorithm\Signature\Signature;
+use Cose\Key\Ec2Key;
+use Cose\Key\Key;
+use Cose\Key\OkpKey;
+use Cose\Tests\Algorithm\Signature\RSA\RsaKeys;
+use ErrorException;
+use function hex2bin;
+use const OPENSSL_KEYTYPE_EC;
+use function ord;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use function random_bytes;
+use function restore_error_handler;
+use function set_error_handler;
+use const STR_PAD_LEFT;
+use function str_repeat;
+use function strlen;
+use function substr;
+
+/**
+ * The contract of Signature::verify(): everything the governing specifications call an "invalid signature" outcome is
+ * returned as false, silently and without raising a PHP error.
+ *
+ * @see \Cose\Algorithm\Signature\Signature
+ * @see https://github.com/web-auth/cose-lib/issues/175
+ */
+final class VerificationContractTest extends TestCase
+{
+    private const MESSAGE = 'Live long and Prosper.';
+
+    /**
+     * The Ed448 secret and public key of the "blank" test vector of RFC 8032, section 7.4.
+     */
+    private const ED448_SECRET = '6c82a562cb808d10d632be89c8513ebf6c929f34ddfa8c9f63c9960ef6e348a3528c8a3fcc2f044e39a3fc5b94492f8f032e7549a20098f95b';
+
+    private const ED448_PUBLIC = '5fd7449b59b461fd2ce787ec616ad46a1da1342485a70e1f8a0ea75d80e96778edf124769b46c7061bd6783df1e50f6cd1fa1abeafe8256180';
+
+    /**
+     * Any PHP notice, warning or deprecation raised while a test of this class runs becomes a failure: verify() must
+     * not leak an E_WARNING that a Symfony style error handler would turn into an exception.
+     */
+    protected function setUp(): void
+    {
+        set_error_handler(
+            static fn (int $severity, string $message, string $file, int $line): bool => throw new ErrorException(
+                $message,
+                0,
+                $severity,
+                $file,
+                $line
+            )
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        restore_error_handler();
+    }
+
+    #[Test]
+    #[DataProvider('getAlgorithms')]
+    public function aMalformedSignatureIsRejected(Signature $algorithm, Key $key, int $signatureLength): void
+    {
+        // Given
+        $signature = $algorithm->sign(self::MESSAGE, $key);
+        $public = self::publicPartOf($key);
+        // chr()/ord() rather than the shorthand operator: PHP does not allow "^=" on a string offset.
+        $flipped = $signature;
+        $flipped[0] = chr(ord($flipped[0]) ^ 0x01);
+
+        // Then
+        static::assertSame($signatureLength, strlen($signature));
+        static::assertTrue($algorithm->verify(self::MESSAGE, $public, $signature));
+
+        static::assertFalse($algorithm->verify('Live long and prosper.', $public, $signature), 'another message');
+        static::assertFalse($algorithm->verify(self::MESSAGE, $public, ''), 'empty signature');
+        static::assertFalse($algorithm->verify(self::MESSAGE, $public, substr($signature, 1)), 'truncated signature');
+        static::assertFalse($algorithm->verify(self::MESSAGE, $public, $signature . "\x00"), 'over-long signature');
+        static::assertFalse($algorithm->verify(self::MESSAGE, $public, $flipped), 'one bit flipped');
+        static::assertFalse(
+            $algorithm->verify(self::MESSAGE, $public, str_repeat("\x00", $signatureLength)),
+            'all-zero signature'
+        );
+        static::assertFalse(
+            $algorithm->verify(self::MESSAGE, $public, str_repeat("\xff", $signatureLength)),
+            'out of range signature'
+        );
+    }
+
+    /**
+     * The RSASSA-PSS verifier used to throw for almost every random signature: only a recovered encoded message that
+     * was structurally sound made it to the boolean comparison.
+     */
+    #[Test]
+    #[DataProvider('getAlgorithms')]
+    public function randomSignatureBytesAreRejected(Signature $algorithm, Key $key, int $signatureLength): void
+    {
+        // Given
+        $public = self::publicPartOf($key);
+
+        // Then
+        for ($i = 0; $i < 25; ++$i) {
+            // The leading zero byte keeps the value below the RSA modulus, so the out-of-range shortcut is not what
+            // is being exercised here.
+            $signature = "\x00" . random_bytes($signatureLength - 1);
+            static::assertFalse($algorithm->verify(self::MESSAGE, $public, $signature));
+        }
+    }
+
+    /**
+     * @return iterable<string, array{Signature, Key, int}>
+     */
+    public static function getAlgorithms(): iterable
+    {
+        $rsa = RsaKeys::privateKey();
+
+        yield 'RS1' => [RS1::create(acknowledgeInsecureAlgorithm: true), $rsa, 256];
+        yield 'RS256' => [RS256::create(), $rsa, 256];
+        yield 'RS384' => [RS384::create(), $rsa, 256];
+        yield 'RS512' => [RS512::create(), $rsa, 256];
+        yield 'PS256' => [PS256::create(), $rsa, 256];
+        yield 'PS384' => [PS384::create(), $rsa, 256];
+        yield 'PS512' => [PS512::create(), $rsa, 256];
+
+        yield 'ES256' => [ES256::create(), self::ecKey('prime256v1', Ec2Key::CURVE_P256, 32), 64];
+        yield 'ES256K' => [ES256K::create(), self::ecKey('secp256k1', Ec2Key::CURVE_P256K, 32), 64];
+        yield 'ES384' => [ES384::create(), self::ecKey('secp384r1', Ec2Key::CURVE_P384, 48), 96];
+        yield 'ES512' => [ES512::create(), self::ecKey('secp521r1', Ec2Key::CURVE_P521, 66), 132];
+
+        yield 'ESP256' => [ESP256::create(), self::ecKey('prime256v1', Ec2Key::CURVE_P256, 32), 64];
+        yield 'ESP384' => [ESP384::create(), self::ecKey('secp384r1', Ec2Key::CURVE_P384, 48), 96];
+        yield 'ESP512' => [ESP512::create(), self::ecKey('secp521r1', Ec2Key::CURVE_P521, 66), 132];
+
+        yield 'ESB256' => [ESB256::create(), self::ecKey('brainpoolP256r1', Ec2Key::CURVE_BP256, 32), 64];
+        yield 'ESB320' => [ESB320::create(), self::ecKey('brainpoolP320r1', Ec2Key::CURVE_BP320, 40), 80];
+        yield 'ESB384' => [ESB384::create(), self::ecKey('brainpoolP384r1', Ec2Key::CURVE_BP384, 48), 96];
+        yield 'ESB512' => [ESB512::create(), self::ecKey('brainpoolP512r1', Ec2Key::CURVE_BP512, 64), 128];
+
+        yield 'EdDSA' => [new EdDSA(), self::ed25519Key(), 64];
+        yield 'Ed25519 (polymorphic)' => [PolymorphicEd25519::create(), self::ed25519Key(), 64];
+        yield 'Ed25519 (fully specified)' => [Ed25519::create(), self::ed25519Key(), 64];
+
+        if (Ed448::isSupported()) {
+            yield 'Ed448' => [Ed448::create(), self::ed448Key(), 114];
+        }
+    }
+
+    private static function publicPartOf(Key $key): Key
+    {
+        return match (true) {
+            $key instanceof Ec2Key => $key->toPublic(),
+            $key instanceof OkpKey => $key->toPublic(),
+            default => $key,
+        };
+    }
+
+    private static function ecKey(string $curveName, int $curve, int $coordinateLength): Ec2Key
+    {
+        $details = openssl_pkey_get_details(openssl_pkey_new([
+            'private_key_type' => OPENSSL_KEYTYPE_EC,
+            'curve_name' => $curveName,
+        ]))['ec'];
+        // OpenSSL strips the leading zero bytes of the coordinates; COSE requires them to be fixed size.
+        $pad = static fn (string $value): string => str_pad($value, $coordinateLength, "\x00", STR_PAD_LEFT);
+
+        return Ec2Key::create([
+            Ec2Key::TYPE => Ec2Key::TYPE_EC2,
+            Ec2Key::DATA_CURVE => $curve,
+            Ec2Key::DATA_X => $pad($details['x']),
+            Ec2Key::DATA_Y => $pad($details['y']),
+            Ec2Key::DATA_D => $pad($details['d']),
+        ]);
+    }
+
+    private static function ed25519Key(): OkpKey
+    {
+        return OkpKey::create([
+            OkpKey::TYPE => OkpKey::TYPE_OKP,
+            OkpKey::DATA_CURVE => OkpKey::CURVE_ED25519,
+            OkpKey::DATA_X => base64_decode('11qYAYKxCrfVS/7TyWQHOg7hcvPapiMlrwIaaPcHURo', true),
+            OkpKey::DATA_D => base64_decode('nWGxne/9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2A', true),
+        ]);
+    }
+
+    private static function ed448Key(): OkpKey
+    {
+        return OkpKey::create([
+            OkpKey::TYPE => OkpKey::TYPE_OKP,
+            OkpKey::DATA_CURVE => OkpKey::CURVE_ED448,
+            OkpKey::DATA_X => hex2bin(self::ED448_PUBLIC),
+            OkpKey::DATA_D => hex2bin(self::ED448_SECRET),
+        ]);
+    }
+}

--- a/tests/Key/EC2KeyTest.php
+++ b/tests/Key/EC2KeyTest.php
@@ -8,6 +8,7 @@ use function base64_decode;
 use function bin2hex;
 use Cose\Algorithm\Signature\ECDSA\ES256;
 use Cose\Key\EC2Key;
+use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -82,6 +83,56 @@ final class EC2KeyTest extends TestCase
             EC2Key::DATA_X => random_bytes($coordinateLength - 1),
             EC2Key::DATA_Y => random_bytes($coordinateLength),
         ]);
+    }
+
+    /**
+     * RFC 5915 section 3 fixes the length of the private key, but only x and y used to be checked. A degenerate d
+     * produced signatures that the key's own public point rejected, with nothing failing at signing time.
+     */
+    #[Test]
+    #[DataProvider('getInvalidPrivateKeyLengths')]
+    public function aPrivateKeyOfTheWrongLengthIsRejected(mixed $d): void
+    {
+        // Then
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid length for d');
+
+        // When
+        EC2Key::create([
+            EC2Key::TYPE => EC2Key::TYPE_EC2,
+            EC2Key::DATA_CURVE => EC2Key::CURVE_P256,
+            EC2Key::DATA_X => random_bytes(32),
+            EC2Key::DATA_Y => random_bytes(32),
+            EC2Key::DATA_D => $d,
+        ]);
+    }
+
+    #[Test]
+    public function anUnsupportedCurveIsRejected(): void
+    {
+        // Then
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The curve is not supported');
+
+        // When
+        EC2Key::create([
+            EC2Key::TYPE => EC2Key::TYPE_EC2,
+            EC2Key::DATA_CURVE => 4242,
+            EC2Key::DATA_X => random_bytes(32),
+            EC2Key::DATA_Y => random_bytes(32),
+        ]);
+    }
+
+    /**
+     * @return iterable<string, array{mixed}>
+     */
+    public static function getInvalidPrivateKeyLengths(): iterable
+    {
+        yield 'empty' => [''];
+        yield 'a single byte' => ["\x00"];
+        yield 'too short' => [random_bytes(31)];
+        yield 'too long' => [random_bytes(40)];
+        yield 'an integer' => [42];
     }
 
     /**

--- a/tests/Key/OkpKeyTest.php
+++ b/tests/Key/OkpKeyTest.php
@@ -7,10 +7,14 @@ namespace Cose\Tests\Key;
 use function base64_decode;
 use Cose\Algorithm\Signature\EdDSA\Ed25519;
 use Cose\Key\OkpKey;
+use function hex2bin;
+use InvalidArgumentException;
 use function openssl_pkey_get_private;
 use function openssl_pkey_get_public;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use function random_bytes;
 
 final class OkpKeyTest extends TestCase
 {
@@ -22,7 +26,7 @@ final class OkpKeyTest extends TestCase
             OkpKey::TYPE => OkpKey::TYPE_OKP,
             OkpKey::ALG => Ed25519::ID,
             OkpKey::DATA_CURVE => 'Ed25519',
-            OkpKey::DATA_X => bin2hex('98C91448E657A3366C3C04551DAFD92A8BB2BA35138B4ACB94CA1E79D2627BAE'),
+            OkpKey::DATA_X => hex2bin('98C91448E657A3366C3C04551DAFD92A8BB2BA35138B4ACB94CA1E79D2627BAE'),
         ]);
 
         // Then
@@ -70,6 +74,59 @@ final class OkpKeyTest extends TestCase
         static::assertTrue($key->isPrivate());
         static::assertFalse($public->isPrivate());
         static::assertSame($key->x(), $public->x());
+    }
+
+    /**
+     * OkpKey used to accept an x of any length, which surfaced as an exception from inside Ed448::verify() rather
+     * than at the time the key was first seen.
+     *
+     * @see https://www.rfc-editor.org/rfc/rfc8032#section-5.2.5
+     */
+    #[Test]
+    #[DataProvider('getInvalidPublicKeyLengths')]
+    public function aPublicKeyOfTheWrongLengthIsRejected(int $curve, int $length): void
+    {
+        // Then
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid length for x coordinate');
+
+        // When
+        OkpKey::create([
+            OkpKey::TYPE => OkpKey::TYPE_OKP,
+            OkpKey::DATA_CURVE => $curve,
+            OkpKey::DATA_X => $length === 0 ? '' : random_bytes($length),
+        ]);
+    }
+
+    #[Test]
+    public function aPrivateKeyOfTheWrongLengthIsRejected(): void
+    {
+        // Then
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid length for d');
+
+        // When
+        OkpKey::create([
+            OkpKey::TYPE => OkpKey::TYPE_OKP,
+            OkpKey::DATA_CURVE => OkpKey::CURVE_ED25519,
+            OkpKey::DATA_X => random_bytes(32),
+            OkpKey::DATA_D => random_bytes(31),
+        ]);
+    }
+
+    /**
+     * @return iterable<string, array{int, int}>
+     */
+    public static function getInvalidPublicKeyLengths(): iterable
+    {
+        yield 'Ed25519, empty' => [OkpKey::CURVE_ED25519, 0];
+        yield 'Ed25519, too short' => [OkpKey::CURVE_ED25519, 31];
+        yield 'Ed25519, too long' => [OkpKey::CURVE_ED25519, 33];
+        yield 'Ed448, empty' => [OkpKey::CURVE_ED448, 0];
+        yield 'Ed448, too short' => [OkpKey::CURVE_ED448, 56];
+        yield 'Ed448, too long' => [OkpKey::CURVE_ED448, 58];
+        yield 'X25519, too short' => [OkpKey::CURVE_X25519, 10];
+        yield 'X448, too long' => [OkpKey::CURVE_X448, 57];
     }
 
     private static function ed25519Key(bool $private): OkpKey

--- a/tests/Key/RSAKeyTest.php
+++ b/tests/Key/RSAKeyTest.php
@@ -6,8 +6,11 @@ namespace Cose\Tests\Key;
 
 use Cose\Algorithm\Signature\RSA\RS256;
 use Cose\Key\RsaKey;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use function str_repeat;
 
 final class RSAKeyTest extends TestCase
 {
@@ -32,5 +35,60 @@ final class RSAKeyTest extends TestCase
 
         // Then
         static::assertSame($expected, $pem);
+    }
+
+    /**
+     * A structurally invalid modulus or exponent used to survive the constructor and surface much later as a
+     * Brick\Math exception or a TypeError, from inside verify().
+     */
+    #[Test]
+    #[DataProvider('getInvalidKeys')]
+    public function aStructurallyInvalidKeyIsRejected(mixed $modulus, mixed $exponent, string $expectedMessage): void
+    {
+        // Then
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage($expectedMessage);
+
+        // When
+        RsaKey::create([
+            RsaKey::TYPE => RsaKey::TYPE_RSA,
+            RsaKey::DATA_N => $modulus,
+            RsaKey::DATA_E => $exponent,
+        ]);
+    }
+
+    #[Test]
+    public function aNonStringPrivateParameterIsRejected(): void
+    {
+        // Then
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid RSA key. The private parameters shall be byte strings');
+
+        // When
+        RsaKey::create([
+            RsaKey::TYPE => RsaKey::TYPE_RSA,
+            RsaKey::DATA_N => str_repeat("\xff", 256),
+            RsaKey::DATA_E => "\x01\x00\x01",
+            RsaKey::DATA_D => 12345,
+        ]);
+    }
+
+    /**
+     * @return iterable<string, array{mixed, mixed, string}>
+     */
+    public static function getInvalidKeys(): iterable
+    {
+        $message = 'Invalid RSA key. The modulus and the exponent shall be non-empty byte strings';
+
+        yield 'an empty modulus' => ['', "\x01\x00\x01", $message];
+        yield 'an empty exponent' => [str_repeat("\xff", 256), '', $message];
+        yield 'an integer modulus' => [12345, "\x01\x00\x01", $message];
+        yield 'an integer exponent' => [str_repeat("\xff", 256), 65537, $message];
+        yield 'a zero modulus' => ["\x00", "\x01\x00\x01", 'Invalid RSA key. The modulus shall not be zero'];
+        yield 'an all-zero modulus' => [
+            str_repeat("\x00", 256),
+            "\x01\x00\x01",
+            'Invalid RSA key. The modulus shall not be zero',
+        ];
     }
 }

--- a/tests/Key/RsaKeyValidatorTest.php
+++ b/tests/Key/RsaKeyValidatorTest.php
@@ -130,7 +130,6 @@ final class RsaKeyValidatorTest extends TestCase
     {
         yield 'leading zero bytes are ignored' => ["\x00\x00\x80" . str_repeat("\x00", 255), 2048];
         yield 'the leading bits are counted' => ["\x01" . str_repeat("\x00", 255), 2041];
-        yield 'an empty modulus is zero bits' => ['', 0];
     }
 
     /**


### PR DESCRIPTION
Target branch: 4.7.x
Resolves issue #175

- [x] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

Rebased on top of #178 and #177, which landed while this was being written. The `ECSignature` and PSS internals work they cover has been dropped from here; what remains is the `verify()` contract itself.

`Signature::verify()` is declared `: bool` with no documented exception, but only `RSA::verify()` and `EdDSA::verify()` honoured that contract. Attacker-controlled input to a verifier turned into an uncaught, untyped exception instead of `false`. Every case is fail-closed — no forgery, no bypass, no key disclosure — but a WebAuthn RP saw the assertion escape `AuthenticatorAssertionResponseValidator::check()` as an `InvalidArgumentException`, a `RuntimeException` or an `ErrorException`, so the failure log entry and the `AuthenticatorAssertionResponseValidationFailedEvent` were skipped and a pure-PHP integration answered with an internal error.

## The contract

Stated on the interface, in the README and in `doc/Usage.md`:

> `verify()` returns `false` for every condition the governing specifications define as an "invalid signature" outcome: any problem with the signature bytes, and any key that the crypto layer cannot decode or use. It throws `InvalidArgumentException` **only** when the key is not usable with this algorithm at all — wrong key type, wrong curve — and the structural checks on key components live in the `Key` constructors, so such a key is refused when it is first seen (registration) rather than at every verification.

The `kty`/`crv` mismatch stays an exception: RFC 9053, section 7.1 is a MUST to *reject* an inconsistent key, and rejecting it at construction is more useful to a relying party than a silent `false` at login. `FullySpecifiedEdDsaTest` already asserted that behaviour and is unchanged.

## One disagreement with #177

#177 kept `ECDSA::verify()` throwing for a wrong-length signature, with the comment *"a signature of the wrong size is a caller error, not attacker input"*. That does not hold for the primary consumer: `CheckSignature::process()` calls `CoseSignatureFixer::fix()` and then `$algorithm->verify(...)` with no `try/catch`, so the length of an ES256 assertion signature is chosen by whoever sends the assertion. This PR returns `false` there.

`ECSignature::toAsn1()` is unchanged and keeps throwing — it is reached from `sign()` and from callers that already know the shape of what they pass. `ECSignatureTest::aSignatureOfTheWrongLengthIsRejected` covered both facts in one test; it is split into `encodingASignatureOfTheWrongLengthIsRejected` (the exception, on the encoder) and `verifyingASignatureOfTheWrongLengthReturnsFalse`.

## Verification

| | before | after |
|---|---|---|
| PS256/384/512, signature not k octets | `InvalidArgumentException('Invalid signature length')` | `false` — RFC 8017 §8.1.2 step 1 |
| PS*, representative >= n | `RuntimeException('Signature representative out of range')` | `false` — §8.1.2 step 2.b |
| PS*, recovered integer larger than emLen | `RuntimeException('Unable to convert the integer')` | `false` — §8.1.2 step 2.c |
| PS*, the five EMSA-PSS-VERIFY checks | `InvalidArgumentException` | `false` — §9.1.2 "inconsistent" |
| ES*, signature of the wrong length | `InvalidArgumentException('Invalid signature length.')` | `false` |
| ES*, point not on the curve, or mislabelled | `E_WARNING` from `openssl_verify()`, i.e. `ErrorException` under Symfony's handler | `false`, no PHP error |
| Ed448, undecodable public key | `InvalidArgumentException` | `false` — RFC 8032 §5.2.7 |
| RS*, undecodable key material | `E_WARNING` | `false` |

The step 2.c case is not in the issue: with `emLen = ceil((modBits - 1) / 8)`, I2OSP can output "integer too large" whenever `modBits ≡ 1 (mod 8)` — the 2041-bit fixture of `RsaKeyValidatorTest` is such a modulus. RFC 8017 §8.1.2 makes it an invalid signature; it raised `RuntimeException('Unable to convert the integer')`.

`exponentiate()` keeps refusing an out-of-range representative: it is public and has no "invalid signature" outcome to fall back on.

## Key structure

Rejected at construction, with the exception type the constructors already use:

- `RsaKey`: a non-empty, non-zero byte string modulus, a non-empty byte string exponent, byte string private parameters. An empty, zero or `int` modulus used to surface as a `Brick\Math` exception or a `TypeError` from inside `verify()`.
- `OkpKey`: `x` — and `d`, when present — of the length the curve fixes: 32 for Ed25519 and X25519, 57 for Ed448 (RFC 8032 §5.2.5), 56 for X448 (RFC 7748 §5). Nothing checked it, so a wrong-length `x` reached `Ed448::verify()`.
- `Ec2Key`: `d` of the curve length (RFC 5915 §3). Only `x` and `y` were checked, so a degenerate `d` produced signatures the key's own public point rejected, with nothing failing at signing time. The curve is now validated before the coordinate length table is indexed, which raised an undefined array key warning for an unsupported curve.

## Signing

`ECDSA::sign()` and `RSA::sign()` ignored the boolean returned by `openssl_sign()`. `RS512::sign()` with a 512-bit modulus left `$signature` null and raised `TypeError: Return value must be of type string, null returned`; `ECDSA::sign()` accepted a public key. Both now reject a public key, load the private key before use, and report a failure as `InvalidArgumentException('Unable to sign the data: …')` — the message read off the OpenSSL error queue by the new `@internal OpenSslError` helper, which drains the queue first so the message describes this call only. `RSA::sign()`'s `try/catch (Throwable)` was dead code and is gone: `openssl_sign()` does not throw.

## Tests

`VerificationContractTest` runs every `Signature` implementation — RS1/RS256/RS384/RS512, PS256/384/512, ES256/ES256K/ES384/ES512, ESP256/384/512, ESB256/320/384/512, EdDSA, Ed25519 (both identifiers) and Ed448 — through the same battery: a valid signature over another message, an empty, truncated, over-long, all-zero, all-`0xFF` and bit-flipped signature, and 25 random in-range signatures each. It installs an error handler that turns any notice, warning or deprecation into an exception, so a stray `E_WARNING` fails the test. Against the source before this PR, 17 of its 44 data sets error out.

The targeted cases live next to the code they cover: the 17-leading-zero-byte signature, the off-curve point and the mislabelled point in `ECDSATest`; the non-decodable 57-byte public key in `FullySpecifiedEdDsaTest`; the wrong-length `x`/`d` in `OkpKeyTest`, the wrong-length `d` and the unsupported curve in `EC2KeyTest`, the invalid modulus and exponent in `RSAKeyTest`; the short-modulus and public-key signing failures in `RSATest`.

`PSSRSATest::aSignatureRepresentativeOutOfRangeIsRejected` and `aSignatureOfTheWrongLengthIsRejected`, from #178, now assert `false`, and a new case covers the exception that `exponentiate()` still raises. Three fixtures passed an empty `x` to `OkpKey` purely as a wrong-key-type placeholder and now pass 32 bytes; `OkpKeyTest::theKeyIsCorrectlyEncoded` used `bin2hex()` where it meant `hex2bin()`; `RsaKeyValidatorTest` loses the `'an empty modulus is zero bits'` data set, which the constructor no longer allows to be built.

373 tests pass on PHP 8.2, 8.3, 8.4 and 8.5, and with `--prefer-lowest`. PHPStan, ECS, Rector and Deptrac are clean; one baseline entry is dropped because `Ec2Key` now validates the curve before indexing the length table.

## Not in scope

The companion change in webauthn-lib — wrapping `CheckSignature::process()` in a `try/catch (InvalidArgumentException)` and rejecting a `kty`/`crv`-vs-`alg` mismatch in `CheckAlgorithm` at registration — is a separate PR, and also covers relying parties still on older cose-lib releases.
