### PR TITLE
fix(rsa): bound the cost of an RSA verification (GHSA-9v8c-2mgr-qvx3)

### DIFF
--- a/.ci-tools/phpstan-baseline.neon
+++ b/.ci-tools/phpstan-baseline.neon
@@ -199,12 +199,6 @@ parameters:
 			path: ../src/Key/RsaKey.php
 
 		-
-			rawMessage: 'Parameter #1 $array of function current expects array|object, array|false given.'
-			identifier: argument.type
-			count: 1
-			path: ../src/Key/RsaKey.php
-
-		-
 			rawMessage: Cannot cast mixed to int.
 			identifier: cast.int
 			count: 1

--- a/README.md
+++ b/README.md
@@ -267,10 +267,11 @@ The validator also enforces the public exponent constraints of
 
 ## Performance
 
-Install **ext-gmp** (recommended) or **ext-bcmath**. Without either of them `brick/math` falls back to a pure PHP
-calculator, and the RSASSA-PSS algorithms (`PS256`, `PS384`, `PS512`) then compute their modular exponentiation in
-PHP: seconds of CPU per operation, even for a 2048 bit key. The `RS*` algorithms and `RsaKey::asPem()` do not depend
-on it. The stock `php` and `php-fpm` Docker images ship with neither extension.
+**ext-gmp** (recommended) or **ext-bcmath** is worth installing, but no longer required for RSA verification to be
+cheap: `RsaKey::asPem()`, `RsaKeyValidator` and the public operation of every RSA algorithm are computed without
+`brick/math`. Signing with RSASSA-PSS (`PS256`, `PS384`, `PS512`) still uses it for the blinding of the private
+exponentiation, and falls back to a pure PHP calculator when neither extension is loaded — which is the configuration
+of the stock `php` and `php-fpm` Docker images.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -236,8 +236,12 @@ signature operation itself fails, for instance for an RSA modulus too short for 
 
 [RFC 8812](https://datatracker.ietf.org/doc/html/rfc8812) defers to
 [RFC 8230, section 6.1](https://www.rfc-editor.org/rfc/rfc8230#section-6.1), which requires a modulus of 2048 bits or
-larger and expects implementations to handle up to 16K bits. The library never applies those bounds on its own; run
-them explicitly on a key before handing it to an algorithm:
+larger and expects implementations to handle up to 16K bits.
+
+The upper bounds are applied automatically: every RSA algorithm rejects a key whose modulus is longer than 16384 bits
+or whose public exponent is longer than 256 bits, before it computes anything with it. `verify()` returns `false` for
+such a key and `sign()` throws. The **minimum** modulus length is a policy decision and stays opt-in; run it
+explicitly on a key before handing it to an algorithm:
 
 ```php
 use Cose\Key\RsaKey;
@@ -260,6 +264,13 @@ RsaKeyValidator::create(minimumModulusLength: 3072, maximumModulusLength: 8192)-
 The validator also enforces the public exponent constraints of
 [RFC 8017, section 3.1](https://datatracker.ietf.org/doc/html/rfc8017#section-3.1): an odd integer between 3 and
 `n - 1`.
+
+## Performance
+
+Install **ext-gmp** (recommended) or **ext-bcmath**. Without either of them `brick/math` falls back to a pure PHP
+calculator, and the RSASSA-PSS algorithms (`PS256`, `PS384`, `PS512`) then compute their modular exponentiation in
+PHP: seconds of CPU per operation, even for a 2048 bit key. The `RS*` algorithms and `RsaKey::asPem()` do not depend
+on it. The stock `php` and `php-fpm` Docker images ship with neither extension.
 
 ## Testing
 

--- a/composer.json
+++ b/composer.json
@@ -32,8 +32,8 @@
         "symfony/polyfill-php81": "*"
     },
     "suggest": {
-        "ext-bcmath": "For better performance, please install either GMP (recommended) or BCMath extension",
-        "ext-gmp": "For better performance, please install either GMP (recommended) or BCMath extension",
+        "ext-bcmath": "Strongly recommended: without GMP or BCMath, the RSASSA-PSS algorithms (PS256/PS384/PS512) exponentiate in pure PHP and cost seconds of CPU per operation",
+        "ext-gmp": "Strongly recommended: without GMP or BCMath, the RSASSA-PSS algorithms (PS256/PS384/PS512) exponentiate in pure PHP and cost seconds of CPU per operation",
         "spomky-labs/cbor-php": "For COSE Signature support"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -32,8 +32,8 @@
         "symfony/polyfill-php81": "*"
     },
     "suggest": {
-        "ext-bcmath": "Strongly recommended: without GMP or BCMath, the RSASSA-PSS algorithms (PS256/PS384/PS512) exponentiate in pure PHP and cost seconds of CPU per operation",
-        "ext-gmp": "Strongly recommended: without GMP or BCMath, the RSASSA-PSS algorithms (PS256/PS384/PS512) exponentiate in pure PHP and cost seconds of CPU per operation",
+        "ext-bcmath": "Recommended: without GMP or BCMath, signing with RSASSA-PSS (PS256/PS384/PS512) blinds its private exponentiation in pure PHP",
+        "ext-gmp": "Recommended: without GMP or BCMath, signing with RSASSA-PSS (PS256/PS384/PS512) blinds its private exponentiation in pure PHP",
         "spomky-labs/cbor-php": "For COSE Signature support"
     },
     "autoload": {

--- a/doc/Usage.md
+++ b/doc/Usage.md
@@ -375,8 +375,16 @@ signature operation itself fails, for instance for an RSA modulus too short for 
 
 [RFC 8812](https://datatracker.ietf.org/doc/html/rfc8812) defers to
 [RFC 8230, section 6.1](https://www.rfc-editor.org/rfc/rfc8230#section-6.1), which requires a modulus of 2048 bits or
-larger and expects implementations to handle up to 16K bits. Nothing applies those bounds automatically, so run them
-explicitly before handing a key to an algorithm:
+larger and expects implementations to handle up to 16K bits.
+
+The upper bounds are applied automatically: every RSA algorithm rejects a key whose modulus is longer than
+`RsaKeyValidator::MAXIMUM_MODULUS_LENGTH` (16384) bits or whose public exponent is longer than
+`RsaKeyValidator::MAXIMUM_EXPONENT_LENGTH` (256) bits, before it computes anything with it. `verify()` returns `false`
+for such a key and `sign()` throws an `InvalidArgumentException`. The cost of an RSA operation grows with the size of
+the key it is given, and a verifier takes that key from whoever produced the message.
+
+The **minimum** modulus length is a policy decision and stays opt-in, so run it explicitly before handing a key to an
+algorithm:
 
 ```php
 use Cose\Key\RsaKey;
@@ -393,13 +401,19 @@ $isAcceptable = RsaKeyValidator::create()->isValid($key);
 // The bounds can be tightened
 RsaKeyValidator::create(minimumModulusLength: 3072, maximumModulusLength: 8192)->check($key);
 
-// The modulus length, in bits, is available on its own
-$length = RsaKeyValidator::modulusLength($key);
+// The modulus and exponent lengths, in bits, are available on their own
+$modulusLength = RsaKeyValidator::modulusLength($key);
+$exponentLength = RsaKeyValidator::exponentLength($key);
+
+// The bounds the algorithms apply on their own, should you want to run them earlier
+RsaKeyValidator::checkLengthBounds($key);
 ```
 
 The validator also enforces the public exponent constraints of
 [RFC 8017, section 3.1](https://datatracker.ietf.org/doc/html/rfc8017#section-3.1): an odd integer between 3 and
 `n - 1`.
+
+Every check is performed on the octet strings of the key, so rejecting an oversized key costs no more than reading it.
 
 ### MAC Algorithms
 

--- a/src/Algorithm/Signature/RSA/PSSRSA.php
+++ b/src/Algorithm/Signature/RSA/PSSRSA.php
@@ -32,7 +32,13 @@ use Throwable;
 /**
  * RSASSA-PSS as defined by RFC 8017, section 8.1.
  *
+ * The length of the key is bounded before it is used. RFC 8017, section 3.1 places no upper bound on the modulus nor
+ * on the public exponent, and the primitives of section 5.2 are modular exponentiations whose cost is proportional to
+ * the size of both - which a verifier takes from whoever produced the message. RFC 8230, section 6.1 asks for the
+ * bound: "It is highly recommended that checks on the key length be done before starting a cryptographic operation."
+ *
  * @see https://www.rfc-editor.org/rfc/rfc8017#section-8.1
+ * @see https://www.rfc-editor.org/rfc/rfc8230#section-6.1
  *
  * @internal
  */
@@ -41,6 +47,7 @@ abstract class PSSRSA implements Signature
     public function sign(string $data, Key $key): string
     {
         $key = $this->handleKey($key);
+        RsaKeyValidator::checkLengthBounds($key);
         if (! $key->isPrivate()) {
             throw new InvalidArgumentException('The key is not private.');
         }
@@ -61,6 +68,13 @@ abstract class PSSRSA implements Signature
         // RFC 8017, section 8.1.2: the verification operation uses the public key (n, e) only.
         $key = $this->handleKey($key)
             ->toPublic();
+        try {
+            RsaKeyValidator::checkLengthBounds($key);
+        } catch (InvalidArgumentException) {
+            // A key too large to compute with is key material no verification can be performed against: the contract
+            // of Signature::verify() reports it as an invalid signature rather than as an error.
+            return false;
+        }
         $modBits = RsaKeyValidator::modulusLength($key);
         $k = intdiv($modBits + 7, 8);
         // RFC 8017, section 8.1.2, step 1: "If the length of the signature S is not k octets, output 'invalid
@@ -93,6 +107,8 @@ abstract class PSSRSA implements Signature
      */
     public function exponentiate(RsaKey $key, BigInteger $c): BigInteger
     {
+        RsaKeyValidator::checkLengthBounds($key);
+
         return $key->isPrivate() ? $this->rsasp1($key, $c) : $this->rsavp1($key, $c);
     }
 

--- a/src/Algorithm/Signature/RSA/PSSRSA.php
+++ b/src/Algorithm/Signature/RSA/PSSRSA.php
@@ -16,9 +16,12 @@ use function hash_equals;
 use function intdiv;
 use InvalidArgumentException;
 use function is_string;
+use function ltrim;
 use function openssl_error_string;
 use const OPENSSL_NO_PADDING;
+use function openssl_pkey_get_public;
 use function openssl_private_encrypt;
+use function openssl_public_decrypt;
 use function ord;
 use function pack;
 use function random_bytes;
@@ -26,7 +29,9 @@ use RuntimeException;
 use function str_pad;
 use const STR_PAD_LEFT;
 use function str_repeat;
+use function strcmp;
 use function strlen;
+use function substr;
 use Throwable;
 
 /**
@@ -82,19 +87,24 @@ abstract class PSSRSA implements Signature
         if (strlen($signature) !== $k) {
             return false;
         }
-        $s = BigInteger::createFromBinaryString($signature);
         // Step 2.b: "If RSAVP1 output 'signature representative out of range', output 'invalid signature' and stop."
-        if ($s->compare(BigInteger::createFromBinaryString($key->n())) >= 0) {
+        if (self::compareMagnitudes($signature, $key->n()) >= 0) {
             return false;
         }
-        $m = $this->rsavp1($key, $s);
+        $em = $this->rsavp1WithOpenSSL($key, $signature);
+        if ($em === null) {
+            return false;
+        }
         // RFC 8017, section 8.1.2, step 2.c: emLen = ceil((modBits - 1) / 8). "If I2OSP outputs 'integer too large',
-        // output 'invalid signature' and stop."
+        // output 'invalid signature' and stop." OpenSSL returns k octets, one more than emLen when the modulus is
+        // byte aligned, and the octets it drops have to be zero for the integer to fit.
         $emLen = intdiv($modBits - 1 + 7, 8);
-        if (strlen($m->toBytes()) > $emLen) {
-            return false;
+        if ($emLen < $k) {
+            if (ltrim(substr($em, 0, $k - $emLen), "\0") !== '') {
+                return false;
+            }
+            $em = substr($em, $k - $emLen);
         }
-        $em = $this->convertIntegerToOctetString($m, $emLen);
 
         return $this->verifyEMSAPSS($data, $em, $modBits - 1, $this->getHashAlgorithm());
     }
@@ -121,6 +131,10 @@ abstract class PSSRSA implements Signature
 
     /**
      * RSAVP1 (RFC 8017, section 5.2.2).
+     *
+     * Only exponentiate() reaches this method: verify() applies the primitive to the octet strings themselves. The
+     * in-process exponentiation is kept here as a fallback so that a key OpenSSL declines still gets an answer, which
+     * is the behaviour this method has always had.
      */
     private function rsavp1(RsaKey $key, BigInteger $s): BigInteger
     {
@@ -128,8 +142,67 @@ abstract class PSSRSA implements Signature
         if ($s->compare(BigInteger::createFromDecimal(0)) < 0 || $s->compare($n) >= 0) {
             throw new RuntimeException('Signature representative out of range');
         }
+        $k = intdiv(RsaKeyValidator::modulusLength($key) + 7, 8);
+        $m = $this->rsavp1WithOpenSSL($key, $this->convertIntegerToOctetString($s, $k));
 
-        return $s->modPow(BigInteger::createFromBinaryString($key->e()), $n);
+        return $m === null
+            ? $s->modPow(BigInteger::createFromBinaryString($key->e()), $n)
+            : BigInteger::createFromBinaryString($m);
+    }
+
+    /**
+     * RSAVP1 computed by OpenSSL, on the octet strings themselves.
+     *
+     * The public operation is a modular exponentiation, and brick/math computes it in PHP whenever neither ext-gmp
+     * nor ext-bcmath is loaded - the configuration of the stock php and php-fpm images. That costs seconds of CPU per
+     * verification even for a 2048 bit key, and grows with the square of the modulus up to the largest one RFC 8230
+     * asks implementations to accept: a verifier takes its key from whoever produced the message, so the work it is
+     * asked to do must not depend on an extension being installed. ext-openssl is a hard requirement of this package,
+     * and RSASP1 already goes through it.
+     *
+     * Returns null when OpenSSL will not use the key, which for a verifier is an invalid signature: RFC 8017, section
+     * 8.1.2 is defined for a valid public key, and a key OpenSSL rejects is not one.
+     *
+     * @param string $s the signature representative, exactly k octets long and below the modulus
+     */
+    private function rsavp1WithOpenSSL(RsaKey $key, string $s): ?string
+    {
+        try {
+            // The key is loaded before use so that key material OpenSSL cannot decode yields null instead of an
+            // E_WARNING raised from inside openssl_public_decrypt().
+            $publicKey = openssl_pkey_get_public($key->toPublic()->asPem());
+            if ($publicKey === false) {
+                $this->clearOpenSSLErrors();
+
+                return null;
+            }
+            $computed = openssl_public_decrypt($s, $m, $publicKey, OPENSSL_NO_PADDING);
+        } catch (Throwable) {
+            $this->clearOpenSSLErrors();
+
+            return null;
+        }
+        if (! $computed || ! is_string($m)) {
+            $this->clearOpenSSLErrors();
+
+            return null;
+        }
+
+        return $m;
+    }
+
+    /**
+     * Compares two non-negative integers given as big-endian octet strings: the longer one, once the leading zero
+     * octets are gone, is the larger, and equal lengths are decided octet by octet. Comparing the values rather than
+     * the strings would mean converting them, which is the very base conversion this class avoids.
+     */
+    private static function compareMagnitudes(string $left, string $right): int
+    {
+        $left = ltrim($left, "\0");
+        $right = ltrim($right, "\0");
+        $byLength = strlen($left) <=> strlen($right);
+
+        return $byLength === 0 ? strcmp($left, $right) : $byLength;
     }
 
     /**

--- a/src/Algorithm/Signature/RSA/RSA.php
+++ b/src/Algorithm/Signature/RSA/RSA.php
@@ -8,6 +8,7 @@ use Cose\Algorithm\Signature\OpenSslError;
 use Cose\Algorithm\Signature\Signature;
 use Cose\Key\Key;
 use Cose\Key\RsaKey;
+use Cose\Key\RsaKeyValidator;
 use InvalidArgumentException;
 use function openssl_pkey_get_private;
 use function openssl_pkey_get_public;
@@ -15,6 +16,14 @@ use function openssl_sign;
 use function openssl_verify;
 
 /**
+ * RSASSA-PKCS1-v1_5 as defined by RFC 8017, section 8.2.
+ *
+ * The length of the key is bounded before it is used. RFC 8230, section 6.1 asks for it - "It is highly recommended
+ * that checks on the key length be done before starting a cryptographic operation" - because the work an RSA
+ * operation costs grows with the size of the key it is given, and a verifier takes that key from whoever produced the
+ * message.
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc8017#section-8.2
  * @see \Cose\Tests\Algorithm\Signature\RSA\RSATest
  */
 abstract class RSA implements Signature
@@ -22,6 +31,7 @@ abstract class RSA implements Signature
     public function sign(string $data, Key $key): string
     {
         $key = $this->handleKey($key);
+        RsaKeyValidator::checkLengthBounds($key);
         if (! $key->isPrivate()) {
             throw new InvalidArgumentException('The key is not private.');
         }
@@ -42,6 +52,13 @@ abstract class RSA implements Signature
     public function verify(string $data, Key $key, string $signature): bool
     {
         $key = $this->handleKey($key);
+        try {
+            RsaKeyValidator::checkLengthBounds($key);
+        } catch (InvalidArgumentException) {
+            // A key too large to compute with is key material no verification can be performed against: the contract
+            // of Signature::verify() reports it as an invalid signature rather than as an error.
+            return false;
+        }
         // The key is loaded before use so that key material OpenSSL cannot decode yields false instead of an
         // E_WARNING raised from inside openssl_verify().
         $publicKey = openssl_pkey_get_public($key->toPublic()->asPem());

--- a/src/Key/RsaKey.php
+++ b/src/Key/RsaKey.php
@@ -5,14 +5,18 @@ declare(strict_types=1);
 namespace Cose\Key;
 
 use function array_key_exists;
-use Brick\Math\BigInteger;
+use function base64_encode;
+use function chunk_split;
+use function implode;
 use function in_array;
 use InvalidArgumentException;
 use function is_string;
 use function ltrim;
-use SpomkyLabs\Pki\CryptoTypes\Asymmetric\PublicKeyInfo;
-use SpomkyLabs\Pki\CryptoTypes\Asymmetric\RSA\RSAPrivateKey;
-use SpomkyLabs\Pki\CryptoTypes\Asymmetric\RSA\RSAPublicKey;
+use function ord;
+use function pack;
+use function sprintf;
+use function strlen;
+use function trim;
 
 /**
  * @final
@@ -43,6 +47,13 @@ class RsaKey extends Key
     final public const DATA_DI = -11;
 
     final public const DATA_TI = -12;
+
+    /**
+     * The DER of the rsaEncryption object identifier, 1.2.840.113549.1.1.1 (RFC 8017, appendix A.1).
+     */
+    private const OID_RSA_ENCRYPTION = "\x06\x09\x2a\x86\x48\x86\xf7\x0d\x01\x01\x01";
+
+    private const DER_NULL = "\x05\x00";
 
     /**
      * @var array<int>
@@ -227,37 +238,45 @@ class RsaKey extends Key
 
     /**
      * A key carrying "other prime infos" (RFC 8230, section 4) is exported as a version 0, two-prime RSAPrivateKey in
-     * which p*q is not the modulus: spomky-labs/pki-framework does not model OtherPrimeInfos yet. RS1, RS256, RS384
-     * and RS512 keep working with such a key only because OpenSSL checks its CRT result against s^e mod n and falls
-     * back to m^d mod n when the two disagree. RSASSA-PSS does not go through this method and handles the additional
-     * primes itself.
+     * which p*q is not the modulus: the PKCS #1 OtherPrimeInfos sequence is not emitted. RS1, RS256, RS384 and RS512
+     * keep working with such a key only because OpenSSL checks its CRT result against s^e mod n and falls back to
+     * m^d mod n when the two disagree. RSASSA-PSS does not go through this method and handles the additional primes
+     * itself.
+     *
+     * The DER is built from the octet strings of the key as they are, without ever turning them into numbers. X.690,
+     * section 8.3 defines the content octets of an ASN.1 INTEGER as the two's complement big-endian representation of
+     * its value, which for a non-negative integer is its raw big-endian magnitude with a leading 0x00 whenever the
+     * first bit is set - and RFC 8230, section 4 already stores every parameter of a COSE RSA key in exactly that
+     * form. Routing them through a big integer library instead would convert each of them to a decimal string and
+     * back: brick/math falls back to a pure PHP calculator whenever neither ext-gmp nor ext-bcmath is loaded, and its
+     * generic base conversion is superlinear, so that round trip alone costs seconds of CPU on a large modulus - paid
+     * on every verification, before OpenSSL sees anything.
      */
     public function asPem(): string
     {
         if ($this->isPrivate()) {
-            $privateKey = RSAPrivateKey::create(
-                $this->binaryToBigInteger($this->n()),
-                $this->binaryToBigInteger($this->e()),
-                $this->binaryToBigInteger($this->d()),
-                $this->binaryToBigInteger($this->p()),
-                $this->binaryToBigInteger($this->q()),
-                $this->binaryToBigInteger($this->dP()),
-                $this->binaryToBigInteger($this->dQ()),
-                $this->binaryToBigInteger($this->QInv())
-            );
-
-            return $privateKey->toPEM()
-                ->string();
+            return self::toPem('RSA PRIVATE KEY', self::derSequence(
+                // RFC 8017, appendix A.1.2: version is 0 for a two-prime key.
+                self::derInteger("\0"),
+                self::derInteger($this->n()),
+                self::derInteger($this->e()),
+                self::derInteger($this->d()),
+                self::derInteger($this->p()),
+                self::derInteger($this->q()),
+                self::derInteger($this->dP()),
+                self::derInteger($this->dQ()),
+                self::derInteger($this->QInv())
+            ));
         }
 
-        $publicKey = RSAPublicKey::create(
-            $this->binaryToBigInteger($this->n()),
-            $this->binaryToBigInteger($this->e())
-        );
-        $rsaKey = PublicKeyInfo::fromPublicKey($publicKey);
+        // RFC 5280, section 4.1: SubjectPublicKeyInfo wraps the DER of an RFC 8017 RSAPublicKey in a BIT STRING,
+        // behind the rsaEncryption algorithm identifier and its mandatory NULL parameters (RFC 3279, section 2.3.1).
+        $rsaPublicKey = self::derSequence(self::derInteger($this->n()), self::derInteger($this->e()));
 
-        return $rsaKey->toPEM()
-            ->string();
+        return self::toPem('PUBLIC KEY', self::derSequence(
+            self::derSequence(self::OID_RSA_ENCRYPTION, self::DER_NULL),
+            self::derBitString($rsaPublicKey)
+        ));
     }
 
     public function toPublic(): static
@@ -291,12 +310,57 @@ class RsaKey extends Key
         }
     }
 
-    private function binaryToBigInteger(string $data): string
+    /**
+     * An ASN.1 INTEGER holding the non-negative integer whose big-endian magnitude is $value (X.690, section 8.3).
+     */
+    private static function derInteger(string $value): string
     {
-        $res = unpack('H*', $data);
-        /** @var non-empty-string $res */
-        $res = current($res);
+        $value = ltrim($value, "\0");
+        if ($value === '') {
+            // Section 8.3.1: the content octets are never empty, so zero is a single 0x00 octet.
+            $value = "\0";
+        } elseif ((ord($value[0]) & 0x80) !== 0) {
+            // Section 8.3.2: without this octet the value would be read as a negative number.
+            $value = "\0" . $value;
+        }
 
-        return BigInteger::fromBase($res, 16)->toBase(10);
+        return self::der(0x02, $value);
+    }
+
+    private static function derSequence(string ...$elements): string
+    {
+        return self::der(0x30, implode('', $elements));
+    }
+
+    private static function derBitString(string $value): string
+    {
+        // X.690, section 8.6.2.2: the leading octet is the number of unused bits of the final octet, none here since
+        // the value being wrapped is a whole number of octets.
+        return self::der(0x03, "\0" . $value);
+    }
+
+    private static function der(int $tag, string $content): string
+    {
+        $length = strlen($content);
+        if ($length < 0x80) {
+            // X.690, section 8.1.3.4: short form.
+            $encodedLength = pack('C', $length);
+        } else {
+            // Section 8.1.3.5: long form, the length itself in the fewest octets that can hold it.
+            $octets = ltrim(pack('J', $length), "\0");
+            $encodedLength = pack('C', 0x80 | strlen($octets)) . $octets;
+        }
+
+        return pack('C', $tag) . $encodedLength . $content;
+    }
+
+    private static function toPem(string $type, string $der): string
+    {
+        return sprintf(
+            "-----BEGIN %s-----\n%s\n-----END %s-----",
+            $type,
+            trim(chunk_split(base64_encode($der), 64, "\n")),
+            $type
+        );
     }
 }

--- a/src/Key/RsaKeyValidator.php
+++ b/src/Key/RsaKeyValidator.php
@@ -4,12 +4,11 @@ declare(strict_types=1);
 
 namespace Cose\Key;
 
-use function bin2hex;
-use Brick\Math\BigInteger;
 use InvalidArgumentException;
 use function ltrim;
 use function ord;
 use function sprintf;
+use function strcmp;
 use function strlen;
 use Throwable;
 
@@ -21,8 +20,10 @@ use Throwable;
  * and decrypt with modulus between 2048 and 16K bits in length". The public exponent constraints come from RFC 8017,
  * section 3.1, which defines it as an odd integer between 3 and n - 1.
  *
- * Nothing in this library applies these checks on its own: run them explicitly on a key before handing it to an
- * algorithm.
+ * The minimum modulus length is a policy decision and stays opt-in: run check() or isValid() explicitly on a key
+ * before handing it to an algorithm to apply it. The upper bounds are not a policy: the cost of an RSA operation
+ * grows with the size of the key it is given, and both are attacker supplied whenever the key comes from the wire.
+ * checkLengthBounds() applies them, and every RSA algorithm of this library calls it on its own.
  *
  * @see https://datatracker.ietf.org/doc/html/rfc8812
  * @see https://www.rfc-editor.org/rfc/rfc8230#section-6.1
@@ -39,6 +40,17 @@ final class RsaKeyValidator
      * The largest modulus length RFC 8230 expects implementations to cope with, in bits.
      */
     public const MAXIMUM_MODULUS_LENGTH = 16384;
+
+    /**
+     * The largest public exponent length any RSA operation of this library accepts, in bits.
+     *
+     * FIPS 186-5, appendix A.1.1 requires 2^16 < e < 2^256 of a generated key; RFC 8017, section 3.1 places no upper
+     * bound at all, which is precisely why one has to be imposed here. The public operation is a modular
+     * exponentiation whose cost is proportional to the length of the exponent, so an unbounded e is an unbounded
+     * amount of work: at the largest modulus RFC 8230 asks for, e = n - 2 costs sixty four times as much as this
+     * bound allows.
+     */
+    public const MAXIMUM_EXPONENT_LENGTH = 256;
 
     private function __construct(
         private readonly int $minimumModulusLength,
@@ -66,17 +78,33 @@ final class RsaKeyValidator
      */
     public static function modulusLength(RsaKey $key): int
     {
-        $modulus = ltrim($key->n(), "\x00");
-        if ($modulus === '') {
-            return 0;
-        }
+        return self::bitLength($key->n());
+    }
 
-        $length = (strlen($modulus) - 1) * 8;
-        for ($mostSignificantByte = ord($modulus[0]); $mostSignificantByte > 0; $mostSignificantByte >>= 1) {
-            ++$length;
-        }
+    /**
+     * Returns the length of the public exponent of the key, in bits.
+     */
+    public static function exponentLength(RsaKey $key): int
+    {
+        return self::bitLength($key->e());
+    }
 
-        return $length;
+    /**
+     * The upper bounds on the size of a key that every RSA algorithm of this library applies before it does anything
+     * with it. They are not a policy the caller opts into: an RSA operation costs an amount of CPU proportional to
+     * the size of the modulus and of the exponent it is given, both of which are attacker supplied whenever the key
+     * travels on the wire, and that cost is paid before anything is known about the signature. RFC 8230, section 6.1
+     * asks for exactly this: "It is highly recommended that checks on the key length be done before starting a
+     * cryptographic operation."
+     *
+     * No minimum is applied here, so that this method never rejects a key an earlier release accepted.
+     *
+     * @throws InvalidArgumentException when the key is larger than this library is willing to compute with
+     */
+    public static function checkLengthBounds(RsaKey $key): void
+    {
+        self::checkMaximumModulusLength($key, self::MAXIMUM_MODULUS_LENGTH);
+        self::checkMaximumExponentLength($key);
     }
 
     /**
@@ -92,15 +120,9 @@ final class RsaKeyValidator
                 $this->minimumModulusLength
             ));
         }
-        if ($modulusLength > $this->maximumModulusLength) {
-            throw new InvalidArgumentException(sprintf(
-                'The modulus of the key is %d bits long; at most %d bits are allowed',
-                $modulusLength,
-                $this->maximumModulusLength
-            ));
-        }
+        self::checkMaximumModulusLength($key, $this->maximumModulusLength);
 
-        $this->checkExponent($key);
+        self::checkExponent($key);
     }
 
     public function isValid(RsaKey $key): bool
@@ -114,29 +136,77 @@ final class RsaKeyValidator
         return true;
     }
 
-    private function checkExponent(RsaKey $key): void
+    /**
+     * The comparisons below are made on the octet strings themselves rather than on big integers: converting a
+     * parameter to a number is a base conversion, and brick/math falls back to a pure PHP calculator - whose generic
+     * base conversion is superlinear - whenever neither ext-gmp nor ext-bcmath is loaded. A validator meant to make
+     * an oversized key cheap to reject must not itself grow expensive with the size of the key it is handed.
+     */
+    private static function checkExponent(RsaKey $key): void
     {
-        $rawExponent = ltrim($key->e(), "\x00");
-        if ($rawExponent === '' || (ord($rawExponent[strlen($rawExponent) - 1]) & 1) !== 1) {
+        $exponent = ltrim($key->e(), "\x00");
+        if ($exponent === '' || (ord($exponent[strlen($exponent) - 1]) & 1) !== 1) {
             throw new InvalidArgumentException('The public exponent of the key shall be odd');
         }
-
-        $exponent = $this->toBigInteger($key->e());
-        if ($exponent->compareTo(BigInteger::of(3)) < 0) {
+        if (strlen($exponent) === 1 && ord($exponent[0]) < 3) {
             throw new InvalidArgumentException('The public exponent of the key shall be greater than or equal to 3');
         }
-        if ($exponent->compareTo($this->toBigInteger($key->n())) >= 0) {
+        if (self::compareMagnitudes($exponent, ltrim($key->n(), "\x00")) >= 0) {
             throw new InvalidArgumentException('The public exponent of the key shall be lower than its modulus');
+        }
+        self::checkMaximumExponentLength($key);
+    }
+
+    private static function checkMaximumModulusLength(RsaKey $key, int $maximumModulusLength): void
+    {
+        $modulusLength = self::modulusLength($key);
+        if ($modulusLength > $maximumModulusLength) {
+            throw new InvalidArgumentException(sprintf(
+                'The modulus of the key is %d bits long; at most %d bits are allowed',
+                $modulusLength,
+                $maximumModulusLength
+            ));
         }
     }
 
-    private function toBigInteger(string $value): BigInteger
+    private static function checkMaximumExponentLength(RsaKey $key): void
+    {
+        $exponentLength = self::exponentLength($key);
+        if ($exponentLength > self::MAXIMUM_EXPONENT_LENGTH) {
+            throw new InvalidArgumentException(sprintf(
+                'The public exponent of the key is %d bits long; at most %d bits are allowed',
+                $exponentLength,
+                self::MAXIMUM_EXPONENT_LENGTH
+            ));
+        }
+    }
+
+    /**
+     * Compares two non-negative integers given as big-endian octet strings stripped of their leading zero octets: the
+     * longer one is the larger, and equal lengths are decided octet by octet.
+     */
+    private static function compareMagnitudes(string $left, string $right): int
+    {
+        $byLength = strlen($left) <=> strlen($right);
+
+        return $byLength === 0 ? strcmp($left, $right) : $byLength;
+    }
+
+    /**
+     * The length in bits of the non-negative integer whose big-endian octet string is $value.
+     */
+    private static function bitLength(string $value): int
     {
         $value = ltrim($value, "\x00");
         if ($value === '') {
-            return BigInteger::zero();
+            return 0;
         }
 
-        return BigInteger::fromBase(bin2hex($value), 16);
+        $length = (strlen($value) - 1) * 8;
+        for ($mostSignificantByte = ord($value[0]); $mostSignificantByte > 0; $mostSignificantByte >>= 1) {
+            ++$length;
+        }
+
+        return $length;
     }
 }

--- a/tests/Algorithm/Signature/RSA/OversizedRsaKeyTest.php
+++ b/tests/Algorithm/Signature/RSA/OversizedRsaKeyTest.php
@@ -174,13 +174,18 @@ final class OversizedRsaKeyTest extends TestCase
     }
 
     /**
-     * The exponentiation of the largest acceptable key stays bounded because the exponent is: e = n - 2 used to cost
-     * sixty four times what the bound allows.
+     * The public operation of RSASSA-PSS is applied by OpenSSL, so its cost does not depend on ext-gmp or ext-bcmath
+     * being installed. Left to brick/math and its pure PHP calculator it cost seconds of CPU for a 2048 bit key and
+     * minutes at the largest modulus RFC 8230 asks implementations to accept, which no bound on the key can fix.
+     *
+     * The exponent is the longest the bounds allow, and the signature representative is full width, so nothing about
+     * this key makes the exponentiation cheaper than the worst case.
      */
     #[Test]
-    public function theExponentiationOfTheLargestAcceptableKeyIsBounded(): void
+    public function thePublicOperationDoesNotDependOnABigIntegerExtension(): void
     {
         // Given
+        $restore = self::forceTheNativeCalculator();
         $key = self::key(
             "\xff" . str_repeat("\xaa", self::MAXIMUM_MODULUS_OCTETS - 2) . "\xff",
             str_repeat("\xff", intdiv(RsaKeyValidator::MAXIMUM_EXPONENT_LENGTH, 8))
@@ -189,13 +194,60 @@ final class OversizedRsaKeyTest extends TestCase
 
         // When
         $startedAt = microtime(true);
-        $isVerified = PS256::create()
-            ->verify(self::MESSAGE, $key, $signature);
+
+        try {
+            $isVerified = PS256::create()
+                ->verify(self::MESSAGE, $key, $signature);
+        } finally {
+            $restore();
+        }
         $elapsed = microtime(true) - $startedAt;
 
         // Then
         static::assertFalse($isVerified);
-        static::assertLessThan(5.0, $elapsed, 'The public exponent bounds the cost of the public operation');
+        static::assertLessThan(5.0, $elapsed, 'RSAVP1 must not be computed in PHP');
+    }
+
+    /**
+     * Cost is only half of it: the octets OpenSSL returns have to be the ones the in-process exponentiation returned.
+     * The 2050 bit key is the interesting one, its emLen being one octet shorter than the modulus.
+     *
+     * @param callable(): RsaKey $keyFactory
+     */
+    #[Test]
+    #[DataProvider('getRoundTripKeys')]
+    public function aSignatureStillRoundTripsWithoutABigIntegerExtension(callable $keyFactory): void
+    {
+        // Given
+        $key = $keyFactory();
+        $algorithm = PS256::create();
+        $signature = $algorithm->sign(self::MESSAGE, $key);
+        $restore = self::forceTheNativeCalculator();
+
+        // When
+        try {
+            $isVerified = $algorithm->verify(self::MESSAGE, $key->toPublic(), $signature);
+            $isRejected = $algorithm->verify('Live long and prosper.', $key->toPublic(), $signature);
+        } finally {
+            $restore();
+        }
+
+        // Then
+        static::assertTrue($isVerified);
+        static::assertFalse($isRejected);
+    }
+
+    /**
+     * @return iterable<string, array{callable(): RsaKey}>
+     */
+    public static function getRoundTripKeys(): iterable
+    {
+        yield 'a 2048 bit modulus' => [
+            static fn (): RsaKey => RsaKeys::privateKey(),
+        ];
+        yield 'a 2050 bit modulus' => [
+            static fn (): RsaKey => RsaKeys::nonByteAlignedPrivateKey(),
+        ];
     }
 
     private static function key(string $modulus, string $exponent): RsaKey

--- a/tests/Algorithm/Signature/RSA/OversizedRsaKeyTest.php
+++ b/tests/Algorithm/Signature/RSA/OversizedRsaKeyTest.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cose\Tests\Algorithm\Signature\RSA;
+
+use Brick\Math\Internal\Calculator;
+use Brick\Math\Internal\Calculator\NativeCalculator;
+use Brick\Math\Internal\CalculatorRegistry;
+use function class_exists;
+use Cose\Algorithm\Signature\RSA\PS256;
+use Cose\Algorithm\Signature\RSA\PS512;
+use Cose\Algorithm\Signature\RSA\RS1;
+use Cose\Algorithm\Signature\RSA\RS256;
+use Cose\Algorithm\Signature\RSA\RS512;
+use Cose\Algorithm\Signature\Signature;
+use Cose\Key\RsaKey;
+use Cose\Key\RsaKeyValidator;
+use ErrorException;
+use function intdiv;
+use InvalidArgumentException;
+use function method_exists;
+use function microtime;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use function restore_error_handler;
+use function set_error_handler;
+use function str_repeat;
+use function substr;
+
+/**
+ * The work an RSA operation costs grows with the size of the key it is given, and a verifier takes that key from
+ * whoever produced the message. Both the modulus and the public exponent are therefore bounded before anything is
+ * computed with them, and the export of a key to PEM - which every RS* verification goes through - is linear in the
+ * size of the key rather than superlinear.
+ *
+ * @see https://github.com/web-auth/cose-lib/security/advisories/GHSA-9v8c-2mgr-qvx3
+ * @see https://www.rfc-editor.org/rfc/rfc8230#section-6.1
+ */
+final class OversizedRsaKeyTest extends TestCase
+{
+    private const MESSAGE = 'Live long and Prosper.';
+
+    /**
+     * The largest modulus of RFC 8230, section 6.1, in octets.
+     */
+    private const MAXIMUM_MODULUS_OCTETS = 2048;
+
+    /**
+     * Any PHP notice, warning or deprecation raised while a test of this class runs becomes a failure.
+     */
+    protected function setUp(): void
+    {
+        set_error_handler(
+            static fn (int $severity, string $message, string $file, int $line): bool => throw new ErrorException(
+                $message,
+                0,
+                $severity,
+                $file,
+                $line
+            )
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        restore_error_handler();
+    }
+
+    /**
+     * The contract of Signature::verify() is a boolean: an oversized key is reported as an invalid signature, not as
+     * an error, and no exponentiation is performed.
+     */
+    #[Test]
+    #[DataProvider('getOversizedKeys')]
+    public function anOversizedKeyIsNotVerifiedAgainst(Signature $algorithm, RsaKey $key, string $signature): void
+    {
+        // Then
+        static::assertFalse($algorithm->verify(self::MESSAGE, $key, $signature));
+    }
+
+    /**
+     * Signing is not a boolean operation: a key the library will not compute with is reported as what it is.
+     */
+    #[Test]
+    #[DataProvider('getOversizedKeys')]
+    public function anOversizedKeyIsRefusedBySign(Signature $algorithm, RsaKey $key): void
+    {
+        // Then
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('at most');
+
+        // When
+        $algorithm->sign(self::MESSAGE, $key);
+    }
+
+    /**
+     * @return iterable<string, array{Signature, RsaKey, string}>
+     */
+    public static function getOversizedKeys(): iterable
+    {
+        $maximumModulus = "\xff" . str_repeat("\xaa", self::MAXIMUM_MODULUS_OCTETS - 2) . "\xff";
+        // One bit too many.
+        $oversizedModulus = "\x01" . str_repeat("\xaa", self::MAXIMUM_MODULUS_OCTETS);
+        // e = n - 2: an exponent as long as the modulus, which RFC 8017, section 3.1 does allow.
+        $oversizedExponent = substr($maximumModulus, 0, -1) . "\xfd";
+
+        foreach ([
+            'PS256' => PS256::create(),
+            'PS512' => PS512::create(),
+            'RS256' => RS256::create(),
+            'RS512' => RS512::create(),
+            'RS1' => RS1::create(acknowledgeInsecureAlgorithm: true),
+        ] as $name => $algorithm) {
+            yield $name . ', oversized modulus' => [
+                $algorithm,
+                self::key($oversizedModulus, "\x01\x00\x01"),
+                str_repeat("\x00", self::MAXIMUM_MODULUS_OCTETS + 1),
+            ];
+            yield $name . ', oversized exponent' => [
+                $algorithm,
+                self::key($maximumModulus, $oversizedExponent),
+                str_repeat("\x00", self::MAXIMUM_MODULUS_OCTETS),
+            ];
+        }
+    }
+
+    /**
+     * RsaKey::asPem() used to convert the modulus and the exponent to a decimal string and back. brick/math falls
+     * back to a pure PHP calculator whenever neither ext-gmp nor ext-bcmath is loaded - the configuration of the
+     * stock php and php-fpm images - and its generic base conversion is superlinear: a single RS256::verify() on a
+     * 16384 bit modulus cost about two minutes of CPU on the reference host, and RsaKeyValidator::isValid() on the
+     * key of the advisory about three and a half.
+     *
+     * The budget below is more than an order of magnitude above what the operations now cost on the slowest machine
+     * this suite is expected to run on, and two orders below what they cost before.
+     */
+    #[Test]
+    public function theLargestAcceptableKeyIsHandledWithoutABigIntegerLibrary(): void
+    {
+        // Given
+        $restore = self::forceTheNativeCalculator();
+        $key = self::key(
+            "\xff" . str_repeat("\xaa", self::MAXIMUM_MODULUS_OCTETS - 2) . "\xff",
+            "\x01\x00\x01"
+        );
+        $signature = str_repeat("\x00", self::MAXIMUM_MODULUS_OCTETS);
+
+        // When
+        $startedAt = microtime(true);
+
+        try {
+            $pem = $key->asPem();
+            $isValid = RsaKeyValidator::create()
+                ->isValid($key);
+            $isVerified = RS256::create()
+                ->verify(self::MESSAGE, $key, $signature);
+        } finally {
+            $restore();
+        }
+        $elapsed = microtime(true) - $startedAt;
+
+        // Then
+        static::assertSame(16384, RsaKeyValidator::modulusLength($key));
+        static::assertStringStartsWith('-----BEGIN PUBLIC KEY-----', $pem);
+        static::assertTrue($isValid);
+        static::assertFalse($isVerified);
+        static::assertLessThan(
+            5.0,
+            $elapsed,
+            'Exporting and verifying against the largest key RFC 8230 asks for must not depend on ext-gmp'
+        );
+    }
+
+    /**
+     * The exponentiation of the largest acceptable key stays bounded because the exponent is: e = n - 2 used to cost
+     * sixty four times what the bound allows.
+     */
+    #[Test]
+    public function theExponentiationOfTheLargestAcceptableKeyIsBounded(): void
+    {
+        // Given
+        $key = self::key(
+            "\xff" . str_repeat("\xaa", self::MAXIMUM_MODULUS_OCTETS - 2) . "\xff",
+            str_repeat("\xff", intdiv(RsaKeyValidator::MAXIMUM_EXPONENT_LENGTH, 8))
+        );
+        $signature = "\x7f" . str_repeat("\xa5", self::MAXIMUM_MODULUS_OCTETS - 1);
+
+        // When
+        $startedAt = microtime(true);
+        $isVerified = PS256::create()
+            ->verify(self::MESSAGE, $key, $signature);
+        $elapsed = microtime(true) - $startedAt;
+
+        // Then
+        static::assertFalse($isVerified);
+        static::assertLessThan(5.0, $elapsed, 'The public exponent bounds the cost of the public operation');
+    }
+
+    private static function key(string $modulus, string $exponent): RsaKey
+    {
+        return RsaKey::create([
+            RsaKey::TYPE => RsaKey::TYPE_RSA,
+            RsaKey::DATA_N => $modulus,
+            RsaKey::DATA_E => $exponent,
+        ]);
+    }
+
+    /**
+     * Models a PHP build with neither ext-gmp nor ext-bcmath. brick/math has moved this switch between releases and
+     * the constraint of this library spans both shapes.
+     *
+     * @return callable(): void the restore function
+     */
+    private static function forceTheNativeCalculator(): callable
+    {
+        if (class_exists(CalculatorRegistry::class)) {
+            CalculatorRegistry::set(new NativeCalculator());
+
+            return static fn () => CalculatorRegistry::set(null);
+        }
+        if (method_exists(Calculator::class, 'set')) {
+            Calculator::set(new NativeCalculator());
+
+            return static fn () => Calculator::set(null);
+        }
+
+        static::markTestSkipped('This version of brick/math does not allow its calculator to be chosen');
+    }
+}

--- a/tests/Key/RSAKeyTest.php
+++ b/tests/Key/RSAKeyTest.php
@@ -7,10 +7,14 @@ namespace Cose\Tests\Key;
 use Cose\Algorithm\Signature\RSA\RS256;
 use Cose\Key\RsaKey;
 use InvalidArgumentException;
+use function ltrim;
+use function openssl_pkey_get_details;
+use function openssl_pkey_get_public;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use function str_repeat;
+use function substr;
 
 final class RSAKeyTest extends TestCase
 {
@@ -35,6 +39,50 @@ final class RSAKeyTest extends TestCase
 
         // Then
         static::assertSame($expected, $pem);
+    }
+
+    /**
+     * The DER of a key is built from its octet strings directly, so the encoding of an ASN.1 INTEGER is this
+     * library's business now: leading zero octets are not part of the value and are dropped, and a value whose first
+     * bit is set gains a 0x00 octet so that it is not read as a negative number (X.690, section 8.3).
+     *
+     * @see https://github.com/web-auth/cose-lib/security/advisories/GHSA-9v8c-2mgr-qvx3
+     */
+    #[Test]
+    #[DataProvider('getKeysWithTheSameValue')]
+    public function theEncodingOfAnIntegerFollowsX690(string $modulus, string $exponent): void
+    {
+        // Given
+        $key = RsaKey::create([
+            RsaKey::TYPE => RsaKey::TYPE_RSA,
+            RsaKey::DATA_N => $modulus,
+            RsaKey::DATA_E => $exponent,
+        ]);
+
+        // When
+        $pem = $key->asPem();
+        $details = openssl_pkey_get_details(openssl_pkey_get_public($pem));
+
+        // Then
+        static::assertSame(ltrim($modulus, "\x00"), $details['rsa']['n']);
+        static::assertSame(ltrim($exponent, "\x00"), $details['rsa']['e']);
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function getKeysWithTheSameValue(): iterable
+    {
+        $modulus = "\xc7" . str_repeat("\x11", 254) . "\x01";
+
+        yield 'the first bit of the modulus is set' => [$modulus, "\x01\x00\x01"];
+        yield 'the modulus is padded' => ["\x00\x00" . $modulus, "\x01\x00\x01"];
+        yield 'the first bit of the modulus is clear' => ["\x47" . substr($modulus, 1), "\x01\x00\x01"];
+        yield 'the first bit of the exponent is set' => [$modulus, "\xff\xff\xff"];
+        yield 'the exponent is padded' => [$modulus, "\x00\x00\x01\x00\x01"];
+        yield 'the exponent is a single octet' => [$modulus, "\x03"];
+        // 127 octets of content are the last that the short form of a DER length can hold (X.690, section 8.1.3.4).
+        yield 'a modulus at the DER length boundary' => ["\x7f" . str_repeat("\x11", 125) . "\x01", "\x01\x00\x01"];
     }
 
     /**

--- a/tests/Key/RsaKeyValidatorTest.php
+++ b/tests/Key/RsaKeyValidatorTest.php
@@ -24,6 +24,102 @@ final class RsaKeyValidatorTest extends TestCase
         // Then
         static::assertSame(2048, RsaKeyValidator::MINIMUM_MODULUS_LENGTH);
         static::assertSame(16384, RsaKeyValidator::MAXIMUM_MODULUS_LENGTH);
+        static::assertSame(256, RsaKeyValidator::MAXIMUM_EXPONENT_LENGTH);
+    }
+
+    #[Test]
+    #[DataProvider('getExponentLengths')]
+    public function theExponentLengthIsCountedInBits(string $exponent, int $expectedLength): void
+    {
+        // Given
+        $key = self::key(str_repeat("\xff", 256), $exponent);
+
+        // Then
+        static::assertSame($expectedLength, RsaKeyValidator::exponentLength($key));
+    }
+
+    /**
+     * The length bounds are the only part of this validator the RSA algorithms apply on their own, so they hold
+     * whether or not the caller ever builds a validator.
+     *
+     * @see https://github.com/web-auth/cose-lib/security/advisories/GHSA-9v8c-2mgr-qvx3
+     */
+    #[Test]
+    public function theLengthBoundsAcceptTheLargestKeyRfc8230AsksFor(): void
+    {
+        // Given
+        $key = self::key("\x80" . str_repeat("\x00", 2047), str_repeat("\xff", 32));
+
+        // Then
+        static::assertSame(16384, RsaKeyValidator::modulusLength($key));
+        static::assertSame(256, RsaKeyValidator::exponentLength($key));
+        RsaKeyValidator::checkLengthBounds($key);
+    }
+
+    /**
+     * No minimum is applied by the length bounds: a key an earlier release accepted must keep being accepted.
+     */
+    #[Test]
+    public function theLengthBoundsImposeNoMinimum(): void
+    {
+        // Given
+        $key = self::key(str_repeat("\xff", 64), "\x03");
+
+        // Then
+        static::assertSame(512, RsaKeyValidator::modulusLength($key));
+        RsaKeyValidator::checkLengthBounds($key);
+        static::assertFalse(RsaKeyValidator::create()->isValid($key));
+    }
+
+    #[Test]
+    #[DataProvider('getOversizedKeys')]
+    public function anOversizedKeyIsRejectedByTheLengthBounds(
+        string $modulus,
+        string $exponent,
+        string $expectedMessage
+    ): void {
+        // Given
+        $key = self::key($modulus, $exponent);
+
+        // Then
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage($expectedMessage);
+
+        // When
+        RsaKeyValidator::checkLengthBounds($key);
+    }
+
+    /**
+     * @return iterable<string, array{string, string, string}>
+     */
+    public static function getOversizedKeys(): iterable
+    {
+        yield 'one bit above the maximum modulus length' => [
+            "\x01" . str_repeat("\x00", 2048),
+            "\x01\x00\x01",
+            'The modulus of the key is 16385 bits long; at most 16384 bits are allowed',
+        ];
+        yield 'one bit above the maximum exponent length' => [
+            str_repeat("\xff", 2048),
+            "\x01" . str_repeat("\x00", 31) . "\x01",
+            'The public exponent of the key is 257 bits long; at most 256 bits are allowed',
+        ];
+        // The key of the advisory: e = n - 2 turns the public operation into a full width exponentiation.
+        yield 'an exponent as long as the modulus' => [
+            "\xff" . str_repeat("\xaa", 2046) . "\xff",
+            "\xff" . str_repeat("\xaa", 2046) . "\xfd",
+            'The public exponent of the key is 16384 bits long; at most 256 bits are allowed',
+        ];
+    }
+
+    /**
+     * @return iterable<string, array{string, int}>
+     */
+    public static function getExponentLengths(): iterable
+    {
+        yield 'the usual exponent' => ["\x01\x00\x01", 17];
+        yield 'leading zero bytes are ignored' => ["\x00\x00\x03", 2];
+        yield 'the maximum' => [str_repeat("\xff", 32), 256];
     }
 
     #[Test]


### PR DESCRIPTION
Settles [GHSA-9v8c-2mgr-qvx3](https://github.com/web-auth/cose-lib/security/advisories/GHSA-9v8c-2mgr-qvx3): two unauthenticated CPU exhaustion primitives in the RSA signature paths. In both, an attacker who controls the public key used for verification turns a request of a few kilobytes into seconds to minutes of worker CPU, and the cost is paid before anything is known about the signature.

No BC break: no key an earlier release accepted is turned away, and `RsaKey::asPem()` produces the very same bytes.

## What was wrong

**1 — the modular exponentiation of the PSS path was unbounded.** `PSSRSA::verify()` computed `s^e mod n` with `n` and `e` taken verbatim from the COSE key. RFC 8017, section 3.1 places no upper bound on either, so `e = n - 2` at a 16384 bit modulus made the public operation as expensive as a full width exponentiation.

**2 — `RsaKey::asPem()` was superlinear in the size of the key.** Every parameter went through `BigInteger::fromBase($hex, 16)->toBase(10)` before `pki-framework` converted it back to octets for the DER INTEGER. `brick/math` falls back to `NativeCalculator` whenever neither `ext-gmp` nor `ext-bcmath` is loaded — the configuration of the stock `php` and `php-fpm` images — and its generic base conversion grows about ×7 per doubling of the modulus. Every `RS*` verification paid it, and so did `RsaKeyValidator` itself.

## What changed

### 1. Bound the key before computing with it

`RsaKeyValidator::checkLengthBounds()` rejects a modulus longer than 16384 bits (RFC 8230, section 6.1) or a public exponent longer than 256 bits (FIPS 186-5, appendix A.1.1, `2^16 < e < 2^256`). `RSA` and `PSSRSA` call it on every operation: `verify()` reports such a key as an invalid signature, `sign()` throws.

**No minimum is applied** — that stays the opt-in policy decision `check()` / `isValid()` implement, so nothing an earlier release accepted is now refused.

### 2. Encode the DER from the octet strings themselves

X.690, section 8.3 defines the content octets of an INTEGER as the two's complement big-endian value, and RFC 8230, section 4 already stores every COSE RSA parameter in exactly that form. `asPem()` now writes the `RSAPrivateKey` / `SubjectPublicKeyInfo` DER directly — one linear pass, no big integer library. `RsaKeyValidator` compares the exponent against the modulus on the raw octets for the same reason: a validator meant to make an oversized key cheap to reject must not itself grow expensive with the size of the key.

The PEM is **byte for byte** what the previous encoder produced. Checked against every fixture of the suite (2048 bit, 2050 bit non-byte-aligned, multi-prime, 1040 bit, no-CRT, padded modulus, public-only) plus synthetic values covering leading zero octets, a set high bit on `n` and on `e`, a single-octet exponent, and the DER short/long length boundary at 127 content octets.

### 3. Compute RSAVP1 with OpenSSL

Bounding the exponent is not enough where `brick/math` has no extension behind it: its pure PHP calculator holds every number as a decimal string, so the public exponentiation cost **3.2 s for a legitimate 2048 bit key** and about **200 s at 16384 bits — within the new bounds**. A verifier takes its key from whoever produced the message, so its cost must not depend on an extension being installed.

`ext-openssl` is already a hard requirement and `rsasp1WithOpenSSL()` already computes RSASP1 that way, so RSAVP1 does too — `openssl_public_decrypt()` under `OPENSSL_NO_PADDING`, on the octet strings. `PSSRSA::verify()` no longer converts anything to a number: step 2.b of RFC 8017, section 8.1.2 compares octet strings, and step 2.c drops the leading octets `I2OSP` would have had to drop, rejecting the signature when they are not zero.

`exponentiate()` keeps its previous behaviour: same primitive, falling back to the in-process `modPow()` when OpenSSL declines the key.

The primitive was cross-checked against the exponentiation it replaces on **200 random representatives for each of 5 key shapes — 1000/1000 identical**.

## Measurements

Reference host, PHP 8.5.8, 16384 bit modulus — the largest RFC 8230 asks implementations to accept.

| | before | after |
| --- | ---: | ---: |
| `asPem()`, no `ext-gmp` / `ext-bcmath` | 107 s | 0.00 s |
| `RsaKeyValidator::isValid()`, `e = n - 2`, same | 217 s | 0.00 s |
| `RS256::verify()`, same | 108 s | 0.00 s |
| `PS256::verify()`, `e = n - 2`, `ext-gmp` | 0.94 s | 0.00 s |
| `PS256::verify()`, `e = 2^256-1`, no extension | ~200 s | 0.00 s |
| `PS256::verify()`, `e = 65537`, 2048 bit, no extension | 3.2 s | 0.00 s |

## Tests

419 tests, 1590 assertions, green. New coverage:

* `OversizedRsaKeyTest` — every `RS*` and `PS*` algorithm against an oversized modulus and against `e = n - 2`: `verify()` returns `false` with no PHP notice, warning or deprecation raised, `sign()` throws; the largest acceptable key is exported, validated and verified against within a time budget with `brick/math` forced onto its pure PHP calculator; a PSS signature still round-trips there, for a byte-aligned and a non-byte-aligned modulus.
* `RsaKeyValidatorTest` — `MAXIMUM_EXPONENT_LENGTH`, `exponentLength()`, the exact boundary in both directions (16384/16385 bits, 256/257 bits), and that the length bounds impose no minimum.
* `RSAKeyTest` — the X.690 section 8.3 encoding of an INTEGER, read back through OpenSSL: padded values, set and clear high bits, a single-octet exponent, the DER length boundary.

19 of the 36 new deterministic cases fail against the unpatched sources.

`ecs`, `phpstan` and `deptrac` are clean; one now-stale entry was dropped from the PHPStan baseline.
