### PR TITLE
feat(rsa): apply the RFC 8230 minimum modulus length by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,10 +243,45 @@ The modulus length is a different matter. [RFC 8812](https://datatracker.ietf.or
 [RFC 8230, section 6.1](https://www.rfc-editor.org/rfc/rfc8230#section-6.1), which requires a modulus of 2048 bits or
 larger and expects implementations to handle up to 16K bits.
 
-The upper bounds are applied automatically: every RSA algorithm rejects a key whose modulus is longer than 16384 bits
-or whose public exponent is longer than 256 bits, before it computes anything with it. `verify()` returns `false` for
-such a key and `sign()` throws. The **minimum** modulus length is a policy decision and stays opt-in, because some
-deployments have to accept legacy sizes; run it explicitly on a key before handing it to an algorithm:
+Both bounds are applied automatically, before the algorithm computes anything with the key.
+
+The **upper** bounds are not negotiable: every RSA algorithm rejects a key whose modulus is longer than 16384 bits or
+whose public exponent is longer than 256 bits. `verify()` returns `false` for such a key and `sign()` throws.
+
+The **minimum** modulus length is applied too, with `RsaKeyValidator::create()`, so that nothing has to be done to
+get the bound RFC 8230 requires. Because legacy authenticators holding 1024 bit keys still exist, a key below it only
+emits an `E_USER_WARNING` for now:
+
+```php
+use Cose\Algorithm\Signature\RSA\RS256;
+
+// Warns: "The RSA key does not satisfy RFC 8230 section 6.1: The modulus of the key is 1024 bits long; …"
+// The signature is still verified, so no deployment breaks on upgrade.
+$isValid = RS256::create()->verify($data, $weakKey, $signature);
+```
+
+As of the next major version, that warning becomes an `InvalidArgumentException` on `sign()` and a `false` on
+`verify()`.
+
+To keep accepting weaker keys, hand the algorithm a validator carrying the bound you actually accept. Writing the
+bound down is the acknowledgement: a key below *it* is still refused, right away and with an exception, because you
+chose that bound.
+
+```php
+use Cose\Algorithm\Signature\RSA\RS256;
+use Cose\Key\RsaKeyValidator;
+
+// 1024 bit keys accepted silently; 512 bit ones still rejected
+$algorithm = RS256::create(RsaKeyValidator::create(minimumModulusLength: 1024));
+
+// The other way round: a stricter policy than the RFC, enforced now rather than in the next major version
+$algorithm = RS256::create(RsaKeyValidator::create(minimumModulusLength: 3072, maximumModulusLength: 8192));
+```
+
+Every RSA algorithm takes it: `RS256`, `RS384`, `RS512`, `PS256`, `PS384` and `PS512` as their only argument, `RS1`
+after its `acknowledgeInsecureAlgorithm` flag — `RS1::create(true, RsaKeyValidator::create(minimumModulusLength: 1024))`.
+
+The validator can also be run on its own, on a key you are about to store:
 
 ```php
 use Cose\Key\RsaKey;
@@ -261,9 +296,6 @@ RsaKeyValidator::create()->check($key);
 if (! RsaKeyValidator::create()->isValid($key)) {
     // reject the key
 }
-
-// The bounds can be tightened
-RsaKeyValidator::create(minimumModulusLength: 3072, maximumModulusLength: 8192)->check($key);
 ```
 
 `check()` and `isValid()` also cover the public parameter constraints described above. They are available on their

--- a/doc/Usage.md
+++ b/doc/Usage.md
@@ -420,8 +420,34 @@ The upper bounds are applied automatically: every RSA algorithm rejects a key wh
 for such a key and `sign()` throws an `InvalidArgumentException`. The cost of an RSA operation grows with the size of
 the key it is given, and a verifier takes that key from whoever produced the message.
 
-The **minimum** modulus length is a policy decision and stays opt-in, so run it explicitly before handing a key to an
-algorithm:
+The **minimum** modulus length is applied automatically too, with `RsaKeyValidator::create()`. Because legacy
+authenticators holding 1024 bit keys still exist, a key below `RsaKeyValidator::MINIMUM_MODULUS_LENGTH` (2048) bits
+only emits an `E_USER_WARNING` — `RsaKeyValidator::WEAK_KEY_MESSAGE`, filled in with the reason — and the operation
+goes through. As of the next major version, that warning becomes an `InvalidArgumentException` on `sign()` and a
+`false` on `verify()`.
+
+A caller that has to accept weaker keys passes the algorithm a validator carrying the bound it accepts. That bound is
+enforced at once, with an exception, since the caller chose it; only the implicit default is on the warn-then-throw
+schedule.
+
+```php
+use Cose\Algorithm\Signature\RSA\PS256;
+use Cose\Algorithm\Signature\RSA\RS1;
+use Cose\Algorithm\Signature\RSA\RS256;
+use Cose\Key\RsaKeyValidator;
+
+// Legacy authenticators: 1024 bit keys accepted silently, anything below still rejected
+$algorithm = RS256::create(RsaKeyValidator::create(minimumModulusLength: 1024));
+$algorithm = PS256::create(RsaKeyValidator::create(minimumModulusLength: 1024));
+
+// RS1 keeps its acknowledgement flag first
+$algorithm = RS1::create(true, RsaKeyValidator::create(minimumModulusLength: 1024));
+
+// A policy stricter than the RFC, enforced now rather than in the next major version
+$algorithm = RS256::create(RsaKeyValidator::create(minimumModulusLength: 3072, maximumModulusLength: 8192));
+```
+
+The validator can also be run on its own, on a key you are about to store:
 
 ```php
 use Cose\Key\RsaKey;
@@ -434,9 +460,6 @@ RsaKeyValidator::create()->check($key);
 
 // …or ask without the exception
 $isAcceptable = RsaKeyValidator::create()->isValid($key);
-
-// The bounds can be tightened
-RsaKeyValidator::create(minimumModulusLength: 3072, maximumModulusLength: 8192)->check($key);
 
 // The modulus and exponent lengths, in bits, are available on their own
 $modulusLength = RsaKeyValidator::modulusLength($key);

--- a/src/Algorithm/Signature/RSA/PS256.php
+++ b/src/Algorithm/Signature/RSA/PS256.php
@@ -5,14 +5,15 @@ declare(strict_types=1);
 namespace Cose\Algorithm\Signature\RSA;
 
 use Cose\Hash;
+use Cose\Key\RsaKeyValidator;
 
 final class PS256 extends PSSRSA
 {
     public const ID = -37;
 
-    public static function create(): self
+    public static function create(?RsaKeyValidator $keyValidator = null): self
     {
-        return new self();
+        return new self($keyValidator);
     }
 
     public static function identifier(): int

--- a/src/Algorithm/Signature/RSA/PS384.php
+++ b/src/Algorithm/Signature/RSA/PS384.php
@@ -5,14 +5,15 @@ declare(strict_types=1);
 namespace Cose\Algorithm\Signature\RSA;
 
 use Cose\Hash;
+use Cose\Key\RsaKeyValidator;
 
 final class PS384 extends PSSRSA
 {
     public const ID = -38;
 
-    public static function create(): self
+    public static function create(?RsaKeyValidator $keyValidator = null): self
     {
-        return new self();
+        return new self($keyValidator);
     }
 
     public static function identifier(): int

--- a/src/Algorithm/Signature/RSA/PS512.php
+++ b/src/Algorithm/Signature/RSA/PS512.php
@@ -5,14 +5,15 @@ declare(strict_types=1);
 namespace Cose\Algorithm\Signature\RSA;
 
 use Cose\Hash;
+use Cose\Key\RsaKeyValidator;
 
 final class PS512 extends PSSRSA
 {
     public const ID = -39;
 
-    public static function create(): self
+    public static function create(?RsaKeyValidator $keyValidator = null): self
     {
-        return new self();
+        return new self($keyValidator);
     }
 
     public static function identifier(): int

--- a/src/Algorithm/Signature/RSA/PSSRSA.php
+++ b/src/Algorithm/Signature/RSA/PSSRSA.php
@@ -41,6 +41,8 @@ use Throwable;
  * on the public exponent, and the primitives of section 5.2 are modular exponentiations whose cost is proportional to
  * the size of both - which a verifier takes from whoever produced the message. RFC 8230, section 6.1 asks for the
  * bound: "It is highly recommended that checks on the key length be done before starting a cryptographic operation."
+ * The same section requires "a key size of 2048 bits or larger": that bound is applied by RsaKeyPolicy, with the
+ * validator this algorithm was created with or, by default, with RsaKeyValidator::create().
  *
  * @see https://www.rfc-editor.org/rfc/rfc8017#section-8.1
  * @see https://www.rfc-editor.org/rfc/rfc8230#section-6.1
@@ -49,11 +51,19 @@ use Throwable;
  */
 abstract class PSSRSA implements Signature
 {
+    use RsaKeyPolicy;
+
+    public function __construct(?RsaKeyValidator $keyValidator = null)
+    {
+        $this->initializeKeyValidator($keyValidator);
+    }
+
     public function sign(string $data, Key $key): string
     {
         $key = $this->handleKey($key);
         RsaKeyValidator::checkPublicParameters($key);
         RsaKeyValidator::checkLengthBounds($key);
+        $this->checkKeyPolicy($key);
         if (! $key->isPrivate()) {
             throw new InvalidArgumentException('The key is not private.');
         }
@@ -83,6 +93,9 @@ abstract class PSSRSA implements Signature
             // signature, per the contract of Signature::verify().
             RsaKeyValidator::checkPublicParameters($key);
             RsaKeyValidator::checkLengthBounds($key);
+            // A key below the bound the caller asked for is a key it declared it does not verify with, which is an
+            // invalid signature rather than an error here too. The implicit default only warns.
+            $this->checkKeyPolicy($key);
         } catch (InvalidArgumentException) {
             return false;
         }
@@ -121,12 +134,14 @@ abstract class PSSRSA implements Signature
      * The operation is selected from the key: RSASP1 (RFC 8017, section 5.2.1) for a private key, RSAVP1 (section
      * 5.2.2) for a public one.
      *
-     * @throws InvalidArgumentException when the public parameters of the key are not those of a valid RSA key
+     * @throws InvalidArgumentException when the public parameters of the key are not those of a valid RSA key, or
+     *                                  when it is rejected by the validator this algorithm was created with
      */
     public function exponentiate(RsaKey $key, BigInteger $c): BigInteger
     {
         RsaKeyValidator::checkPublicParameters($key);
         RsaKeyValidator::checkLengthBounds($key);
+        $this->checkKeyPolicy($key);
 
         return $key->isPrivate() ? $this->rsasp1($key, $c) : $this->rsavp1($key, $c);
     }

--- a/src/Algorithm/Signature/RSA/RS1.php
+++ b/src/Algorithm/Signature/RSA/RS1.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Cose\Algorithm\Signature\RSA;
 
+use Cose\Key\RsaKeyValidator;
 use const E_USER_WARNING;
 use const OPENSSL_ALGO_SHA1;
 use function trigger_error;
@@ -28,16 +29,19 @@ final class RS1 extends RSA
 
     public const INSECURE_ALGORITHM_MESSAGE = 'The algorithm RS1 (RSASSA-PKCS1-v1_5 with SHA-1) is not secure and shall only be used to verify signatures produced by legacy authenticators. If you know what you are doing, create it with "acknowledgeInsecureAlgorithm: true"; as of v5.0.0, omitting that acknowledgement will throw an exception.';
 
-    public function __construct(bool $acknowledgeInsecureAlgorithm = false)
+    public function __construct(bool $acknowledgeInsecureAlgorithm = false, ?RsaKeyValidator $keyValidator = null)
     {
+        parent::__construct($keyValidator);
         if (! $acknowledgeInsecureAlgorithm) {
             trigger_error(self::INSECURE_ALGORITHM_MESSAGE, E_USER_WARNING);
         }
     }
 
-    public static function create(bool $acknowledgeInsecureAlgorithm = false): self
-    {
-        return new self($acknowledgeInsecureAlgorithm);
+    public static function create(
+        bool $acknowledgeInsecureAlgorithm = false,
+        ?RsaKeyValidator $keyValidator = null
+    ): self {
+        return new self($acknowledgeInsecureAlgorithm, $keyValidator);
     }
 
     public static function identifier(): int

--- a/src/Algorithm/Signature/RSA/RS256.php
+++ b/src/Algorithm/Signature/RSA/RS256.php
@@ -4,15 +4,16 @@ declare(strict_types=1);
 
 namespace Cose\Algorithm\Signature\RSA;
 
+use Cose\Key\RsaKeyValidator;
 use const OPENSSL_ALGO_SHA256;
 
 final class RS256 extends RSA
 {
     public const ID = -257;
 
-    public static function create(): self
+    public static function create(?RsaKeyValidator $keyValidator = null): self
     {
-        return new self();
+        return new self($keyValidator);
     }
 
     public static function identifier(): int

--- a/src/Algorithm/Signature/RSA/RS384.php
+++ b/src/Algorithm/Signature/RSA/RS384.php
@@ -4,15 +4,16 @@ declare(strict_types=1);
 
 namespace Cose\Algorithm\Signature\RSA;
 
+use Cose\Key\RsaKeyValidator;
 use const OPENSSL_ALGO_SHA384;
 
 final class RS384 extends RSA
 {
     public const ID = -258;
 
-    public static function create(): self
+    public static function create(?RsaKeyValidator $keyValidator = null): self
     {
-        return new self();
+        return new self($keyValidator);
     }
 
     public static function identifier(): int

--- a/src/Algorithm/Signature/RSA/RS512.php
+++ b/src/Algorithm/Signature/RSA/RS512.php
@@ -4,15 +4,16 @@ declare(strict_types=1);
 
 namespace Cose\Algorithm\Signature\RSA;
 
+use Cose\Key\RsaKeyValidator;
 use const OPENSSL_ALGO_SHA512;
 
 final class RS512 extends RSA
 {
     public const ID = -259;
 
-    public static function create(): self
+    public static function create(?RsaKeyValidator $keyValidator = null): self
     {
-        return new self();
+        return new self($keyValidator);
     }
 
     public static function identifier(): int

--- a/src/Algorithm/Signature/RSA/RSA.php
+++ b/src/Algorithm/Signature/RSA/RSA.php
@@ -26,17 +26,27 @@ use function openssl_verify;
  * Its length is bounded too, before it is used. RFC 8230, section 6.1 asks for it - "It is highly recommended that
  * checks on the key length be done before starting a cryptographic operation" - because the work an RSA operation
  * costs grows with the size of the key it is given, and a verifier takes that key from whoever produced the message.
+ * The same section requires "a key size of 2048 bits or larger": that bound is applied by RsaKeyPolicy, with the
+ * validator this algorithm was created with or, by default, with RsaKeyValidator::create().
  *
  * @see https://www.rfc-editor.org/rfc/rfc8017#section-8.2
  * @see \Cose\Tests\Algorithm\Signature\RSA\RSATest
  */
 abstract class RSA implements Signature
 {
+    use RsaKeyPolicy;
+
+    public function __construct(?RsaKeyValidator $keyValidator = null)
+    {
+        $this->initializeKeyValidator($keyValidator);
+    }
+
     public function sign(string $data, Key $key): string
     {
         $key = $this->handleKey($key);
         RsaKeyValidator::checkPublicParameters($key);
         RsaKeyValidator::checkLengthBounds($key);
+        $this->checkKeyPolicy($key);
         if (! $key->isPrivate()) {
             throw new InvalidArgumentException('The key is not private.');
         }
@@ -60,6 +70,9 @@ abstract class RSA implements Signature
         try {
             RsaKeyValidator::checkPublicParameters($key);
             RsaKeyValidator::checkLengthBounds($key);
+            // A key below the bound the caller asked for is a key it declared it does not verify with, which is an
+            // invalid signature rather than an error here too. The implicit default only warns.
+            $this->checkKeyPolicy($key);
         } catch (InvalidArgumentException) {
             // A key too large to compute with, or one that does not satisfy RFC 8017, section 3.1, is key material no
             // verification can be performed with: the contract of Signature::verify() reports it as an invalid

--- a/src/Algorithm/Signature/RSA/RsaKeyPolicy.php
+++ b/src/Algorithm/Signature/RSA/RsaKeyPolicy.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cose\Algorithm\Signature\RSA;
+
+use Cose\Key\RsaKey;
+use Cose\Key\RsaKeyValidator;
+use const E_USER_WARNING;
+use InvalidArgumentException;
+use function sprintf;
+use function trigger_error;
+
+/**
+ * The minimum modulus length every RSA algorithm of this library applies to the keys it is given.
+ *
+ * RFC 8230, section 6.1 - to which RFC 8812 defers for the WebAuthn registrations - states that "a key size of 2048
+ * bits or larger MUST be used with these algorithms" and that "it is highly recommended that checks on the key length
+ * be done before starting a cryptographic operation". That recommendation is addressed to the component performing
+ * the operation, which is this library, so RsaKeyValidator::create() is applied by default rather than left to the
+ * caller.
+ *
+ * Legacy authenticators holding 1024 bit keys exist, so the default bound cannot be enforced with an exception
+ * without breaking them: it emits an E_USER_WARNING in 4.x and will throw as of v5.0.0, following the schedule RS1
+ * already uses. A caller who has to accept a weaker key says so by handing the algorithm a validator of its own -
+ * RsaKeyValidator::create(minimumModulusLength: 1024) - which both records the bound actually accepted and applies it
+ * immediately, with an exception, instead of silencing the check altogether.
+ *
+ * Only the *minimum* modulus length goes through here. The public parameter constraints of RFC 8017, section 3.1 and
+ * the upper bounds on the size of the key are not a policy and are applied unconditionally by the algorithms
+ * themselves, before this check runs; nothing a validator rejects here has been left unchecked by them.
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc8230#section-6.1
+ *
+ * @internal
+ */
+trait RsaKeyPolicy
+{
+    private RsaKeyValidator $keyValidator;
+
+    /**
+     * Whether the validator was chosen by the caller, in which case the bound it carries is enforced with an
+     * exception, as opposed to the implicit default, which only warns until v5.0.0.
+     */
+    private bool $keyValidatorIsExplicit;
+
+    private function initializeKeyValidator(?RsaKeyValidator $keyValidator): void
+    {
+        $this->keyValidatorIsExplicit = $keyValidator !== null;
+        $this->keyValidator = $keyValidator ?? RsaKeyValidator::create();
+    }
+
+    /**
+     * @throws InvalidArgumentException when the key is rejected by a validator the caller provided
+     */
+    private function checkKeyPolicy(RsaKey $key): void
+    {
+        if (! isset($this->keyValidator)) {
+            // Both abstract classes gained their constructor in 4.8.0: an algorithm extending one of them from
+            // outside this library and overriding it without calling the parent gets the default rather than an
+            // error on an uninitialised property.
+            $this->initializeKeyValidator(null);
+        }
+
+        try {
+            $this->keyValidator->check($key);
+        } catch (InvalidArgumentException $exception) {
+            if ($this->keyValidatorIsExplicit) {
+                throw $exception;
+            }
+            trigger_error(
+                sprintf(RsaKeyValidator::WEAK_KEY_MESSAGE, $exception->getMessage()),
+                E_USER_WARNING
+            );
+        }
+    }
+}

--- a/src/Key/RsaKeyValidator.php
+++ b/src/Key/RsaKeyValidator.php
@@ -26,8 +26,11 @@ use Throwable;
  * (checkLengthBounds()). Neither depends on a policy - an RSA operation costs an amount of CPU proportional to the
  * size of the key it is given, and that key is attacker supplied whenever it comes from the wire.
  *
- * The *minimum* modulus length is the policy choice, and it remains opt-in: run check() or isValid() explicitly on a
- * key before handing it to an algorithm to apply it.
+ * The *minimum* modulus length is the policy choice, and the algorithms apply it too: each of them runs check() on
+ * every key it is handed, with the validator it was created with or, by default, with create(). Legacy
+ * authenticators holding 1024 bit keys exist, so the default bound only emits an E_USER_WARNING in 4.x and will
+ * throw as of v5.0.0; a validator passed explicitly to the algorithm - RS256::create(RsaKeyValidator::create(
+ * minimumModulusLength: 1024)) - is enforced with an exception right away, because the caller chose the bound.
  *
  * Every check below reads the parameters as the octet strings they are. Turning one into a number is a base
  * conversion, and brick/math falls back to a pure PHP calculator - whose generic base conversion is superlinear -
@@ -60,6 +63,14 @@ final class RsaKeyValidator
      * bound allows.
      */
     public const MAXIMUM_EXPONENT_LENGTH = 256;
+
+    /**
+     * The warning an RSA algorithm emits when the key it is given is rejected by the validator it defaulted to. Its
+     * only placeholder receives the message of the underlying InvalidArgumentException.
+     *
+     * @see \Cose\Algorithm\Signature\RSA\RsaKeyPolicy
+     */
+    public const WEAK_KEY_MESSAGE = 'The RSA key does not satisfy RFC 8230 section 6.1: %s. If you must accept such keys, for instance those of legacy authenticators, create the algorithm with an explicit validator such as "RsaKeyValidator::create(minimumModulusLength: 1024)"; as of v5.0.0, this key will be rejected with an exception.';
 
     private function __construct(
         private readonly int $minimumModulusLength,

--- a/src/Key/RsaKeyValidator.php
+++ b/src/Key/RsaKeyValidator.php
@@ -70,7 +70,7 @@ final class RsaKeyValidator
      *
      * @see \Cose\Algorithm\Signature\RSA\RsaKeyPolicy
      */
-    public const WEAK_KEY_MESSAGE = 'The RSA key does not satisfy RFC 8230 section 6.1: %s. If you must accept such keys, for instance those of legacy authenticators, create the algorithm with an explicit validator such as "RsaKeyValidator::create(minimumModulusLength: 1024)"; as of v5.0.0, this key will be rejected with an exception.';
+    public const WEAK_KEY_MESSAGE = 'The RSA key does not satisfy RFC 8230 section 6.1: %s. Accept it explicitly with "RsaKeyValidator::create(minimumModulusLength: 1024)"; as of v5.0.0, it will be rejected with an exception.';
 
     private function __construct(
         private readonly int $minimumModulusLength,

--- a/tests/Algorithm/Signature/RSA/PSSRSATest.php
+++ b/tests/Algorithm/Signature/RSA/PSSRSATest.php
@@ -11,6 +11,7 @@ use Cose\Algorithm\Signature\RSA\PS512;
 use Cose\Algorithm\Signature\RSA\PSSRSA;
 use Cose\BigInteger;
 use Cose\Key\RsaKey;
+use Cose\Key\RsaKeyValidator;
 use const E_DEPRECATED;
 use const E_USER_DEPRECATED;
 use InvalidArgumentException;
@@ -255,7 +256,7 @@ final class PSSRSATest extends TestCase
     public function theSmallestModulusPs512CanEncodeIsAccepted(): void
     {
         // Given
-        $algorithm = PS512::create();
+        $algorithm = PS512::create(RsaKeyValidator::create(minimumModulusLength: 1024));
         $key = RsaKeys::shortPrivateKey();
         $opensslSignature = base64_decode(
             'Oy42J6jxml86dEe/FiZIm9gDfMOfuTslnxxgilfSISCc25xDwiy7VQlddqljAwh7BsO9INIXl/Aeu2RztLIEYobHQbJXvyuf' .
@@ -282,7 +283,7 @@ final class PSSRSATest extends TestCase
         $this->expectExceptionMessage('the modulus is too short for this hash and salt length');
 
         // When
-        PS512::create()
+        PS512::create(RsaKeyValidator::create(minimumModulusLength: 1024))
             ->sign(self::MESSAGE, $key)
         ;
     }

--- a/tests/Algorithm/Signature/RSA/RSATest.php
+++ b/tests/Algorithm/Signature/RSA/RSATest.php
@@ -15,6 +15,7 @@ use Cose\Algorithm\Signature\RSA\RS384;
 use Cose\Algorithm\Signature\RSA\RS512;
 use Cose\Algorithm\Signature\RSA\RSA;
 use Cose\Key\RsaKey;
+use Cose\Key\RsaKeyValidator;
 use InvalidArgumentException;
 use const OPENSSL_KEYTYPE_RSA;
 use function openssl_pkey_get_details;
@@ -117,7 +118,9 @@ final class RSATest extends TestCase
     public function signingWithAModulusTooShortForTheDigestIsRejected(): void
     {
         // Given
-        $algorithm = RS512::create();
+        // The bound of RFC 8230 section 6.1 is declared away so that the failure under test is the one openssl_sign()
+        // reports, not the policy check that now precedes it.
+        $algorithm = RS512::create(RsaKeyValidator::create(minimumModulusLength: 512));
         $key = self::generatedKey(512);
 
         // Then

--- a/tests/Algorithm/Signature/RSA/RsaKeyPolicyTest.php
+++ b/tests/Algorithm/Signature/RSA/RsaKeyPolicyTest.php
@@ -1,0 +1,402 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cose\Tests\Algorithm\Signature\RSA;
+
+use Cose\Algorithm\Manager;
+use Cose\Algorithm\Signature\RSA\PS256;
+use Cose\Algorithm\Signature\RSA\PS384;
+use Cose\Algorithm\Signature\RSA\PS512;
+use Cose\Algorithm\Signature\RSA\RS1;
+use Cose\Algorithm\Signature\RSA\RS256;
+use Cose\Algorithm\Signature\RSA\RS384;
+use Cose\Algorithm\Signature\RSA\RS512;
+use Cose\Algorithm\Signature\RSA\RSA;
+use Cose\Algorithm\Signature\Signature;
+use Cose\BigInteger;
+use Cose\Key\RsaKeyValidator;
+use const E_USER_WARNING;
+use InvalidArgumentException;
+use const OPENSSL_ALGO_SHA256;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\WithoutErrorHandler;
+use PHPUnit\Framework\TestCase;
+use function restore_error_handler;
+use function set_error_handler;
+use function sprintf;
+
+/**
+ * The minimum modulus length of RFC 8230 section 6.1, as the RSA algorithms apply it.
+ *
+ * "A key size of 2048 bits or larger MUST be used with these algorithms", and "it is highly recommended that checks
+ * on the key length be done before starting a cryptographic operation". The bound is applied by default, but only as
+ * an E_USER_WARNING until v5.0.0, because the 1024 bit keys of legacy authenticators have to keep working; a caller
+ * who needs them says which bound it accepts by passing a validator of its own, and that one is enforced with an
+ * exception right away.
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc8230#section-6.1
+ * @see https://github.com/web-auth/cose-lib/issues/174
+ */
+final class RsaKeyPolicyTest extends TestCase
+{
+    private const MESSAGE = 'Live long and Prosper.';
+
+    /**
+     * @var array<int, array{severity: int, message: string}>
+     */
+    private array $capturedErrors = [];
+
+    #[Test]
+    #[WithoutErrorHandler]
+    #[DataProvider('getAlgorithms')]
+    public function aKeyBelowTheRfcMinimumIsSignedWithButWarnedAbout(Signature $algorithm): void
+    {
+        // Given
+        $key = RsaKeys::weakPrivateKey();
+        $this->captureErrors();
+
+        // When
+        $signature = $algorithm->sign(self::MESSAGE, $key);
+        restore_error_handler();
+
+        // Then
+        static::assertTrue(@$algorithm->verify(self::MESSAGE, $key->toPublic(), $signature));
+        static::assertCount(1, $this->capturedErrors);
+        static::assertSame(E_USER_WARNING, $this->capturedErrors[0]['severity']);
+        static::assertSame(
+            sprintf(RsaKeyValidator::WEAK_KEY_MESSAGE, 'The modulus of the key is 1024 bits long; at least 2048 bits are required'),
+            $this->capturedErrors[0]['message']
+        );
+    }
+
+    /**
+     * A verifier gets the very same signal, and it gets it for every assertion it verifies rather than once at
+     * registration: the key travels with the message.
+     */
+    #[Test]
+    #[WithoutErrorHandler]
+    #[DataProvider('getAlgorithms')]
+    public function aKeyBelowTheRfcMinimumIsVerifiedWithButWarnedAbout(Signature $algorithm): void
+    {
+        // Given
+        $key = RsaKeys::weakPrivateKey();
+        $signature = @$algorithm->sign(self::MESSAGE, $key);
+        $this->captureErrors();
+
+        // When
+        $isValid = $algorithm->verify(self::MESSAGE, $key->toPublic(), $signature);
+        $isTamperedValid = $algorithm->verify(self::MESSAGE . '!', $key->toPublic(), $signature);
+        restore_error_handler();
+
+        // Then
+        static::assertTrue($isValid);
+        static::assertFalse($isTamperedValid);
+        static::assertCount(2, $this->capturedErrors);
+        static::assertStringContainsString('1024 bits', $this->capturedErrors[0]['message']);
+        static::assertStringContainsString('1024 bits', $this->capturedErrors[1]['message']);
+    }
+
+    /**
+     * The way webauthn-lib resolves the algorithm of a credential.
+     */
+    #[Test]
+    #[WithoutErrorHandler]
+    public function theWarningReachesAVerifierGoingThroughTheAlgorithmManager(): void
+    {
+        // Given
+        $key = RsaKeys::weakPrivateKey();
+        $signature = @RS256::create()->sign(self::MESSAGE, $key);
+        $manager = Manager::create()->add(RS256::create());
+        $this->captureErrors();
+
+        // When
+        $isValid = $manager->get(RS256::ID)
+            ->verify(self::MESSAGE, $key->toPublic(), $signature)
+        ;
+        restore_error_handler();
+
+        // Then
+        static::assertTrue($isValid);
+        static::assertCount(1, $this->capturedErrors);
+        static::assertStringContainsString('1024 bits', $this->capturedErrors[0]['message']);
+    }
+
+    /**
+     * The escape hatch: the caller writes the bound it accepts down instead of switching the check off, so a key
+     * weaker than the one it meant to accept is still refused.
+     */
+    #[Test]
+    #[WithoutErrorHandler]
+    #[DataProvider('getAlgorithms')]
+    public function anExplicitValidatorAcceptingTheKeySilencesTheWarning(Signature $algorithm): void
+    {
+        // Given
+        $algorithm = self::withValidator($algorithm, RsaKeyValidator::create(minimumModulusLength: 1024));
+        $key = RsaKeys::weakPrivateKey();
+        $this->captureErrors();
+
+        // When
+        $signature = $algorithm->sign(self::MESSAGE, $key);
+        $isValid = $algorithm->verify(self::MESSAGE, $key->toPublic(), $signature);
+        restore_error_handler();
+
+        // Then
+        static::assertTrue($isValid);
+        static::assertSame([], $this->capturedErrors);
+    }
+
+    #[Test]
+    #[WithoutErrorHandler]
+    #[DataProvider('getAlgorithms')]
+    public function anExplicitValidatorRejectingTheKeyThrowsInsteadOfWarning(Signature $algorithm): void
+    {
+        // Given
+        $algorithm = self::withValidator($algorithm, RsaKeyValidator::create());
+        $key = RsaKeys::weakPrivateKey();
+        $this->captureErrors();
+
+        // When
+        try {
+            $algorithm->sign(self::MESSAGE, $key);
+            $thrown = null;
+        } catch (InvalidArgumentException $exception) {
+            $thrown = $exception;
+        }
+        restore_error_handler();
+
+        // Then
+        static::assertNotNull($thrown);
+        static::assertSame(
+            'The modulus of the key is 1024 bits long; at least 2048 bits are required',
+            $thrown->getMessage()
+        );
+        static::assertSame([], $this->capturedErrors);
+    }
+
+    /**
+     * Signature::verify() stays total: a key the caller declared it does not verify with is an invalid signature,
+     * exactly like a key above the upper bounds, and not an exception.
+     */
+    #[Test]
+    #[WithoutErrorHandler]
+    #[DataProvider('getAlgorithms')]
+    public function anExplicitValidatorRejectingTheKeyMakesVerificationFail(Signature $algorithm): void
+    {
+        // Given
+        $key = RsaKeys::weakPrivateKey();
+        $signature = @$algorithm->sign(self::MESSAGE, $key);
+        $strict = self::withValidator($algorithm, RsaKeyValidator::create());
+        $this->captureErrors();
+
+        // When
+        $isValid = $strict->verify(self::MESSAGE, $key->toPublic(), $signature);
+        restore_error_handler();
+
+        // Then
+        static::assertFalse($isValid);
+        static::assertSame([], $this->capturedErrors);
+    }
+
+    #[Test]
+    #[WithoutErrorHandler]
+    #[DataProvider('getAlgorithms')]
+    public function aCompliantKeyIsNeverWarnedAbout(Signature $algorithm): void
+    {
+        // Given
+        $key = RsaKeys::privateKey();
+        $this->captureErrors();
+
+        // When
+        $signature = $algorithm->sign(self::MESSAGE, $key);
+        $isValid = $algorithm->verify(self::MESSAGE, $key->toPublic(), $signature);
+        restore_error_handler();
+
+        // Then
+        static::assertTrue($isValid);
+        static::assertSame([], $this->capturedErrors);
+    }
+
+    /**
+     * The acknowledgement flag of RS1 keeps its place, so the algorithm can be created without warning about SHA-1
+     * and with a validator that accepts the keys of the very authenticators it exists for.
+     */
+    #[Test]
+    #[WithoutErrorHandler]
+    public function rs1KeepsItsAcknowledgementFlagFirst(): void
+    {
+        // Given
+        $this->captureErrors();
+
+        // When
+        $algorithm = RS1::create(true, RsaKeyValidator::create(minimumModulusLength: 1024));
+        $key = RsaKeys::weakPrivateKey();
+        $signature = $algorithm->sign(self::MESSAGE, $key);
+        restore_error_handler();
+
+        // Then
+        static::assertTrue($algorithm->verify(self::MESSAGE, $key->toPublic(), $signature));
+        static::assertSame([], $this->capturedErrors);
+    }
+
+    #[Test]
+    #[WithoutErrorHandler]
+    public function rs1StillWarnsAboutSha1WhenTheValidatorIsTheOnlyArgumentGiven(): void
+    {
+        // Given
+        $this->captureErrors();
+
+        // When
+        RS1::create(keyValidator: RsaKeyValidator::create(minimumModulusLength: 1024));
+        restore_error_handler();
+
+        // Then
+        static::assertCount(1, $this->capturedErrors);
+        static::assertSame(RS1::INSECURE_ALGORITHM_MESSAGE, $this->capturedErrors[0]['message']);
+    }
+
+    /**
+     * The primitive exposed on its own by PSSRSA::exponentiate() is a cryptographic operation too, so the bound is
+     * applied there as well.
+     */
+    #[Test]
+    #[WithoutErrorHandler]
+    public function theExponentiationPrimitiveAppliesThePolicy(): void
+    {
+        // Given
+        $key = RsaKeys::weakPrivateKey();
+        $message = BigInteger::createFromDecimal(2);
+        $this->captureErrors();
+
+        // When
+        PS256::create()
+            ->exponentiate($key, $message)
+        ;
+        restore_error_handler();
+
+        // Then
+        static::assertCount(1, $this->capturedErrors);
+        static::assertStringContainsString('1024 bits', $this->capturedErrors[0]['message']);
+
+        // Then, with a validator that refuses the key
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The modulus of the key is 1024 bits long');
+        PS256::create(RsaKeyValidator::create())
+            ->exponentiate($key, $message)
+        ;
+    }
+
+    /**
+     * The default of every algorithm is the bound of RFC 8230 section 6.1 itself.
+     */
+    #[Test]
+    #[WithoutErrorHandler]
+    #[DataProvider('getAlgorithms')]
+    public function theDefaultBoundIsTheOneOfTheRfc(Signature $algorithm): void
+    {
+        // Given
+        $key = RsaKeys::weakPrivateKey();
+        $atTheRfcBound = self::withValidator(
+            $algorithm,
+            RsaKeyValidator::create(minimumModulusLength: RsaKeyValidator::MINIMUM_MODULUS_LENGTH)
+        );
+        $this->captureErrors();
+
+        // When
+        try {
+            $atTheRfcBound->sign(self::MESSAGE, $key);
+            $thrown = null;
+        } catch (InvalidArgumentException $exception) {
+            $thrown = $exception;
+        }
+        restore_error_handler();
+
+        // Then
+        static::assertNotNull($thrown);
+        static::assertSame(2048, RsaKeyValidator::MINIMUM_MODULUS_LENGTH);
+        static::assertSame([], $this->capturedErrors);
+    }
+
+    /**
+     * Both abstract classes gained their constructor in 4.8.0. An algorithm extending one of them from outside this
+     * library, with a constructor of its own that predates it, keeps working and gets the default bound.
+     */
+    #[Test]
+    #[WithoutErrorHandler]
+    public function anAlgorithmNotCallingTheParentConstructorFallsBackToTheDefault(): void
+    {
+        // Given
+        $algorithm = new class() extends RSA {
+            public function __construct()
+            {
+                // No parent::__construct(), as a class written against 4.7 would have.
+            }
+
+            protected function getHashAlgorithm(): int
+            {
+                return OPENSSL_ALGO_SHA256;
+            }
+
+            public static function identifier(): int
+            {
+                return RS256::ID;
+            }
+        };
+        $key = RsaKeys::weakPrivateKey();
+        $this->captureErrors();
+
+        // When
+        $signature = $algorithm->sign(self::MESSAGE, $key);
+        restore_error_handler();
+
+        // Then
+        static::assertTrue(@$algorithm->verify(self::MESSAGE, $key->toPublic(), $signature));
+        static::assertCount(1, $this->capturedErrors);
+        static::assertStringContainsString('1024 bits', $this->capturedErrors[0]['message']);
+    }
+
+    /**
+     * @return iterable<string, array{Signature}>
+     */
+    public static function getAlgorithms(): iterable
+    {
+        yield 'RS1' => [RS1::create(acknowledgeInsecureAlgorithm: true)];
+        yield 'RS256' => [RS256::create()];
+        yield 'RS384' => [RS384::create()];
+        yield 'PS256' => [PS256::create()];
+        // RS512 and PS384 are the largest digests a 1024 bit modulus can still carry; PS512 cannot, and is covered by
+        // PSSRSATest instead.
+        yield 'RS512' => [RS512::create()];
+        yield 'PS384' => [PS384::create()];
+    }
+
+    /**
+     * Rebuilds the algorithm given by the data provider with a validator of its own.
+     */
+    private static function withValidator(Signature $algorithm, RsaKeyValidator $keyValidator): Signature
+    {
+        return match ($algorithm::class) {
+            RS1::class => RS1::create(true, $keyValidator),
+            RS256::class => RS256::create($keyValidator),
+            RS384::class => RS384::create($keyValidator),
+            RS512::class => RS512::create($keyValidator),
+            PS256::class => PS256::create($keyValidator),
+            PS384::class => PS384::create($keyValidator),
+            PS512::class => PS512::create($keyValidator),
+        };
+    }
+
+    private function captureErrors(): void
+    {
+        $this->capturedErrors = [];
+        set_error_handler(function (int $severity, string $message): bool {
+            $this->capturedErrors[] = [
+                'severity' => $severity,
+                'message' => $message,
+            ];
+
+            return true;
+        });
+    }
+}

--- a/tests/Algorithm/Signature/RSA/RsaKeys.php
+++ b/tests/Algorithm/Signature/RSA/RsaKeys.php
@@ -273,6 +273,33 @@ final class RsaKeys
     }
 
     /**
+     * A 1024 bit key: the size the legacy authenticators that RFC 8230 section 6.1 rules out still use. It is only
+     * ever handed to an algorithm created with an explicit RsaKeyValidator that accepts it.
+     */
+    public static function weakPrivateKey(): RsaKey
+    {
+        return RsaKey::create([
+            RsaKey::TYPE => RsaKey::TYPE_RSA,
+            RsaKey::DATA_N => base64_decode(
+                '4yULtdoMYDuRujvfpXRP4zeCM48BuVSvKxHFI8uDw6WsAf9qGJ1xDez5Y5P1+Kjk+FKo5DiuyUDu6aFjukvGJyAeuRQ0Pi6w' .
+                'jxh4+jJ2oJWSZovNbPC3Yrx5pyy8QiztxnjV1KgoruBcPEZUHeER6Z18cBFwzn6HyWTlBXV/RjM=',
+                true
+            ),
+            RsaKey::DATA_E => base64_decode('AQAB', true),
+            RsaKey::DATA_D => base64_decode(
+                'Jm4OHSZXEbECZs/adtPG8Fpj3PVFBWYefNr0z6mPEXrmLzBXcvKwPfrp9r8BzqBEnP7fND2i1Mn3oe98P/ix/Xr9cCWkil3f' .
+                'PdxtYszvYZ2NVHXdKZcfuNaTuEkzs1RfmWG8bqD7g4xUZHgPTzIjKhEkqNFK7vVUSNGPaHO11oE=',
+                true
+            ),
+            RsaKey::DATA_P => base64_decode('+UBB7ko1wbO7AkJp0RTlfCe6pF09rXPe5gi+je5AtCjRjavmkvQNgGLqh7NxLnLQ7OQhcCOhzj2ovFJr28LALw==', true),
+            RsaKey::DATA_Q => base64_decode('6UuNnGLUSJBSJ69g25sFymM8o237E8OzWI1hHlfgCeEVZU3BEx/Wwg2eS0j1EYFDEoR/n7y656A+E4Lai151PQ==', true),
+            RsaKey::DATA_DP => base64_decode('TEb15k6flN/D4zUf3PRgJlaiL5q5PVOwawVSC21WL8wuFQT+UwqM9zVOQKkRgf1xIo3ODdtZsRv9f2RZza8T0Q==', true),
+            RsaKey::DATA_DQ => base64_decode('wEE7Gj13o7ULfxjQQSmnw/mz5xqjZs5H5hnchxzzzDBpaWqCSjhayuBeKryc+SgFFiWK5yCpBmjPv1R+tYvKIQ==', true),
+            RsaKey::DATA_QI => base64_decode('vWLv8JJCKSiMF0N+31mfDYbTtLfdUSGl+g6WQyKUs62yOsvfBVQgDQ4gR85wl2U/wOctVZhptxI9Hta6XLA4SQ==', true),
+        ]);
+    }
+
+    /**
      * A 1040 bit key: the smallest modulus PS512 can encode (emLen == hLen + sLen + 2). Far below the RFC 8230
      * section 6.1 minimum, and only used to exercise that boundary.
      */

--- a/tests/Algorithm/Signature/RSA/RsaKeysTest.php
+++ b/tests/Algorithm/Signature/RSA/RsaKeysTest.php
@@ -124,6 +124,7 @@ final class RsaKeysTest extends TestCase
         yield 'padded modulus' => [RsaKeys::privateKeyWithPaddedModulus(), 2048];
         yield 'not byte aligned' => [RsaKeys::nonByteAlignedPrivateKey(), 2050];
         yield 'multi-prime' => [RsaKeys::multiPrimePrivateKey(), 2048];
+        yield 'weak' => [RsaKeys::weakPrivateKey(), 1024];
         yield 'short' => [RsaKeys::shortPrivateKey(), 1040];
         yield 'too short' => [RsaKeys::tooShortPrivateKey(), 1032];
     }


### PR DESCRIPTION
Closes #174

## Summary

RFC 8230 §6.1 — to which RFC 8812 defers for the WebAuthn registrations — states that *"a key size of 2048 bits or larger MUST be used with these algorithms"* and that *"it is highly recommended that checks on the key length be done before starting a cryptographic operation"*. That recommendation is addressed to the component performing the operation, i.e. this library.

`RsaKeyValidator` already carried the bound, but nothing in `src/` ran it: `RS1`, `RS256`, `RS384`, `RS512`, `PS256`, `PS384` and `PS512` signed and verified with any modulus the padding happened to fit — down to 512 bits for RS1/RS256 — and the primary consumer (`webauthn-lib`'s `CheckSignature`) never calls the validator either.

Every RSA algorithm now runs a validator on the key it is handed, in `sign()`, in `verify()` and in `PSSRSA::exponentiate()`.

## No BC break

Legacy WebAuthn authenticators holding 1024-bit keys exist, so the **implicit default** follows the schedule `RS1` already uses: an `E_USER_WARNING` now, an exception as of v5.0.0. Nothing that worked before stops working.

```
The RSA key does not satisfy RFC 8230 section 6.1: The modulus of the key is 1024 bits
long; at least 2048 bits are required. Accept it explicitly with
"RsaKeyValidator::create(minimumModulusLength: 1024)"; as of v5.0.0, it will be rejected
with an exception.
```

## New feature: the escape hatch is a validator, not a boolean

A bare `acknowledgeWeakKeys: true` would switch the check off entirely and let a 512-bit key through together with the 1024-bit one the caller actually wanted. Passing a validator makes the caller **write the bound down**, which is the acknowledgement the project's policy asks for — and that bound is then enforced at once, with an exception, because the caller chose it. Only the implicit default is on the warn-then-throw schedule.

```php
// Legacy authenticators: 1024 bit keys accepted silently, 512 bit ones still rejected
$algorithm = RS256::create(RsaKeyValidator::create(minimumModulusLength: 1024));

// RS1 keeps its acknowledgement flag first, so existing calls are untouched
$algorithm = RS1::create(true, RsaKeyValidator::create(minimumModulusLength: 1024));

// A policy stricter than the RFC, enforced now rather than in the next major version
$algorithm = RS256::create(RsaKeyValidator::create(minimumModulusLength: 3072, maximumModulusLength: 8192));
```

`sign()` throws and `verify()` returns `false`, exactly as they already do for the upper bounds, so `Signature::verify()` stays total.

## Changes

- **new** `Cose\Algorithm\Signature\RSA\RsaKeyPolicy` (`@internal` trait), shared by `RSA` and `PSSRSA`: holds the validator, throws when it was chosen by the caller, warns when it is the default. It also falls back to the default when a third-party subclass overrides the new constructor without calling the parent.
- `RSA` and `PSSRSA` gain `__construct(?RsaKeyValidator $keyValidator = null)` and run the check after the (unconditional, non-policy) RFC 8017 §3.1 and upper-bound checks — so a degenerate key is never reported twice, and the implicit warning only ever concerns the minimum modulus length.
- `RS256`, `RS384`, `RS512`, `PS256`, `PS384`, `PS512`: `create(?RsaKeyValidator $keyValidator = null)`.
- `RS1`: `create(bool $acknowledgeInsecureAlgorithm = false, ?RsaKeyValidator $keyValidator = null)`.
- **new** `RsaKeyValidator::WEAK_KEY_MESSAGE`, plus an updated class docblock.
- README and `doc/Usage.md`: the "Validating RSA Keys" sections no longer say the bound is the caller's job.

## Tests

New `tests/Algorithm/Signature/RSA/RsaKeyPolicyTest.php` (48 cases), plus a fixed 1024-bit `RsaKeys::weakPrivateKey()` fixture asserted by `RsaKeysTest` like every other one. It covers, for RS1/RS256/RS384/RS512/PS256/PS384:

- a 1024-bit key still signs and verifies, with exactly one `E_USER_WARNING` per call, on both paths and through `Manager::get()` (how webauthn-lib resolves the algorithm);
- `RsaKeyValidator::create(minimumModulusLength: 1024)` — accepted silently;
- `RsaKeyValidator::create()` passed explicitly — `InvalidArgumentException` on `sign()`, `false` on `verify()`, no warning, already in 4.x;
- a 2048-bit key — never warned about;
- `RS1::create(true, …)` still silent about SHA-1, `RS1::create(keyValidator: …)` still warns about it;
- `PSSRSA::exponentiate()` applies the policy too;
- a subclass with a pre-4.8 constructor gets the default bound instead of an uninitialised-property error.

The two existing sub-2048-bit `PSSRSATest` cases and the 512-bit `RSATest` one now declare their bound explicitly rather than lowering the default.

`519 tests, 1969 assertions` — PHPUnit, ECS, PHPStan, Rector and Deptrac all green.

## Upgrade note

> RSA algorithms now emit an `E_USER_WARNING` when the key is below 2048 bits, as RFC 8230 §6.1 requires. Pass an explicit `RsaKeyValidator` to the algorithm to accept such keys; from v5.0.0 the warning becomes an `InvalidArgumentException` on `sign()` and a `false` on `verify()`.

A follow-up in `webauthn-lib` should document that the default `CheckSignature` manager now warns on sub-2048-bit credentials, and how to build a `Manager` with `RS256::create(RsaKeyValidator::create(minimumModulusLength: 1024))` when legacy authenticators must keep working.
