### PR TITLE
fix(mac): validate the type and the length of the HMAC key

### DIFF
--- a/.ci-tools/phpstan-baseline.neon
+++ b/.ci-tools/phpstan-baseline.neon
@@ -1,12 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			rawMessage: Cannot cast mixed to string.
-			identifier: cast.string
-			count: 1
-			path: ../src/Algorithm/Mac/Hmac.php
-
-		-
 			rawMessage: 'Parameter #1 $signature of static method Cose\Algorithm\Signature\ECDSA\ECSignature::fromAsn1() expects string, mixed given.'
 			identifier: argument.type
 			count: 1

--- a/README.md
+++ b/README.md
@@ -202,6 +202,46 @@ the key. They live in the `Cose\Algorithm\Signature\FullySpecified` namespace.
 | HS512 | 7 | HMAC with SHA-512 |
 | HS256/64 | 4 | HMAC with SHA-256 truncated to 64 bits |
 
+#### The HMAC Key
+
+[RFC 9053, section 3.1](https://www.rfc-editor.org/rfc/rfc9053#section-3.1) requires implementations "creating and
+validating MAC values" to validate the key type, the key length and the algorithm. The key value `k` is a `bstr`
+(section 7.3), so `hash()` and `verify()` reject — with an `InvalidArgumentException` — a key that is not symmetric,
+or whose `k` is missing, is not a PHP string, or is empty. A decoded CBOR object has to be normalized to its value
+first: a `CBOR\ByteStringObject` is not a byte string.
+
+A key shorter than the output of the underlying hash function (32 bytes for HS256 and HS256/64, 48 for HS384, 64 for
+HS512) is "strongly discouraged" by [RFC 2104, section 3](https://www.rfc-editor.org/rfc/rfc2104#section-3) but stays
+accepted, because deployments do key HS384 and HS512 with 32 bytes. It emits an `E_USER_WARNING` unless you
+acknowledge it:
+
+```php
+use Cose\Algorithm\Mac\HS512;
+
+$algorithm = HS512::create(acknowledgeShortKey: true);
+```
+
+As of the next major version, omitting that acknowledgement will throw an exception instead of warning.
+
+To fail hard on a short key today, validate it before handing it to the algorithm:
+
+```php
+use Cose\Algorithm\Mac\HS256;
+use Cose\Key\SymmetricKey;
+use Cose\Key\SymmetricKeyValidator;
+
+$algorithm = HS256::create();
+$key = SymmetricKey::create($data);
+
+// Throws an InvalidArgumentException when the key is shorter than 32 bytes
+SymmetricKeyValidator::create($algorithm->minimumKeyLength())->check($key);
+
+// …or ask without the exception
+if (! SymmetricKeyValidator::create()->isValid($key)) {
+    // reject the key
+}
+```
+
 ## Signature Verification Contract
 
 `Cose\Algorithm\Signature\Signature::verify()` is total for every condition the governing specifications define as an

--- a/doc/Usage.md
+++ b/doc/Usage.md
@@ -20,6 +20,7 @@ This library provides full support for COSE (CBOR Object Signing and Encryption)
   - [Signature Verification Contract](#signature-verification-contract)
   - [Ed25519 Private Keys](#ed25519-private-keys)
   - [Validating RSA Keys](#validating-rsa-keys)
+  - [Validating Symmetric Keys](#validating-symmetric-keys)
 
 ## Installation
 
@@ -459,6 +460,57 @@ Every check is performed on the octet strings of the key, so rejecting an oversi
   - HS384 (6): HMAC with SHA-384
   - HS512 (7): HMAC with SHA-512
   - HS256/64 (4): HMAC with SHA-256 truncated to 64 bits
+
+### Validating Symmetric Keys
+
+[RFC 9053, section 3.1](https://www.rfc-editor.org/rfc/rfc9053#section-3.1) requires implementations "creating and
+validating MAC values" to validate the key type, the key length and the algorithm. The first two constraints admit no
+exception and are applied by the MAC algorithms themselves: `hash()` and `verify()` throw an
+`InvalidArgumentException` when the key is not symmetric, or when its `k` is missing, is not a PHP string or is empty.
+`SymmetricKey` applies the same contract at construction time, where the mistake is easiest to attribute. A value
+decoded from CBOR has to be normalized first — a `CBOR\ByteStringObject` is not a byte string.
+
+```php
+use Cose\Key\SymmetricKey;
+
+// Throws an InvalidArgumentException: "k" is typed as a bstr by RFC 9053, section 7.3
+SymmetricKey::create([
+    SymmetricKey::TYPE => SymmetricKey::TYPE_OCT,
+    SymmetricKey::DATA_K => ByteStringObject::create($secret), // use ->getValue() instead
+]);
+```
+
+The **minimum** key length is a policy decision and stays opt-in, as it does for RSA moduli: a key shorter than the
+output of the hash function (32 bytes for HS256 and HS256/64, 48 for HS384, 64 for HS512) is only "strongly
+discouraged" by [RFC 2104, section 3](https://www.rfc-editor.org/rfc/rfc2104#section-3), and deployments do key HS384
+and HS512 with 32 bytes. Such a key emits an `E_USER_WARNING` at every `hash()`/`verify()` call unless the algorithm
+is created with `acknowledgeShortKey: true`; the next major version will throw instead.
+
+```php
+use Cose\Algorithm\Mac\HS512;
+use Cose\Key\SymmetricKeyValidator;
+
+// No warning: the risk is acknowledged
+$algorithm = HS512::create(acknowledgeShortKey: true);
+
+// The length RFC 2104 does not discourage for this algorithm, in bytes (32, 48 or 64)
+$minimumKeyLength = $algorithm->minimumKeyLength();
+
+// Throws an InvalidArgumentException when the key is shorter
+SymmetricKeyValidator::create($minimumKeyLength)->check($key);
+
+// …or ask without the exception
+$isAcceptable = SymmetricKeyValidator::create()->isValid($key);
+
+// The key length, in bytes, on its own
+$keyLength = SymmetricKeyValidator::keyLength($key);
+
+// The checks the algorithms apply on their own, should you want to run them earlier
+SymmetricKeyValidator::checkKeyValue($key);
+```
+
+`SymmetricKeyValidator` accepts any `Key`, not only a `SymmetricKey`: `Key::create()` and `Key::createFromData()` with
+an integer `kty` build a generic `Key` that never goes through the `SymmetricKey` constructor.
 
 ## Common Header Parameters
 

--- a/src/Algorithm/Mac/HS256.php
+++ b/src/Algorithm/Mac/HS256.php
@@ -8,9 +8,9 @@ final class HS256 extends Hmac
 {
     public const ID = 5;
 
-    public static function create(): self
+    public static function create(bool $acknowledgeShortKey = false): self
     {
-        return new self();
+        return new self($acknowledgeShortKey);
     }
 
     public static function identifier(): int

--- a/src/Algorithm/Mac/HS256Truncated64.php
+++ b/src/Algorithm/Mac/HS256Truncated64.php
@@ -8,9 +8,9 @@ final class HS256Truncated64 extends Hmac
 {
     public const ID = 4;
 
-    public static function create(): self
+    public static function create(bool $acknowledgeShortKey = false): self
     {
-        return new self();
+        return new self($acknowledgeShortKey);
     }
 
     public static function identifier(): int

--- a/src/Algorithm/Mac/HS384.php
+++ b/src/Algorithm/Mac/HS384.php
@@ -8,9 +8,9 @@ final class HS384 extends Hmac
 {
     public const ID = 6;
 
-    public static function create(): self
+    public static function create(bool $acknowledgeShortKey = false): self
     {
-        return new self();
+        return new self($acknowledgeShortKey);
     }
 
     public static function identifier(): int

--- a/src/Algorithm/Mac/HS512.php
+++ b/src/Algorithm/Mac/HS512.php
@@ -8,9 +8,9 @@ final class HS512 extends Hmac
 {
     public const ID = 7;
 
-    public static function create(): self
+    public static function create(bool $acknowledgeShortKey = false): self
     {
-        return new self();
+        return new self($acknowledgeShortKey);
     }
 
     public static function identifier(): int

--- a/src/Algorithm/Mac/Hmac.php
+++ b/src/Algorithm/Mac/Hmac.php
@@ -38,7 +38,7 @@ use function trigger_error;
  */
 abstract class Hmac implements Mac
 {
-    public const SHORT_KEY_MESSAGE = 'The HMAC key is %d bytes long, which is shorter than the %d-byte output of the underlying hash function (RFC 2104, section 3, strongly discourages this). If you know what you are doing, create the algorithm with "acknowledgeShortKey: true"; as of v5.0.0, omitting that acknowledgement will throw an exception.';
+    public const SHORT_KEY_MESSAGE = 'The HMAC key is %d bytes long, shorter than the %d-byte hash output (RFC 2104, section 3). Create the algorithm with "acknowledgeShortKey: true" to acknowledge it; as of v5.0.0 this will throw.';
 
     public function __construct(
         private readonly bool $acknowledgeShortKey = false

--- a/src/Algorithm/Mac/Hmac.php
+++ b/src/Algorithm/Mac/Hmac.php
@@ -6,17 +6,48 @@ namespace Cose\Algorithm\Mac;
 
 use Cose\Key\Key;
 use Cose\Key\SymmetricKey;
+use const E_USER_WARNING;
+use function hash;
+use function hash_hmac;
 use InvalidArgumentException;
+use function is_string;
+use function sprintf;
+use function strlen;
+use function trigger_error;
 
 /**
+ * HMAC-based Message Authentication Codes (RFC 9053, section 3.1).
+ *
+ * RFC 9053, section 3.1 requires that "implementations creating and validating MAC values MUST validate that the key
+ * type, key length, and algorithm are correct and appropriate for the entities involved", and section 7.3 types the
+ * key value `k` as a byte string. Accordingly, a key whose `k` is absent, not a PHP string or empty is rejected: none
+ * of them is ever a legitimate HMAC key, and coercing such a value would silently key the MAC with a constant an
+ * outsider can guess ("Array", "1", the empty string, …).
+ *
+ * The key length is a softer matter. RFC 2104, section 3 states that a key shorter than the output of the hash
+ * function is "strongly discouraged", and RFC 9053, section 3.1 only makes the hash output size a SHOULD for keys
+ * that are transported or derived by a recipient algorithm - neither of which this library implements. A shorter key
+ * is therefore accepted, but it emits an E_USER_WARNING unless the caller explicitly acknowledges the risk by
+ * creating the algorithm with `acknowledgeShortKey: true`, following the same shape as
+ * Cose\Algorithm\Signature\RSA\RS1. From v5.0.0 the same call without that acknowledgement will throw an
+ * InvalidArgumentException instead of warning.
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc9053#section-3.1
+ * @see https://www.rfc-editor.org/rfc/rfc2104#section-3
  * @see \Cose\Tests\Algorithm\Mac\HmacTest
  */
 abstract class Hmac implements Mac
 {
+    public const SHORT_KEY_MESSAGE = 'The HMAC key is %d bytes long, which is shorter than the %d-byte output of the underlying hash function (RFC 2104, section 3, strongly discourages this). If you know what you are doing, create the algorithm with "acknowledgeShortKey: true"; as of v5.0.0, omitting that acknowledgement will throw an exception.';
+
+    public function __construct(
+        private readonly bool $acknowledgeShortKey = false
+    ) {
+    }
+
     public function hash(string $data, Key $key): string
     {
-        $this->checKey($key);
-        $signature = hash_hmac($this->getHashAlgorithm(), $data, (string) $key->get(SymmetricKey::DATA_K), true);
+        $signature = hash_hmac($this->getHashAlgorithm(), $data, $this->checKey($key), true);
 
         return substr($signature, 0, intdiv($this->getSignatureLength(), 8));
     }
@@ -26,11 +57,23 @@ abstract class Hmac implements Mac
         return hash_equals($this->hash($data, $key), $signature);
     }
 
+    /**
+     * The length, in bytes, of the output of the underlying hash function: the shortest key RFC 2104, section 3 does
+     * not discourage for this algorithm.
+     */
+    public function minimumKeyLength(): int
+    {
+        return strlen(hash($this->getHashAlgorithm(), '', true));
+    }
+
     abstract protected function getHashAlgorithm(): string;
 
     abstract protected function getSignatureLength(): int;
 
-    private function checKey(Key $key): void
+    /**
+     * @throws InvalidArgumentException when the key cannot be used with this algorithm
+     */
+    private function checKey(Key $key): string
     {
         if ($key->type() !== Key::TYPE_OCT && $key->type() !== Key::TYPE_NAME_OCT) {
             throw new InvalidArgumentException('Invalid key. Must be of type symmetric');
@@ -39,5 +82,22 @@ abstract class Hmac implements Mac
         if (! $key->has(SymmetricKey::DATA_K)) {
             throw new InvalidArgumentException('Invalid key. The value of the key is missing');
         }
+
+        $k = $key->get(SymmetricKey::DATA_K);
+        if (! is_string($k)) {
+            throw new InvalidArgumentException(
+                'Invalid key. The value of the key must be a byte string (CBOR objects shall be normalized first)'
+            );
+        }
+        if ($k === '') {
+            throw new InvalidArgumentException('Invalid key. The value of the key is empty');
+        }
+
+        $minimumKeyLength = $this->minimumKeyLength();
+        if (strlen($k) < $minimumKeyLength && ! $this->acknowledgeShortKey) {
+            trigger_error(sprintf(self::SHORT_KEY_MESSAGE, strlen($k), $minimumKeyLength), E_USER_WARNING);
+        }
+
+        return $k;
     }
 }

--- a/src/Key/SymmetricKey.php
+++ b/src/Key/SymmetricKey.php
@@ -5,8 +5,18 @@ declare(strict_types=1);
 namespace Cose\Key;
 
 use InvalidArgumentException;
+use function is_string;
 
 /**
+ * A symmetric COSE key (RFC 9053, section 7.3).
+ *
+ * Table 21 of that section types the key value `k` as a `bstr`, which is what the k() accessor of this class has
+ * always returned. The constructor enforces the same contract: a `k` that is not a PHP string, or that is empty, is
+ * rejected where the mistake is easiest to attribute rather than at the first cryptographic operation.
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc9053#section-7.3
+ * @see \Cose\Tests\Key\SymmetricKeyTest
+ *
  * @final
  */
 class SymmetricKey extends Key
@@ -26,6 +36,14 @@ class SymmetricKey extends Key
         }
         if (! isset($data[self::DATA_K])) {
             throw new InvalidArgumentException('Invalid symmetric key. The parameter "k" is missing');
+        }
+        if (! is_string($data[self::DATA_K])) {
+            throw new InvalidArgumentException(
+                'Invalid symmetric key. The parameter "k" shall be a byte string (CBOR objects shall be normalized first)'
+            );
+        }
+        if ($data[self::DATA_K] === '') {
+            throw new InvalidArgumentException('Invalid symmetric key. The parameter "k" is empty');
         }
     }
 

--- a/src/Key/SymmetricKeyValidator.php
+++ b/src/Key/SymmetricKeyValidator.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cose\Key;
+
+use InvalidArgumentException;
+use function is_string;
+use function sprintf;
+use function strlen;
+use Throwable;
+
+/**
+ * Checks a symmetric key against the constraints the COSE MAC algorithms rely on.
+ *
+ * RFC 9053, section 3.1 requires implementations to "validate that the key type, key length, and algorithm are
+ * correct and appropriate for the entities involved". The key type and the byte string nature of `k` admit no
+ * exception and are therefore applied by the algorithms themselves: Cose\Algorithm\Mac\Hmac rejects a key that is
+ * not symmetric, whose `k` is missing, is not a PHP string, or is empty.
+ *
+ * The *minimum* key length is the policy choice, and it stays opt-in, exactly like the minimum modulus length of
+ * RsaKeyValidator: RFC 2104, section 3 only states that a key shorter than the output of the hash function is
+ * "strongly discouraged", and existing deployments do key HS384/HS512 with 32 bytes. Run this validator explicitly
+ * on a key before handing it to an algorithm to turn that discouragement into a hard failure today, instead of the
+ * E_USER_WARNING the algorithms emit.
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc9053#section-3.1
+ * @see https://www.rfc-editor.org/rfc/rfc2104#section-3
+ * @see \Cose\Tests\Key\SymmetricKeyValidatorTest
+ */
+final class SymmetricKeyValidator
+{
+    /**
+     * The output length of SHA-256, in bytes: the shortest key RFC 2104, section 3 does not discourage for HS256 and
+     * HS256/64, and the smallest of the three lengths the MAC algorithms of this library use.
+     *
+     * Cose\Algorithm\Mac\Hmac::minimumKeyLength() gives the value that matches a given algorithm (32, 48 or 64).
+     */
+    public const MINIMUM_KEY_LENGTH = 32;
+
+    private function __construct(
+        private readonly int $minimumKeyLength
+    ) {
+        if ($minimumKeyLength < 1) {
+            throw new InvalidArgumentException('The minimum key length shall be a positive integer');
+        }
+    }
+
+    public static function create(int $minimumKeyLength = self::MINIMUM_KEY_LENGTH): self
+    {
+        return new self($minimumKeyLength);
+    }
+
+    /**
+     * Returns the length of the key value, in bytes.
+     *
+     * @throws InvalidArgumentException when the key is not a usable symmetric key
+     */
+    public static function keyLength(Key $key): int
+    {
+        return strlen(self::keyValue($key));
+    }
+
+    /**
+     * The constraints every MAC algorithm of this library applies on its own: a symmetric key whose `k` is present,
+     * is a byte string and is not empty. None of them depends on a policy - a `k` that is not a byte string is
+     * outside RFC 9053, section 7.3, and an empty key makes every tag computable by anyone.
+     *
+     * @throws InvalidArgumentException when the key does not satisfy the constraints
+     */
+    public static function checkKeyValue(Key $key): void
+    {
+        self::keyValue($key);
+    }
+
+    /**
+     * @throws InvalidArgumentException when the key does not satisfy the constraints
+     */
+    public function check(Key $key): void
+    {
+        $keyLength = strlen(self::keyValue($key));
+        if ($keyLength < $this->minimumKeyLength) {
+            throw new InvalidArgumentException(sprintf(
+                'The key is %d bytes long; at least %d bytes are required',
+                $keyLength,
+                $this->minimumKeyLength
+            ));
+        }
+    }
+
+    public function isValid(Key $key): bool
+    {
+        try {
+            $this->check($key);
+        } catch (Throwable) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @throws InvalidArgumentException when the key does not satisfy the constraints
+     */
+    private static function keyValue(Key $key): string
+    {
+        if ($key->type() !== Key::TYPE_OCT && $key->type() !== Key::TYPE_NAME_OCT) {
+            throw new InvalidArgumentException('Invalid key. Must be of type symmetric');
+        }
+        if (! $key->has(SymmetricKey::DATA_K)) {
+            throw new InvalidArgumentException('Invalid key. The value of the key is missing');
+        }
+        $k = $key->get(SymmetricKey::DATA_K);
+        if (! is_string($k)) {
+            throw new InvalidArgumentException(
+                'Invalid key. The value of the key must be a byte string (CBOR objects shall be normalized first)'
+            );
+        }
+        if ($k === '') {
+            throw new InvalidArgumentException('Invalid key. The value of the key is empty');
+        }
+
+        return $k;
+    }
+}

--- a/tests/Algorithm/Mac/HmacTest.php
+++ b/tests/Algorithm/Mac/HmacTest.php
@@ -5,20 +5,35 @@ declare(strict_types=1);
 namespace Cose\Tests\Algorithm\Mac;
 
 use function base64_decode;
+use CBOR\ByteStringObject;
 use Cose\Algorithm\Mac\Hmac;
 use Cose\Algorithm\Mac\HS256;
 use Cose\Algorithm\Mac\HS256Truncated64;
 use Cose\Algorithm\Mac\HS384;
 use Cose\Algorithm\Mac\HS512;
+use Cose\Key\Key;
 use Cose\Key\OkpKey;
 use Cose\Key\SymmetricKey;
+use const E_USER_WARNING;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use PHPUnit\Framework\TestCase;
+use function restore_error_handler;
+use function set_error_handler;
+use function sprintf;
+use function str_repeat;
 
 final class HmacTest extends TestCase
 {
+    private const DATA = 'eyJhbGciOiJIUzI1NiIsImtpZCI6IjAxOGMwYWU1LTRkOWItNDcxYi1iZmQ2LWVlZjMxNGJjNzAzNyJ9.SXTigJlzIGEgZGFuZ2Vyb3VzIGJ1c2luZXNzLCBGcm9kbywgZ29pbmcgb3V0IHlvdXIgZG9vci4gWW91IHN0ZXAgb250byB0aGUgcm9hZCwgYW5kIGlmIHlvdSBkb24ndCBrZWVwIHlvdXIgZmVldCwgdGhlcmXigJlzIG5vIGtub3dpbmcgd2hlcmUgeW91IG1pZ2h0IGJlIHN3ZXB0IG9mZiB0by4';
+
+    /**
+     * @var array<int, array{severity: int, message: string}>
+     */
+    private array $capturedErrors = [];
+
     #[Test]
     public function theAlgorithsmHaveCorrectInnerParameters(): void
     {
@@ -81,10 +96,7 @@ final class HmacTest extends TestCase
         ]);
 
         // When
-        $algorithm->hash(
-            'eyJhbGciOiJIUzI1NiIsImtpZCI6IjAxOGMwYWU1LTRkOWItNDcxYi1iZmQ2LWVlZjMxNGJjNzAzNyJ9.SXTigJlzIGEgZGFuZ2Vyb3VzIGJ1c2luZXNzLCBGcm9kbywgZ29pbmcgb3V0IHlvdXIgZG9vci4gWW91IHN0ZXAgb250byB0aGUgcm9hZCwgYW5kIGlmIHlvdSBkb24ndCBrZWVwIHlvdXIgZmVldCwgdGhlcmXigJlzIG5vIGtub3dpbmcgd2hlcmUgeW91IG1pZ2h0IGJlIHN3ZXB0IG9mZiB0by4',
-            $key
-        );
+        $algorithm->hash(self::DATA, $key);
     }
 
     #[Test]
@@ -101,37 +113,232 @@ final class HmacTest extends TestCase
         ]);
 
         // When
-        $algorithm->hash(
-            'eyJhbGciOiJIUzI1NiIsImtpZCI6IjAxOGMwYWU1LTRkOWItNDcxYi1iZmQ2LWVlZjMxNGJjNzAzNyJ9.SXTigJlzIGEgZGFuZ2Vyb3VzIGJ1c2luZXNzLCBGcm9kbywgZ29pbmcgb3V0IHlvdXIgZG9vci4gWW91IHN0ZXAgb250byB0aGUgcm9hZCwgYW5kIGlmIHlvdSBkb24ndCBrZWVwIHlvdXIgZmVldCwgdGhlcmXigJlzIG5vIGtub3dpbmcgd2hlcmUgeW91IG1pZ2h0IGJlIHN3ZXB0IG9mZiB0by4',
-            $key
-        );
+        $algorithm->hash(self::DATA, $key);
+    }
+
+    #[Test]
+    public function theKeyDataIsMissing(): void
+    {
+        // Then
+        static::expectException(InvalidArgumentException::class);
+        static::expectExceptionMessage('Invalid key. The value of the key is missing');
+
+        // Given
+        $algorithm = new HS256();
+        $key = Key::create([
+            Key::TYPE => Key::TYPE_OCT,
+        ]);
+
+        // When
+        $algorithm->hash(self::DATA, $key);
     }
 
     /**
-     * @return array<string>[]
+     * A "k" that is not a byte string used to be coerced with (string), which keys the MAC with a constant an
+     * outsider can guess: "Array" for an array, "1" for true, "" for false or null.
+     */
+    #[Test]
+    #[DataProvider('getInvalidKeyValues')]
+    public function theKeyValueIsNotAByteString(mixed $k): void
+    {
+        // Then
+        static::expectException(InvalidArgumentException::class);
+        static::expectExceptionMessage('Invalid key. The value of the key must be a byte string');
+
+        // Given
+        $algorithm = new HS256();
+        $key = Key::create([
+            Key::TYPE => Key::TYPE_OCT,
+            SymmetricKey::DATA_K => $k,
+        ]);
+
+        // When
+        $algorithm->hash(self::DATA, $key);
+    }
+
+    #[Test]
+    #[DataProvider('getAlgorithms')]
+    public function theKeyValueIsEmpty(Hmac $algorithm): void
+    {
+        // Then
+        static::expectException(InvalidArgumentException::class);
+        static::expectExceptionMessage('Invalid key. The value of the key is empty');
+
+        // Given
+        $key = Key::create([
+            Key::TYPE => Key::TYPE_OCT,
+            SymmetricKey::DATA_K => '',
+        ]);
+
+        // When
+        $algorithm->hash(self::DATA, $key);
+    }
+
+    #[Test]
+    #[DataProvider('getAlgorithms')]
+    public function theVerificationOfAnInvalidKeyThrowsAsWell(Hmac $algorithm): void
+    {
+        // Then
+        static::expectException(InvalidArgumentException::class);
+        static::expectExceptionMessage('Invalid key. The value of the key must be a byte string');
+
+        // Given
+        $key = Key::create([
+            Key::TYPE => Key::TYPE_OCT,
+            SymmetricKey::DATA_K => null,
+        ]);
+
+        // When
+        $algorithm->verify(self::DATA, $key, str_repeat("\0", 32));
+    }
+
+    #[Test]
+    #[DataProvider('getMinimumKeyLengths')]
+    public function theMinimumKeyLengthIsTheHashOutputLength(Hmac $algorithm, int $expectedLength): void
+    {
+        // Then
+        static::assertSame($expectedLength, $algorithm->minimumKeyLength());
+    }
+
+    #[Test]
+    #[DataProvider('getMinimumKeyLengths')]
+    #[WithoutErrorHandler]
+    public function aShortKeyTriggersAWarning(Hmac $algorithm, int $minimumKeyLength): void
+    {
+        // Given
+        $key = SymmetricKey::create([
+            SymmetricKey::TYPE => SymmetricKey::TYPE_OCT,
+            SymmetricKey::DATA_K => str_repeat("\x2a", $minimumKeyLength - 1),
+        ]);
+        $this->captureErrors();
+
+        // When
+        $hash = $algorithm->hash(self::DATA, $key);
+        restore_error_handler();
+
+        // Then
+        static::assertNotSame('', $hash);
+        static::assertCount(1, $this->capturedErrors);
+        static::assertSame(E_USER_WARNING, $this->capturedErrors[0]['severity']);
+        static::assertSame(
+            sprintf(Hmac::SHORT_KEY_MESSAGE, $minimumKeyLength - 1, $minimumKeyLength),
+            $this->capturedErrors[0]['message']
+        );
+    }
+
+    #[Test]
+    #[DataProvider('getMinimumKeyLengths')]
+    #[WithoutErrorHandler]
+    public function aKeyOfTheHashOutputLengthTriggersNoWarning(Hmac $algorithm, int $minimumKeyLength): void
+    {
+        // Given
+        $key = SymmetricKey::create([
+            SymmetricKey::TYPE => SymmetricKey::TYPE_OCT,
+            SymmetricKey::DATA_K => str_repeat("\x2a", $minimumKeyLength),
+        ]);
+        $this->captureErrors();
+
+        // When
+        $algorithm->hash(self::DATA, $key);
+        restore_error_handler();
+
+        // Then
+        static::assertSame([], $this->capturedErrors);
+    }
+
+    #[Test]
+    #[DataProvider('getAcknowledgedAlgorithms')]
+    #[WithoutErrorHandler]
+    public function acknowledgingTheRiskSilencesTheWarning(Hmac $algorithm): void
+    {
+        // Given
+        $key = SymmetricKey::create([
+            SymmetricKey::TYPE => SymmetricKey::TYPE_OCT,
+            SymmetricKey::DATA_K => "\x2a",
+        ]);
+        $this->captureErrors();
+
+        // When
+        $hash = $algorithm->hash(self::DATA, $key);
+        $isValid = $algorithm->verify(self::DATA, $key, $hash);
+        restore_error_handler();
+
+        // Then
+        static::assertTrue($isValid);
+        static::assertSame([], $this->capturedErrors);
+    }
+
+    /**
+     * verify() computes the MAC, so it warns exactly like hash() does: once per operation.
+     */
+    #[Test]
+    #[WithoutErrorHandler]
+    public function everyOperationWithAShortKeyWarnsOnce(): void
+    {
+        // Given
+        $algorithm = HS256::create();
+        $key = SymmetricKey::create([
+            SymmetricKey::TYPE => SymmetricKey::TYPE_OCT,
+            SymmetricKey::DATA_K => "\x2a",
+        ]);
+        $this->captureErrors();
+
+        // When
+        $hash = $algorithm->hash(self::DATA, $key);
+        $isValid = $algorithm->verify(self::DATA, $key, $hash);
+        restore_error_handler();
+
+        // Then
+        static::assertTrue($isValid);
+        static::assertCount(2, $this->capturedErrors);
+        static::assertSame(sprintf(Hmac::SHORT_KEY_MESSAGE, 1, 32), $this->capturedErrors[0]['message']);
+    }
+
+    /**
+     * @return iterable<array{0: Hmac, 1: string, 2: string, 3: string}>
      */
     public static function getVectors(): iterable
     {
-        yield [
+        yield 'HS256 with a 32-byte key' => [
             HS256::create(),
             base64_decode('hJtXIZ2uSN5kbQfbtTNWbpdmhkV8FJG+Onbc6mxCcYg', true),
-            'eyJhbGciOiJIUzI1NiIsImtpZCI6IjAxOGMwYWU1LTRkOWItNDcxYi1iZmQ2LWVlZjMxNGJjNzAzNyJ9.SXTigJlzIGEgZGFuZ2Vyb3VzIGJ1c2luZXNzLCBGcm9kbywgZ29pbmcgb3V0IHlvdXIgZG9vci4gWW91IHN0ZXAgb250byB0aGUgcm9hZCwgYW5kIGlmIHlvdSBkb24ndCBrZWVwIHlvdXIgZmVldCwgdGhlcmXigJlzIG5vIGtub3dpbmcgd2hlcmUgeW91IG1pZ2h0IGJlIHN3ZXB0IG9mZiB0by4',
+            self::DATA,
             base64_decode('s0h6KThzkfBBBkLspW1h84VsJZFTsPPqMDA7g1Md7p0', true),
         ];
-        yield [
+        yield 'HS256/64 with a 32-byte key' => [
             HS256Truncated64::create(),
             base64_decode('hJtXIZ2uSN5kbQfbtTNWbpdmhkV8FJG+Onbc6mxCcYg', true),
-            'eyJhbGciOiJIUzI1NiIsImtpZCI6IjAxOGMwYWU1LTRkOWItNDcxYi1iZmQ2LWVlZjMxNGJjNzAzNyJ9.SXTigJlzIGEgZGFuZ2Vyb3VzIGJ1c2luZXNzLCBGcm9kbywgZ29pbmcgb3V0IHlvdXIgZG9vci4gWW91IHN0ZXAgb250byB0aGUgcm9hZCwgYW5kIGlmIHlvdSBkb24ndCBrZWVwIHlvdXIgZmVldCwgdGhlcmXigJlzIG5vIGtub3dpbmcgd2hlcmUgeW91IG1pZ2h0IGJlIHN3ZXB0IG9mZiB0by4',
+            self::DATA,
             base64_decode('s0h6KThzkfA', true),
         ];
-        yield [
+        yield 'HS384 with a 48-byte key' => [
             HS384::create(),
+            base64_decode('DDVKiA7ujY+xdy1WhIYbJpAPCgFUFyyotcFhh5elhvRE2rph61YMR8xVMwCtYERs', true),
+            'Live long and Prosper.',
+            base64_decode('yuGcnpTocjcTCLtzbHe8ZLcQGFzOTuKFgh9zMzc+FYeV31WP5ACSe+bg9hrHxVvs', true),
+        ];
+        yield 'HS512 with a 64-byte key' => [
+            HS512::create(),
+            base64_decode(
+                'EdxdisiEXoRKH/HPzH05ZyEoAnC2DH5ztKcXNQx41do/DVuw7/pkZ35OioKyKRMMTTiMeeG68d38fWSFmlKgPw==',
+                true
+            ),
+            'Live long and Prosper.',
+            base64_decode(
+                'WoFFyV1QXnzqBlTHyb/ZAmzXTIsTQCnNLJg+dTw5QW19XoQXLUjfQ4L7G/D5GisPZU/Y8k9xjDF+gemNuJqYfQ==',
+                true
+            ),
+        ];
+        // A 32-byte key is shorter than the output of SHA-384 and SHA-512: these vectors are the regression test of
+        // the acknowledgement path.
+        yield 'HS384 with an acknowledged 32-byte key' => [
+            HS384::create(acknowledgeShortKey: true),
             base64_decode('hJtXIZ2uSN5kbQfbtTNWbpdmhkV8FJG+Onbc6mxCcYg', true),
             'Live long and Prosper.',
             base64_decode('siXuHzld4TPYfNB5blTxAlSjIV3QG3GWBisyp8F2RHbT7tL82ex+y46PqVCeUrEG', true),
         ];
-        yield [
-            HS512::create(),
+        yield 'HS512 with an acknowledged 32-byte key' => [
+            HS512::create(acknowledgeShortKey: true),
             base64_decode('hJtXIZ2uSN5kbQfbtTNWbpdmhkV8FJG+Onbc6mxCcYg', true),
             'Live long and Prosper.',
             base64_decode(
@@ -139,5 +346,67 @@ final class HmacTest extends TestCase
                 true
             ),
         ];
+    }
+
+    /**
+     * @return iterable<array{0: mixed}>
+     */
+    public static function getInvalidKeyValues(): iterable
+    {
+        yield 'null' => [null];
+        yield 'array' => [[
+            'k' => str_repeat("\x2a", 32),
+        ]];
+        yield 'integer' => [123];
+        yield 'false' => [false];
+        yield 'true' => [true];
+        yield 'float' => [1.5];
+        yield 'CBOR object' => [ByteStringObject::create(str_repeat("\x2a", 32))];
+    }
+
+    /**
+     * @return iterable<array{0: Hmac}>
+     */
+    public static function getAlgorithms(): iterable
+    {
+        yield 'HS256' => [HS256::create()];
+        yield 'HS256/64' => [HS256Truncated64::create()];
+        yield 'HS384' => [HS384::create()];
+        yield 'HS512' => [HS512::create()];
+    }
+
+    /**
+     * @return iterable<array{0: Hmac}>
+     */
+    public static function getAcknowledgedAlgorithms(): iterable
+    {
+        yield 'HS256' => [HS256::create(acknowledgeShortKey: true)];
+        yield 'HS256/64' => [HS256Truncated64::create(acknowledgeShortKey: true)];
+        yield 'HS384' => [HS384::create(acknowledgeShortKey: true)];
+        yield 'HS512' => [HS512::create(acknowledgeShortKey: true)];
+    }
+
+    /**
+     * @return iterable<array{0: Hmac, 1: int}>
+     */
+    public static function getMinimumKeyLengths(): iterable
+    {
+        yield 'HS256' => [HS256::create(), 32];
+        yield 'HS256/64' => [HS256Truncated64::create(), 32];
+        yield 'HS384' => [HS384::create(), 48];
+        yield 'HS512' => [HS512::create(), 64];
+    }
+
+    private function captureErrors(): void
+    {
+        $this->capturedErrors = [];
+        set_error_handler(function (int $severity, string $message): bool {
+            $this->capturedErrors[] = [
+                'severity' => $severity,
+                'message' => $message,
+            ];
+
+            return true;
+        });
     }
 }

--- a/tests/Key/SymmetricKeyTest.php
+++ b/tests/Key/SymmetricKeyTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cose\Tests\Key;
+
+use CBOR\ByteStringObject;
+use Cose\Key\Key;
+use Cose\Key\SymmetricKey;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use function str_repeat;
+
+/**
+ * @internal
+ */
+final class SymmetricKeyTest extends TestCase
+{
+    #[Test]
+    public function aSymmetricKeyCanBeCreated(): void
+    {
+        // Given
+        $k = str_repeat("\x2a", 32);
+
+        // When
+        $key = SymmetricKey::create([
+            SymmetricKey::TYPE => SymmetricKey::TYPE_OCT,
+            SymmetricKey::DATA_K => $k,
+        ]);
+
+        // Then
+        static::assertSame(SymmetricKey::TYPE_OCT, $key->type());
+        static::assertSame($k, $key->k());
+    }
+
+    #[Test]
+    public function theKeyTypeShallBeSymmetric(): void
+    {
+        // Then
+        static::expectException(InvalidArgumentException::class);
+        static::expectExceptionMessage('Invalid symmetric key. The key type does not correspond to a symmetric key');
+
+        // When
+        SymmetricKey::create([
+            SymmetricKey::TYPE => SymmetricKey::TYPE_EC2,
+            SymmetricKey::DATA_K => str_repeat("\x2a", 32),
+        ]);
+    }
+
+    #[Test]
+    public function theKeyValueIsMissing(): void
+    {
+        // Then
+        static::expectException(InvalidArgumentException::class);
+        static::expectExceptionMessage('Invalid symmetric key. The parameter "k" is missing');
+
+        // When
+        SymmetricKey::create([
+            SymmetricKey::TYPE => SymmetricKey::TYPE_OCT,
+        ]);
+    }
+
+    #[Test]
+    public function theKeyValueIsNull(): void
+    {
+        // Then
+        static::expectException(InvalidArgumentException::class);
+        static::expectExceptionMessage('Invalid symmetric key. The parameter "k" is missing');
+
+        // When
+        SymmetricKey::create([
+            SymmetricKey::TYPE => SymmetricKey::TYPE_OCT,
+            SymmetricKey::DATA_K => null,
+        ]);
+    }
+
+    /**
+     * RFC 9053, section 7.3 types "k" as a bstr, which is what k() has always returned.
+     */
+    #[Test]
+    #[DataProvider('getInvalidKeyValues')]
+    public function theKeyValueShallBeAByteString(mixed $k): void
+    {
+        // Then
+        static::expectException(InvalidArgumentException::class);
+        static::expectExceptionMessage('Invalid symmetric key. The parameter "k" shall be a byte string');
+
+        // When
+        SymmetricKey::create([
+            SymmetricKey::TYPE => SymmetricKey::TYPE_OCT,
+            SymmetricKey::DATA_K => $k,
+        ]);
+    }
+
+    #[Test]
+    public function theKeyValueShallNotBeEmpty(): void
+    {
+        // Then
+        static::expectException(InvalidArgumentException::class);
+        static::expectExceptionMessage('Invalid symmetric key. The parameter "k" is empty');
+
+        // When
+        SymmetricKey::create([
+            SymmetricKey::TYPE => SymmetricKey::TYPE_OCT,
+            SymmetricKey::DATA_K => '',
+        ]);
+    }
+
+    #[Test]
+    public function theCreationFromDataAppliesTheSameChecks(): void
+    {
+        // Then
+        static::expectException(InvalidArgumentException::class);
+        static::expectExceptionMessage('Invalid symmetric key. The parameter "k" is empty');
+
+        // When
+        Key::createFromData([
+            Key::TYPE => '4',
+            SymmetricKey::DATA_K => '',
+        ]);
+    }
+
+    /**
+     * @return iterable<array{0: mixed}>
+     */
+    public static function getInvalidKeyValues(): iterable
+    {
+        yield 'array' => [[
+            'k' => str_repeat("\x2a", 32),
+        ]];
+        yield 'integer' => [123];
+        yield 'false' => [false];
+        yield 'true' => [true];
+        yield 'float' => [1.5];
+        yield 'CBOR object' => [ByteStringObject::create(str_repeat("\x2a", 32))];
+    }
+}

--- a/tests/Key/SymmetricKeyValidatorTest.php
+++ b/tests/Key/SymmetricKeyValidatorTest.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cose\Tests\Key;
+
+use Cose\Algorithm\Mac\HS256;
+use Cose\Algorithm\Mac\HS384;
+use Cose\Algorithm\Mac\HS512;
+use Cose\Key\Key;
+use Cose\Key\OkpKey;
+use Cose\Key\SymmetricKey;
+use Cose\Key\SymmetricKeyValidator;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use function str_repeat;
+
+/**
+ * @internal
+ */
+final class SymmetricKeyValidatorTest extends TestCase
+{
+    #[Test]
+    public function aKeyOfTheDefaultMinimumLengthIsAccepted(): void
+    {
+        // Given
+        $key = self::key(32);
+
+        // When
+        SymmetricKeyValidator::create()->check($key);
+
+        // Then
+        static::assertTrue(SymmetricKeyValidator::create()->isValid($key));
+        static::assertSame(32, SymmetricKeyValidator::keyLength($key));
+    }
+
+    #[Test]
+    public function aShorterKeyIsRejected(): void
+    {
+        // Then
+        static::expectException(InvalidArgumentException::class);
+        static::expectExceptionMessage('The key is 31 bytes long; at least 32 bytes are required');
+
+        // When
+        SymmetricKeyValidator::create()->check(self::key(31));
+    }
+
+    #[Test]
+    public function aShorterKeyIsNotValid(): void
+    {
+        // Then
+        static::assertFalse(SymmetricKeyValidator::create()->isValid(self::key(31)));
+    }
+
+    /**
+     * The minimum that matches an algorithm is the output length of its hash function.
+     */
+    #[Test]
+    #[DataProvider('getAlgorithmMinimums')]
+    public function theMinimumCanBeTakenFromTheAlgorithm(int $minimumKeyLength): void
+    {
+        // Given
+        $validator = SymmetricKeyValidator::create($minimumKeyLength);
+
+        // Then
+        static::assertTrue($validator->isValid(self::key($minimumKeyLength)));
+        static::assertFalse($validator->isValid(self::key($minimumKeyLength - 1)));
+    }
+
+    #[Test]
+    public function theMinimumLengthShallBePositive(): void
+    {
+        // Then
+        static::expectException(InvalidArgumentException::class);
+        static::expectExceptionMessage('The minimum key length shall be a positive integer');
+
+        // When
+        SymmetricKeyValidator::create(0);
+    }
+
+    #[Test]
+    public function theKeyTypeShallBeSymmetric(): void
+    {
+        // Then
+        static::expectException(InvalidArgumentException::class);
+        static::expectExceptionMessage('Invalid key. Must be of type symmetric');
+
+        // Given
+        $key = OkpKey::create([
+            OkpKey::TYPE => OkpKey::TYPE_OKP,
+            OkpKey::DATA_CURVE => OkpKey::CURVE_X25519,
+            OkpKey::DATA_X => str_repeat("\0", 32),
+        ]);
+
+        // When
+        SymmetricKeyValidator::create()->check($key);
+    }
+
+    /**
+     * The generic Key class does not go through the SymmetricKey constructor, so the validator applies the byte
+     * string contract itself.
+     */
+    #[Test]
+    #[DataProvider('getUnusableKeyValues')]
+    public function anUnusableKeyValueIsRejected(mixed $k, string $expectedMessage): void
+    {
+        // Then
+        static::expectException(InvalidArgumentException::class);
+        static::expectExceptionMessage($expectedMessage);
+
+        // Given
+        $key = Key::create([
+            Key::TYPE => Key::TYPE_OCT,
+            SymmetricKey::DATA_K => $k,
+        ]);
+
+        // When
+        SymmetricKeyValidator::checkKeyValue($key);
+    }
+
+    #[Test]
+    public function aMissingKeyValueIsRejected(): void
+    {
+        // Then
+        static::expectException(InvalidArgumentException::class);
+        static::expectExceptionMessage('Invalid key. The value of the key is missing');
+
+        // When
+        SymmetricKeyValidator::checkKeyValue(Key::create([
+            Key::TYPE => Key::TYPE_OCT,
+        ]));
+    }
+
+    #[Test]
+    public function aUsableKeyValuePassesTheKeyValueCheck(): void
+    {
+        // Given
+        $key = self::key(1);
+
+        // When
+        SymmetricKeyValidator::checkKeyValue($key);
+
+        // Then
+        static::assertSame(1, SymmetricKeyValidator::keyLength($key));
+    }
+
+    /**
+     * @return iterable<array{0: int}>
+     */
+    public static function getAlgorithmMinimums(): iterable
+    {
+        yield 'HS256' => [HS256::create()->minimumKeyLength()];
+        yield 'HS384' => [HS384::create()->minimumKeyLength()];
+        yield 'HS512' => [HS512::create()->minimumKeyLength()];
+    }
+
+    /**
+     * @return iterable<array{0: mixed, 1: string}>
+     */
+    public static function getUnusableKeyValues(): iterable
+    {
+        yield 'null' => [null, 'Invalid key. The value of the key must be a byte string'];
+        yield 'array' => [[
+            'k' => 'secret',
+        ], 'Invalid key. The value of the key must be a byte string'];
+        yield 'integer' => [123, 'Invalid key. The value of the key must be a byte string'];
+        yield 'empty string' => ['', 'Invalid key. The value of the key is empty'];
+    }
+
+    private static function key(int $length): SymmetricKey
+    {
+        return SymmetricKey::create([
+            SymmetricKey::TYPE => SymmetricKey::TYPE_OCT,
+            SymmetricKey::DATA_K => str_repeat("\x2a", $length),
+        ]);
+    }
+}


### PR DESCRIPTION
Fixes #168.

`Cose\Algorithm\Mac\Hmac` checked the key *type* only. The value of `k` was cast with `(string)` and handed to
`hash_hmac()`, so an empty key, a `null` reaching the generic `Key` class, an array, a bool, a number or a
`CBOR\ByteStringObject` were all accepted, and the MAC was keyed with a constant an outsider can guess (`"Array"`,
`"1"`, `""`). [RFC 9053, section 3.1](https://www.rfc-editor.org/rfc/rfc9053#section-3.1) requires implementations
"creating and validating MAC values" to validate the key type, the **key length** and the algorithm; section 7.3
types `k` as a `bstr`.

## What changed

**Hard rejection (never a legitimate key):** `hash()` and `verify()` throw an `InvalidArgumentException` when `k` is
not a PHP string or is empty; the `(string)` cast is gone, which also closes the `null` path through
`Key::create()`. `SymmetricKey::__construct()` applies the same contract, i.e. the one its own `k(): string`
accessor has always defined, where the mistake is easiest to attribute.

**Warning + acknowledgement (a policy call):** a key shorter than the output of the hash function is only "strongly
discouraged" by [RFC 2104, section 3](https://www.rfc-editor.org/rfc/rfc2104#section-3), and deployments — including
this library's own HS384/HS512 vectors — do key them with 32 bytes. Such a key stays accepted and emits an
`E_USER_WARNING` at each `hash()`/`verify()` call, unless the algorithm is created with `acknowledgeShortKey: true`.
Same shape as `RS1::create(acknowledgeInsecureAlgorithm: true)`; the next major version will throw instead.

```php
$algorithm = HS512::create(acknowledgeShortKey: true); // no warning for a 32-byte key
```

**New, opt-in:** `Hmac::minimumKeyLength()` returns the hash output length (32, 48 or 64), and
`Cose\Key\SymmetricKeyValidator` gives symmetric keys the strictness `RsaKeyValidator` gives RSA moduli, for callers
who want a short key to fail hard today:

```php
SymmetricKeyValidator::create($algorithm->minimumKeyLength())->check($key);
$isAcceptable = SymmetricKeyValidator::create()->isValid($key);
```

It accepts any `Key`, because `Key::create()` and `Key::createFromData()` with an integer `kty` never go through the
`SymmetricKey` constructor.

## Backward compatibility

No signature changes: every constructor and factory keeps working with no argument, and `acknowledgeShortKey` is a
defaulted parameter. What changes is that keys which were silently accepted and are unusable as HMAC keys — a
non-string or empty `k` — now throw instead of failing open, and a short key warns. That is the point of the fix.

## Tests

`tests/Algorithm/Mac/HmacTest.php` covers, for the four algorithms: the rejection of `''`, `null`, arrays, bools,
numbers and `ByteStringObject` (both through `SymmetricKey::create()` and through the generic `Key` path), one
`E_USER_WARNING` carrying `Hmac::SHORT_KEY_MESSAGE` for a key one byte short of the hash output, none for a key of
exactly that length or with the acknowledgement, and new vectors with 48- and 64-byte keys. The pre-existing 32-byte
HS384/HS512 vectors are kept and now created with `acknowledgeShortKey: true`, as the regression test of that path.
`tests/Key/SymmetricKeyTest.php` and `tests/Key/SymmetricKeyValidatorTest.php` are new.

534 tests / 1947 assertions pass; PHPStan (one now-stale baseline entry for the removed cast dropped), ECS, Rector
and Deptrac are clean. The reproduction script of the issue was run against the branch: parts 1 and 2 now throw for
every empty, `null` and non-string key, and the 1-byte keys warn with the documented message.

README.md and doc/Usage.md document the `k` contract, the warning and the validator.
