### PR TITLE
fix(packaging): declare the cbor-php floor and fix the packaging and documentation defects of #171

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -23,6 +23,7 @@ such as fix tests, fix 2, fix 3, etc.
 Run test suite
 ------------
 
-* install composer: `curl -s http://getcomposer.org/installer | php`
-* install dependencies: `php composer.phar install`
-* run tests: `vendor/bin/phpunit`
+* install Composer with your distribution package manager, or follow https://getcomposer.org/download/ and verify the
+  SHA-384 of the installer before running it (never pipe the installer straight into `php`)
+* install dependencies: `composer install`
+* run tests: `composer test`, or `castor phpunit` to run them in the project QA container

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,5 +13,6 @@ Replace this comment by a description of what your PR is solving.
 
 Please consider the following requirement:
 * Modification of existing tests should be avoided unless deemed necessary.
-* You MUST never open a PR related to a security issue. Contact Spomky in private at https://gitter.im/Spomky/
+* You MUST never open a PR or an issue related to a security issue. Report it privately to security@spomky-labs.com
+  or through GitHub private vulnerability reporting (see SECURITY.md).
 -->

--- a/README.md
+++ b/README.md
@@ -44,8 +44,12 @@ composer require web-auth/cose-lib
 For COSE tag support (Sign, Encrypt, Mac operations), also install:
 
 ```bash
-composer require spomky-labs/cbor-php
+composer require "spomky-labs/cbor-php:^3.3.4"
 ```
+
+3.3.4 is the floor this library declares (`conflict: <3.3.4`): the CBOR decoder is what enforces the header-map rules
+of [RFC 9052](https://datatracker.ietf.org/doc/html/rfc9052) — a label appearing twice in a map makes the message
+malformed (§3, §9), and nesting is bounded so that a crafted header cannot exhaust the memory of the process.
 
 ## Quick Start
 
@@ -53,36 +57,57 @@ composer require spomky-labs/cbor-php
 
 ```php
 use CBOR\Decoder;
+use CBOR\ListObject;
 use CBOR\OtherObject\OtherObjectManager;
 use CBOR\StringStream;
 use CBOR\Tag\TagManager;
+use Cose\Algorithm\Signature\ECDSA\ES256;
+use Cose\Key\Ec2Key;
 use Cose\Signature\CoseSign1Tag;
 use Cose\Signature\Signature1;
+
+// The key of the signer you trust, and the algorithm you expect it to be used with.
+$key = Ec2Key::create($theCoseKeyYouPinned);
+$algorithm = ES256::create();
+// The protected header labels this application knows how to process (1 = alg, 2 = crit).
+$understoodLabels = [1, 2];
 
 // Setup decoder with COSE tag support
 $tagManager = TagManager::create()->add(CoseSign1Tag::class);
 $decoder = Decoder::create($tagManager, OtherObjectManager::create());
 
 // Decode COSE_Sign1 message
-$stream = new StringStream($encodedData);
-$coseSign1 = $decoder->decode($stream);
+$coseSign1 = $decoder->decode(new StringStream($encodedData));
+$header = $coseSign1->getProtectedHeaderAsMap();
 
-// Extract components
-$protectedHeader = $coseSign1->getProtectedHeader();
-$payload = $coseSign1->getPayload();
-$signature = $coseSign1->getSignature();
+// RFC 9052 §3.1: bind the signature to the algorithm the protected header declares.
+if (! $header->has(1) || (int) $header->get(1)->normalize() !== $algorithm::identifier()) {
+    throw new RuntimeException('Unexpected or missing "alg" in the protected header');
+}
 
-// Create signature structure for verification
-$sigStructure = Signature1::create($protectedHeader, $payload);
+// RFC 9052 §3.1: every parameter listed in "crit" must be processed, or the message must be rejected.
+if ($header->has(2)) {
+    $crit = $header->get(2);
+    if (! $crit instanceof ListObject) {
+        throw new RuntimeException('"crit" is not an array');
+    }
+    foreach ($crit as $label) {
+        if (! in_array((int) $label->normalize(), $understoodLabels, true)) {
+            throw new RuntimeException('Unsupported critical header parameter');
+        }
+    }
+}
 
-// Verify (example with OpenSSL)
-$isValid = openssl_verify(
-    (string) $sigStructure,
-    $derSignature,
-    $publicKey,
-    'sha256'
-);
+// Verify the Sig_structure the signature covers
+$sigStructure = Signature1::create($coseSign1->getProtectedHeader(), $coseSign1->getPayload());
+$isValid = $algorithm->verify((string) $sigStructure, $key, $coseSign1->getSignature()->getValue());
 ```
+
+> [!IMPORTANT]
+> The library verifies signatures; it does not decide what a message is allowed to say. Checking that `alg` is the one
+> expected for that key, and refusing any `crit` label the application does not process, are the caller's
+> responsibility ([RFC 9052 §3.1](https://datatracker.ietf.org/doc/html/rfc9052#section-3.1)) — the snippet above is
+> the shape they take. `tests/Signature/DocumentedVerifierTest.php` runs exactly this code.
 
 ### Creating a COSE_Sign1 Message
 
@@ -148,7 +173,9 @@ This library is perfect for:
 | ES512 | -36 | ECDSA with SHA-512 |
 | ES256K | -47 | ECDSA with secp256k1 |
 | EdDSA | -8 | EdDSA |
-| Ed25519 | - | EdDSA with Curve25519 |
+| Ed25519 | -8 | Alias of EdDSA (Curve25519); see -19 below for the fully-specified form |
+| Ed256 | -260 | Ed25519 over a SHA-256 digest — non-standard, see below |
+| Ed512 | -261 | Ed25519 over a SHA-512 digest — non-standard, see below |
 | RS256 | -257 | RSASSA-PKCS1-v1_5 with SHA-256 |
 | RS384 | -258 | RSASSA-PKCS1-v1_5 with SHA-384 |
 | RS512 | -259 | RSASSA-PKCS1-v1_5 with SHA-512 |
@@ -180,6 +207,12 @@ the key. They live in the `Cose\Algorithm\Signature\FullySpecified` namespace.
 >
 > Ed448 is not covered by the sodium extension and goes through OpenSSL, which PHP only wires up for Edwards curves
 > as of PHP 8.4. Call `Ed448::isSupported()` when the platform is not known in advance.
+
+> [!WARNING]
+> `Cose\Algorithm\Signature\EdDSA\Ed256` (-260) and `Ed512` (-261) sign a SHA-256 or SHA-512 digest of the message
+> with **Ed25519**. They are neither EdDSA identifiers nor registered anywhere — IANA assigns -260 to WalnutDSA and
+> -261 to TurboSHAKE128 — and neither supports Curve448. They are kept for the authenticators that already produce
+> them. EdDSA with Curve448 is `FullySpecified\Ed448` (-53).
 
 > [!WARNING]
 > **RS1 (SHA-1) is not secure.** It is kept only for the legacy authenticators that still rely on it.
@@ -284,16 +317,16 @@ of the stock `php` and `php-fpm` Docker images.
 
 ## Testing
 
-Run the test suite with:
-
-```bash
-composer test
-```
-
-Or using Castor:
+Run the test suite in the project QA container (nothing to install):
 
 ```bash
 castor phpunit
+```
+
+Or directly, on a host that provides PHPUnit 11 as `phpunit-11`:
+
+```bash
+composer test
 ```
 
 The library includes comprehensive tests including:
@@ -309,13 +342,23 @@ The library includes comprehensive tests including:
 - ext-openssl
 - brick/math
 - spomky-labs/pki-framework
-- spomky-labs/cbor-php (for COSE tag support)
+
+Optional, depending on what you use:
+
+- **ext-sodium** — required by every Ed25519 algorithm (`EdDSA` -8, `Ed25519` -8 and -19, `Ed256` -260, `Ed512` -261)
+  and to recompute an OKP public key from its private key. Sodium ships with PHP and is enabled by default, but a
+  build can leave it out: creating one of these algorithms then throws a `RuntimeException` instead of reporting
+  valid signatures as invalid. Call `EdDSA::isSupported()` when the platform is not known in advance.
+- **spomky-labs/cbor-php** `^3.3.4` — required by the COSE tag classes (Sign, Encrypt, Mac). Versions below 3.3.4 are
+  rejected by a `conflict` entry, because that decoder is what enforces the RFC 9052 header-map rules.
+- **ext-gmp** or **ext-bcmath** — see [Performance](#performance).
 
 ## Contributing
 
-Contributions are welcome! Please see [CONTRIBUTING.md](doc/Contributing.md) for details.
+Contributions are welcome! Please see [CONTRIBUTING.md](.github/CONTRIBUTING.md) for details.
 
-For security vulnerabilities, please email **security [at] spomky-labs.com** instead of using the issue tracker.
+For security vulnerabilities, do not open an issue: report them privately through GitHub private vulnerability
+reporting or by e-mail to **security [at] spomky-labs.com**. See [SECURITY.md](SECURITY.md).
 
 ## Support
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,18 +1,23 @@
 # Versioning and Release
 
-This document describes the versioning and release process of the Webauthn Framework.
+This document describes the versioning and release process of the COSE Library for PHP.
 This document is a living document, contents will be updated according to each release.
 
 ## Releases
 
-Webauthn Framework releases will be versioned using dotted triples, similar to [Semantic Version](http://semver.org/).
+Releases will be versioned using dotted triples, similar to [Semantic Version](http://semver.org/).
 For this specific document, we will refer to the respective components of this triple as `<major>.<minor>.<patch>`.
 The version number may have additional information, such as "-rc1,-rc2,-rc3" to mark release candidate builds for earlier access.
 Such releases will be considered as "pre-releases".
 
 ## Minor Release Support Matrix
 
-| Version | Supported          |
-|---------|--------------------|
-| 4.5.x   | :white_check_mark: |
-| < 4.5.x | :x:                |
+This matrix is the single source of truth for the branches under support; [SECURITY.md](SECURITY.md) refers to it.
+
+| Version | Supported                              |
+|---------|----------------------------------------|
+| 4.8.x   | :white_check_mark: (in development)    |
+| 4.7.x   | :white_check_mark:                     |
+| 4.6.x   | :white_check_mark: (security fix only) |
+| 4.5.x   | :white_check_mark: (security fix only) |
+| < 4.5.x | :x:                                    |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,12 +2,15 @@
 
 ## Supported Versions
 
-| Version | Supported                              |
-| ------- |----------------------------------------|
-| 4.0.x   | :white_check_mark:                     |
-| 3.3.x   | :white_check_mark: (security fix only) |
-| < 3.3.x | :x:                                    |
+The maintained branches and what each one receives are listed in a single place, [RELEASES.md](RELEASES.md#minor-release-support-matrix),
+so that this file cannot drift away from it.
 
 ## Reporting a Vulnerability
 
-If you think you have found a security issue, DO NOT open an issue. You MUST submit email security AT spomky-labs.com
+If you think you have found a security issue, **do not open a public issue**. Report it privately, either way:
+
+- through GitHub private vulnerability reporting, from the [Security tab](https://github.com/web-auth/cose-lib/security/advisories/new) of this repository, or
+- by e-mail to **security [at] spomky-labs.com**.
+
+Please include the affected version, a description of the issue and, when possible, a reproduction script. You will
+get an acknowledgement of the report, and a fix will be prepared privately before any public disclosure.

--- a/composer.json
+++ b/composer.json
@@ -26,16 +26,19 @@
         "spomky-labs/pki-framework": "^1.0"
     },
     "require-dev": {
-        "spomky-labs/cbor-php": "^3.2.2"
+        "spomky-labs/cbor-php": "^3.3.4"
     },
     "replace": {
         "symfony/polyfill-php81": "*"
+    },
+    "conflict": {
+        "spomky-labs/cbor-php": "<3.3.4"
     },
     "suggest": {
         "ext-bcmath": "Recommended: without GMP or BCMath, signing with RSASSA-PSS (PS256/PS384/PS512) blinds its private exponentiation in pure PHP",
         "ext-gmp": "Recommended: without GMP or BCMath, signing with RSASSA-PSS (PS256/PS384/PS512) blinds its private exponentiation in pure PHP",
         "ext-sodium": "Required by the EdDSA/Ed25519 signature algorithms (-8, -19, -260, -261) and to recompute an OKP public key from its private key",
-        "spomky-labs/cbor-php": "For COSE Signature support"
+        "spomky-labs/cbor-php": "Required by the COSE_Sign/COSE_Encrypt/COSE_Mac tag classes. 3.3.4 or later: the decoder is what enforces the RFC 9052 label uniqueness and nesting bounds this library relies on"
     },
     "autoload": {
         "psr-4": {
@@ -46,5 +49,8 @@
         "psr-4": {
             "Cose\\Tests\\": "tests/"
         }
+    },
+    "scripts": {
+        "test": "@composer exec -- phpunit-11 --configuration .ci-tools/phpunit.xml.dist"
     }
 }

--- a/doc/Usage.md
+++ b/doc/Usage.md
@@ -30,8 +30,17 @@ composer require web-auth/cose-lib
 For COSE tag support, you also need:
 
 ```bash
-composer require spomky-labs/cbor-php
+composer require "spomky-labs/cbor-php:^3.3.4"
 ```
+
+3.3.4 is the floor this library declares (`conflict: <3.3.4`). The CBOR decoder is what enforces the header-map rules
+of RFC 9052: [§3](https://datatracker.ietf.org/doc/html/rfc9052#section-3) and
+[§9](https://datatracker.ietf.org/doc/html/rfc9052#section-9) make a message malformed when a label appears twice in a
+map, and the decoder bounds the nesting depth so that a crafted header cannot exhaust the memory of the process.
+Nothing in this library re-checks either rule.
+
+Every Ed25519 algorithm needs `ext-sodium`, which ships with PHP and is enabled by default; see
+[Signature Algorithms](#signature-algorithms) for what happens on a build without it.
 
 ## COSE Tags
 
@@ -99,10 +108,12 @@ $encoded = (string) $coseSign1;
 
 ```php
 use CBOR\Decoder;
+use CBOR\ListObject;
 use CBOR\OtherObject\OtherObjectManager;
 use CBOR\StringStream;
 use CBOR\Tag\TagManager;
-use Cose\Algorithm\Signature\ECDSA\ECSignature;
+use Cose\Algorithm\Signature\ECDSA\ES256;
+use Cose\Key\Ec2Key;
 use Cose\Signature\CoseSign1Tag;
 use Cose\Signature\Signature1;
 
@@ -121,27 +132,65 @@ $unprotectedHeader = $coseSign1->getUnprotectedHeader(); // MapObject
 $payload = $coseSign1->getPayload(); // ByteStringObject
 $signature = $coseSign1->getSignature(); // ByteStringObject
 
-// Use a custom decoder for protected header (e.g., with custom CBOR tags)
+// The key of the signer you trust, and the algorithm you expect it to be used with
+$key = Ec2Key::create($theCoseKeyYouPinned);
+$algorithm = ES256::create();
+// The protected header labels this application knows how to process (1 = alg, 2 = crit)
+$understoodLabels = [1, 2];
+
+// RFC 9052 §3.1: bind the signature to the algorithm the protected header declares
+if (! $protectedHeaderMap->has(1)
+    || (int) $protectedHeaderMap->get(1)->normalize() !== $algorithm::identifier()) {
+    throw new RuntimeException('Unexpected or missing "alg" in the protected header');
+}
+
+// RFC 9052 §3.1: every parameter listed in "crit" must be processed, or the message must be rejected
+if ($protectedHeaderMap->has(2)) {
+    $crit = $protectedHeaderMap->get(2);
+    if (! $crit instanceof ListObject) {
+        throw new RuntimeException('"crit" is not an array');
+    }
+    foreach ($crit as $label) {
+        if (! in_array((int) $label->normalize(), $understoodLabels, true)) {
+            throw new RuntimeException('Unsupported critical header parameter');
+        }
+    }
+}
+
+// Create Sig_structure and verify the signature it covers
+$sigStructure = Signature1::create($coseSign1->getProtectedHeader(), $coseSign1->getPayload());
+$isValid = $algorithm->verify((string) $sigStructure, $key, $coseSign1->getSignature()->getValue());
+```
+
+`tests/Signature/DocumentedVerifierTest.php` runs exactly this code, against a genuine ES256 message and against
+messages crafted to exercise each check.
+
+##### What the application must check
+
+The library verifies signatures; it does not decide what a message is allowed to say. Two checks
+[RFC 9052 §3.1](https://datatracker.ietf.org/doc/html/rfc9052#section-3.1) requires are therefore the caller's, and
+both are in the snippet above:
+
+- **`alg` (label 1)** — "This header parameter MUST be authenticated where the ability to do so exists". Read it from
+  the *protected* header, which the signature covers, and compare it with the algorithm you decided to accept for
+  that key. A verifier that hard-codes its algorithm and ignores the header still accepts a message that announces a
+  different one.
+- **`crit` (label 2)** — it lists the protected header parameters a recipient is *required* to understand. Any label
+  in that list your application does not process makes the message unusable: reject it instead of verifying it.
+
+The protected header itself is decoded with a decoder bounded to
+`CoseSign1Tag::DEFAULT_PROTECTED_HEADER_MAX_DEPTH` (32) levels of nesting. Pass your own `Decoder` to
+`getProtectedHeaderAsMap()` when a header carries custom CBOR tags, or a different `$maxDepth` when 32 is not the
+right bound:
+
+```php
+// Use a custom decoder for the protected header (e.g. with custom CBOR tags)
 $customDecoder = Decoder::create(
     TagManager::create()->add(MyCustomTag::class),
-    OtherObjectManager::create()
+    OtherObjectManager::create(),
+    32
 );
 $protectedHeaderMap = $coseSign1->getProtectedHeaderAsMap($customDecoder);
-
-// Create Sig_structure for verification
-$sigStructure = Signature1::create(
-    $coseSign1->getProtectedHeader(),
-    $coseSign1->getPayload()
-);
-
-// Verify signature (example with OpenSSL and ECDSA)
-$derSignature = ECSignature::toAsn1($signature->getValue(), 64);
-$isValid = openssl_verify(
-    (string) $sigStructure,
-    $derSignature,
-    $publicKey,
-    'sha256'
-);
 ```
 
 ### COSE_Sign (Multiple Signers)
@@ -268,10 +317,14 @@ $coseMac = CoseMacTag::create(
   - ES512 (-36): ECDSA with SHA-512
   - ES256K (-47): ECDSA with secp256k1 curve
 
-- **EdDSA**
-  - EdDSA (-8): Edwards-curve Digital Signature Algorithm
-  - Ed25519: EdDSA with Curve25519
-  - Ed448 (Ed512): EdDSA with Curve448
+- **EdDSA** (`Cose\Algorithm\Signature\EdDSA`) — Ed25519 keys only, whatever the class
+  - EdDSA (-8): Edwards-curve Digital Signature Algorithm. The IANA COSE Algorithms registry marks -8 deprecated in
+    favour of the fully-specified Ed25519 (-19) and Ed448 (-53) below
+  - Ed25519 (-8): the same algorithm under its own class name; identical signatures, identical identifier
+  - Ed256 (-260) and Ed512 (-261): **non-standard**. They sign a SHA-256 or SHA-512 digest of the message with
+    Ed25519. They are not EdDSA identifiers and are registered nowhere — IANA assigns -260 to WalnutDSA and -261 to
+    TurboSHAKE128 — and neither of them supports Curve448. Kept for the authenticators that already produce them;
+    EdDSA with Curve448 is `FullySpecified\Ed448` (-53)
 
 - **RSA**
   - RS256 (-257): RSASSA-PKCS1-v1_5 with SHA-256

--- a/src/Algorithm/Signature/EdDSA/Ed256.php
+++ b/src/Algorithm/Signature/EdDSA/Ed256.php
@@ -6,6 +6,13 @@ namespace Cose\Algorithm\Signature\EdDSA;
 
 use Cose\Key\Key;
 
+/**
+ * Ed25519 over the SHA-256 digest of the message. Neither this pre-hash variant nor the identifier -260 belongs to
+ * EdDSA — the IANA COSE Algorithms registry assigns -260 to WalnutDSA — and the class is kept for the authenticators
+ * that already produce it. The fully-specified EdDSA identifiers are
+ * {@see \Cose\Algorithm\Signature\FullySpecified\Ed25519} (-19) and
+ * {@see \Cose\Algorithm\Signature\FullySpecified\Ed448} (-53).
+ */
 final class Ed256 extends EdDSA
 {
     public const ID = -260;

--- a/src/Algorithm/Signature/EdDSA/Ed512.php
+++ b/src/Algorithm/Signature/EdDSA/Ed512.php
@@ -6,6 +6,13 @@ namespace Cose\Algorithm\Signature\EdDSA;
 
 use Cose\Key\Key;
 
+/**
+ * Ed25519 over the SHA-512 digest of the message, not EdDSA with Curve448: the signature is computed by
+ * {@see EdDSA}, which accepts Ed25519 keys only. Neither this pre-hash variant nor the identifier -261 belongs to
+ * EdDSA — the IANA COSE Algorithms registry assigns -261 to TurboSHAKE128 — and the class is kept for the
+ * authenticators that already produce it. EdDSA with Curve448 is
+ * {@see \Cose\Algorithm\Signature\FullySpecified\Ed448} (-53).
+ */
 final class Ed512 extends EdDSA
 {
     public const ID = -261;

--- a/src/Algorithm/Signature/EdDSA/EdDSA.php
+++ b/src/Algorithm/Signature/EdDSA/EdDSA.php
@@ -18,7 +18,7 @@ use function sodium_crypto_sign_secretkey;
 use function sodium_crypto_sign_seed_keypair;
 use function sodium_crypto_sign_verify_detached;
 use function sodium_memzero;
-use Throwable;
+use SodiumException;
 
 /**
  * @see \Cose\Tests\Algorithm\Signature\EdDSA\EdDSATest
@@ -87,9 +87,12 @@ class EdDSA implements Signature
         if ($key->curve() !== OkpKey::CURVE_ED25519 && $key->curve() !== OkpKey::CURVE_NAME_ED25519) {
             throw new InvalidArgumentException('Unsupported curve');
         }
+        // Sodium reports a signature or a public key whose size is not the one Ed25519 defines with a
+        // SodiumException; that is an invalid signature, not an error. Anything else — a missing extension above
+        // all — is a platform fault and must not be reported as a verification outcome.
         try {
             return sodium_crypto_sign_verify_detached($signature, $data, $key->x());
-        } catch (Throwable) {
+        } catch (SodiumException) {
             return false;
         }
     }

--- a/src/Algorithms.php
+++ b/src/Algorithms.php
@@ -73,6 +73,12 @@ abstract class Algorithms
 
     final public const COSE_ALGORITHM_EDDSA = -8;
 
+    /**
+     * Ed25519 over a SHA-256 (-260) or SHA-512 (-261) digest of the message. These pre-hash variants are not
+     * registered anywhere and are not EdDSA identifiers: the IANA COSE Algorithms registry assigns -260 to WalnutDSA
+     * and -261 to TurboSHAKE128. They are kept for the authenticators that already produce them; new code should use
+     * COSE_ALGORITHM_ED25519 (-19) or COSE_ALGORITHM_ED448 (-53).
+     */
     final public const COSE_ALGORITHM_ED256 = -260;
 
     final public const COSE_ALGORITHM_ED512 = -261;

--- a/src/Encryption/CoseEncrypt0Tag.php
+++ b/src/Encryption/CoseEncrypt0Tag.php
@@ -17,6 +17,13 @@ use InvalidArgumentException;
 
 final class CoseEncrypt0Tag extends Tag
 {
+    /**
+     * A COSE header is a flat map of a handful of parameters whose values nest a couple of levels at most, so the
+     * decoder built when none is given is bounded far below the cbor-php default of 1000: a protected header crafted
+     * to nest thousands of levels is rejected instead of being walked.
+     */
+    public const DEFAULT_PROTECTED_HEADER_MAX_DEPTH = 32;
+
     private const TAG_ID = 16;
 
     private readonly ByteStringObject $protectedHeader;
@@ -86,10 +93,16 @@ final class CoseEncrypt0Tag extends Tag
         return $this->protectedHeader;
     }
 
-    public function getProtectedHeaderAsMap(?Decoder $decoder = null): MapObject
-    {
+    /**
+     * The nesting bound only applies to the decoder created here: a caller passing its own $decoder sets its own
+     * bound, and $maxDepth is then ignored.
+     */
+    public function getProtectedHeaderAsMap(
+        ?Decoder $decoder = null,
+        int $maxDepth = self::DEFAULT_PROTECTED_HEADER_MAX_DEPTH
+    ): MapObject {
         $stream = new StringStream($this->protectedHeader->getValue());
-        $decoder ??= Decoder::create(TagManager::create(), OtherObjectManager::create());
+        $decoder ??= Decoder::create(TagManager::create(), OtherObjectManager::create(), $maxDepth);
         $decoded = $decoder->decode($stream);
 
         if (! $decoded instanceof MapObject) {

--- a/src/Encryption/CoseEncryptTag.php
+++ b/src/Encryption/CoseEncryptTag.php
@@ -17,6 +17,13 @@ use InvalidArgumentException;
 
 final class CoseEncryptTag extends Tag
 {
+    /**
+     * A COSE header is a flat map of a handful of parameters whose values nest a couple of levels at most, so the
+     * decoder built when none is given is bounded far below the cbor-php default of 1000: a protected header crafted
+     * to nest thousands of levels is rejected instead of being walked.
+     */
+    public const DEFAULT_PROTECTED_HEADER_MAX_DEPTH = 32;
+
     private const TAG_ID = 96;
 
     private readonly ByteStringObject $protectedHeader;
@@ -99,10 +106,16 @@ final class CoseEncryptTag extends Tag
         return $this->protectedHeader;
     }
 
-    public function getProtectedHeaderAsMap(?Decoder $decoder = null): MapObject
-    {
+    /**
+     * The nesting bound only applies to the decoder created here: a caller passing its own $decoder sets its own
+     * bound, and $maxDepth is then ignored.
+     */
+    public function getProtectedHeaderAsMap(
+        ?Decoder $decoder = null,
+        int $maxDepth = self::DEFAULT_PROTECTED_HEADER_MAX_DEPTH
+    ): MapObject {
         $stream = new StringStream($this->protectedHeader->getValue());
-        $decoder ??= Decoder::create(TagManager::create(), OtherObjectManager::create());
+        $decoder ??= Decoder::create(TagManager::create(), OtherObjectManager::create(), $maxDepth);
         $decoded = $decoder->decode($stream);
 
         if (! $decoded instanceof MapObject) {

--- a/src/Mac/CoseMac0Tag.php
+++ b/src/Mac/CoseMac0Tag.php
@@ -17,6 +17,13 @@ use InvalidArgumentException;
 
 final class CoseMac0Tag extends Tag
 {
+    /**
+     * A COSE header is a flat map of a handful of parameters whose values nest a couple of levels at most, so the
+     * decoder built when none is given is bounded far below the cbor-php default of 1000: a protected header crafted
+     * to nest thousands of levels is rejected instead of being walked.
+     */
+    public const DEFAULT_PROTECTED_HEADER_MAX_DEPTH = 32;
+
     private const TAG_ID = 17;
 
     private readonly ByteStringObject $protectedHeader;
@@ -90,10 +97,16 @@ final class CoseMac0Tag extends Tag
         return $this->protectedHeader;
     }
 
-    public function getProtectedHeaderAsMap(?Decoder $decoder = null): MapObject
-    {
+    /**
+     * The nesting bound only applies to the decoder created here: a caller passing its own $decoder sets its own
+     * bound, and $maxDepth is then ignored.
+     */
+    public function getProtectedHeaderAsMap(
+        ?Decoder $decoder = null,
+        int $maxDepth = self::DEFAULT_PROTECTED_HEADER_MAX_DEPTH
+    ): MapObject {
         $stream = new StringStream($this->protectedHeader->getValue());
-        $decoder ??= Decoder::create(TagManager::create(), OtherObjectManager::create());
+        $decoder ??= Decoder::create(TagManager::create(), OtherObjectManager::create(), $maxDepth);
         $decoded = $decoder->decode($stream);
 
         if (! $decoded instanceof MapObject) {

--- a/src/Mac/CoseMacTag.php
+++ b/src/Mac/CoseMacTag.php
@@ -17,6 +17,13 @@ use InvalidArgumentException;
 
 final class CoseMacTag extends Tag
 {
+    /**
+     * A COSE header is a flat map of a handful of parameters whose values nest a couple of levels at most, so the
+     * decoder built when none is given is bounded far below the cbor-php default of 1000: a protected header crafted
+     * to nest thousands of levels is rejected instead of being walked.
+     */
+    public const DEFAULT_PROTECTED_HEADER_MAX_DEPTH = 32;
+
     private const TAG_ID = 97;
 
     private readonly ByteStringObject $protectedHeader;
@@ -104,10 +111,16 @@ final class CoseMacTag extends Tag
         return $this->protectedHeader;
     }
 
-    public function getProtectedHeaderAsMap(?Decoder $decoder = null): MapObject
-    {
+    /**
+     * The nesting bound only applies to the decoder created here: a caller passing its own $decoder sets its own
+     * bound, and $maxDepth is then ignored.
+     */
+    public function getProtectedHeaderAsMap(
+        ?Decoder $decoder = null,
+        int $maxDepth = self::DEFAULT_PROTECTED_HEADER_MAX_DEPTH
+    ): MapObject {
         $stream = new StringStream($this->protectedHeader->getValue());
-        $decoder ??= Decoder::create(TagManager::create(), OtherObjectManager::create());
+        $decoder ??= Decoder::create(TagManager::create(), OtherObjectManager::create(), $maxDepth);
         $decoded = $decoder->decode($stream);
 
         if (! $decoded instanceof MapObject) {

--- a/src/Signature/CoseSign1Tag.php
+++ b/src/Signature/CoseSign1Tag.php
@@ -17,6 +17,13 @@ use InvalidArgumentException;
 
 final class CoseSign1Tag extends Tag
 {
+    /**
+     * A COSE header is a flat map of a handful of parameters whose values nest a couple of levels at most, so the
+     * decoder built when none is given is bounded far below the cbor-php default of 1000: a protected header crafted
+     * to nest thousands of levels is rejected instead of being walked.
+     */
+    public const DEFAULT_PROTECTED_HEADER_MAX_DEPTH = 32;
+
     private const TAG_ID = 18;
 
     private readonly ByteStringObject $protectedHeader;
@@ -96,10 +103,16 @@ final class CoseSign1Tag extends Tag
         return $this->protectedHeader;
     }
 
-    public function getProtectedHeaderAsMap(?Decoder $decoder = null): MapObject
-    {
+    /**
+     * The nesting bound only applies to the decoder created here: a caller passing its own $decoder sets its own
+     * bound, and $maxDepth is then ignored.
+     */
+    public function getProtectedHeaderAsMap(
+        ?Decoder $decoder = null,
+        int $maxDepth = self::DEFAULT_PROTECTED_HEADER_MAX_DEPTH
+    ): MapObject {
         $stream = new StringStream($this->protectedHeader->getValue());
-        $decoder ??= Decoder::create(TagManager::create(), OtherObjectManager::create());
+        $decoder ??= Decoder::create(TagManager::create(), OtherObjectManager::create(), $maxDepth);
         $decoded = $decoder->decode($stream);
 
         if (! $decoded instanceof MapObject) {

--- a/src/Signature/CoseSignTag.php
+++ b/src/Signature/CoseSignTag.php
@@ -17,6 +17,13 @@ use InvalidArgumentException;
 
 final class CoseSignTag extends Tag
 {
+    /**
+     * A COSE header is a flat map of a handful of parameters whose values nest a couple of levels at most, so the
+     * decoder built when none is given is bounded far below the cbor-php default of 1000: a protected header crafted
+     * to nest thousands of levels is rejected instead of being walked.
+     */
+    public const DEFAULT_PROTECTED_HEADER_MAX_DEPTH = 32;
+
     private const TAG_ID = 98;
 
     private readonly ByteStringObject $protectedHeader;
@@ -90,10 +97,16 @@ final class CoseSignTag extends Tag
         return $this->protectedHeader;
     }
 
-    public function getProtectedHeaderAsMap(?Decoder $decoder = null): MapObject
-    {
+    /**
+     * The nesting bound only applies to the decoder created here: a caller passing its own $decoder sets its own
+     * bound, and $maxDepth is then ignored.
+     */
+    public function getProtectedHeaderAsMap(
+        ?Decoder $decoder = null,
+        int $maxDepth = self::DEFAULT_PROTECTED_HEADER_MAX_DEPTH
+    ): MapObject {
         $stream = new StringStream($this->protectedHeader->getValue());
-        $decoder ??= Decoder::create(TagManager::create(), OtherObjectManager::create());
+        $decoder ??= Decoder::create(TagManager::create(), OtherObjectManager::create(), $maxDepth);
         $decoded = $decoder->decode($stream);
 
         if (! $decoded instanceof MapObject) {

--- a/tests/PackagingTest.php
+++ b/tests/PackagingTest.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cose\Tests;
+
+use function file_get_contents;
+use function is_array;
+use function is_string;
+use function json_decode;
+use const JSON_THROW_ON_ERROR;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * What the package promises about its own environment. These declarations have been lost before — ext-sodium was
+ * added and reverted five minutes later in 2019 — and nothing else in the test suite notices when they go.
+ *
+ * @see https://github.com/web-auth/cose-lib/issues/171
+ */
+final class PackagingTest extends TestCase
+{
+    private const ROOT = __DIR__ . '/..';
+
+    /**
+     * Every EdDSA/Ed25519 algorithm calls sodium_*() and OkpKey recomputes a public key with it. The extension ships
+     * with PHP and is enabled by default, so it stays a suggestion rather than a hard requirement — but it must be
+     * declared somewhere, or a build without it looks like a library bug.
+     */
+    #[Test]
+    public function theSodiumExtensionIsDeclared(): void
+    {
+        // Given
+        $composer = self::composerJson();
+
+        // Then
+        $declaration = $composer['require']['ext-sodium'] ?? $composer['suggest']['ext-sodium'] ?? null;
+        static::assertIsString($declaration, 'ext-sodium is declared neither in "require" nor in "suggest"');
+        static::assertStringContainsString('EdDSA', (string) $declaration);
+    }
+
+    /**
+     * RFC 9052 label uniqueness (sections 3 and 9) and the nesting bound are enforced by the CBOR decoder alone.
+     * Duplicate labels are rejected since spomky-labs/cbor-php 3.3.4 (GHSA-388j-mw2g-rx5f) and the depth bound
+     * exists since 3.3.3, so anything below 3.3.4 must not be installed next to this library. "require-dev" is never
+     * read downstream: only the "conflict" entry makes the floor binding.
+     */
+    #[Test]
+    public function theCborDecoderFloorIsBinding(): void
+    {
+        // Given
+        $composer = self::composerJson();
+
+        // Then
+        static::assertSame('<3.3.4', $composer['conflict']['spomky-labs/cbor-php'] ?? null);
+        static::assertSame('^3.3.4', $composer['require-dev']['spomky-labs/cbor-php'] ?? null);
+        static::assertStringContainsString(
+            '3.3.4',
+            (string) ($composer['suggest']['spomky-labs/cbor-php'] ?? ''),
+            'The suggestion does not mention the version the header-map rules need'
+        );
+    }
+
+    /**
+     * README.md documents "composer test"; the script has to exist.
+     */
+    #[Test]
+    public function theDocumentedComposerScriptsExist(): void
+    {
+        // Given
+        $composer = self::composerJson();
+
+        // Then
+        static::assertArrayHasKey('test', $composer['scripts'] ?? []);
+        static::assertStringContainsString('phpunit', (string) $composer['scripts']['test']);
+    }
+
+    /**
+     * The links of the documentation, checked against the files that are actually shipped.
+     */
+    #[Test]
+    #[DataProvider('getDocumentedFiles')]
+    public function theDocumentedFilesExist(string $path): void
+    {
+        static::assertFileExists(self::ROOT . '/' . $path);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function getDocumentedFiles(): iterable
+    {
+        yield '.github/CONTRIBUTING.md' => ['.github/CONTRIBUTING.md'];
+        yield 'doc/Usage.md' => ['doc/Usage.md'];
+        yield 'RELEASES.md' => ['RELEASES.md'];
+        yield 'SECURITY.md' => ['SECURITY.md'];
+        yield '.ci-tools/phpunit.xml.dist' => ['.ci-tools/phpunit.xml.dist'];
+    }
+
+    #[Test]
+    public function theReadmeOnlyLinksToFilesThatExist(): void
+    {
+        // Given
+        $readme = self::read('README.md');
+
+        // Then
+        static::assertStringContainsString('[CONTRIBUTING.md](.github/CONTRIBUTING.md)', $readme);
+        static::assertStringNotContainsString('doc/Contributing.md', $readme);
+    }
+
+    /**
+     * A security report must never be routed to a public or dead channel: the Gitter room the pull request template
+     * used to point at is neither private nor read.
+     */
+    #[Test]
+    public function securityReportsAreRoutedToAPrivateChannel(): void
+    {
+        // Given
+        $template = self::read('.github/PULL_REQUEST_TEMPLATE.md');
+        $security = self::read('SECURITY.md');
+
+        // Then
+        static::assertStringNotContainsString('gitter.im', $template);
+        static::assertStringContainsString('security@spomky-labs.com', $template);
+        static::assertStringContainsString('spomky-labs.com', $security);
+        static::assertStringContainsString('RELEASES.md', $security);
+    }
+
+    /**
+     * The contributing guide used to pipe the Composer installer from plain HTTP straight into php, which runs
+     * unauthenticated code fetched in cleartext.
+     */
+    #[Test]
+    public function theContributingGuideDoesNotPipeAnInstallerIntoPhp(): void
+    {
+        // Given
+        $contributing = self::read('.github/CONTRIBUTING.md');
+
+        // Then
+        static::assertStringNotContainsString('http://getcomposer.org', $contributing);
+        static::assertStringNotContainsString('| php', $contributing, 'An installer is piped into php');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function composerJson(): array
+    {
+        $composer = json_decode(self::read('composer.json'), true, 512, JSON_THROW_ON_ERROR);
+        static::assertTrue(is_array($composer));
+
+        return $composer;
+    }
+
+    private static function read(string $path): string
+    {
+        $content = file_get_contents(self::ROOT . '/' . $path);
+        static::assertTrue(is_string($content), 'Cannot read ' . $path);
+
+        return $content;
+    }
+}

--- a/tests/ProtectedHeaderDecodingTest.php
+++ b/tests/ProtectedHeaderDecodingTest.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cose\Tests;
+
+use CBOR\ByteStringObject;
+use CBOR\CBORObject;
+use CBOR\Decoder;
+use CBOR\ListObject;
+use CBOR\MapItem;
+use CBOR\MapObject;
+use CBOR\NegativeIntegerObject;
+use CBOR\OtherObject\OtherObjectManager;
+use CBOR\Tag;
+use CBOR\Tag\TagManager;
+use CBOR\UnsignedIntegerObject;
+use function chr;
+use Cose\Encryption\CoseEncrypt0Tag;
+use Cose\Encryption\CoseEncryptTag;
+use Cose\Mac\CoseMac0Tag;
+use Cose\Mac\CoseMacTag;
+use Cose\Signature\CoseSign1Tag;
+use Cose\Signature\CoseSignTag;
+use function count;
+use function in_array;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use function str_repeat;
+
+/**
+ * The header-map rules of RFC 9052 are enforced by the CBOR decoder, not by this library: section 3 and section 9
+ * make a message malformed when a label appears twice in a map, and the decoder is what bounds the nesting depth.
+ * That is why the package declares a floor of 3.3.4 on spomky-labs/cbor-php, and why the decoder built when the
+ * caller does not provide one is bounded far below the cbor-php default of 1000 levels.
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc9052#section-3
+ * @see https://www.rfc-editor.org/rfc/rfc9052#section-9
+ * @see https://github.com/web-auth/cose-lib/issues/171
+ */
+final class ProtectedHeaderDecodingTest extends TestCase
+{
+    /**
+     * @param class-string $class
+     */
+    #[Test]
+    #[DataProvider('getTagClasses')]
+    public function aWellFormedProtectedHeaderIsDecoded(string $class, int $tagId, int $items): void
+    {
+        // Given: {1: -7, 33: [h'cert']} — an algorithm and an x5chain-like array
+        $header = MapObject::create([
+            MapItem::create(UnsignedIntegerObject::create(1), NegativeIntegerObject::create(-7)),
+            MapItem::create(UnsignedIntegerObject::create(33), ListObject::create([ByteStringObject::create('cert')])),
+        ]);
+        $tag = self::tagWithProtectedHeader($class, $tagId, $items, (string) $header);
+
+        // When
+        $decoded = $tag->getProtectedHeaderAsMap();
+
+        // Then
+        static::assertCount(2, $decoded);
+        static::assertSame('-7', $decoded->get(1)->normalize());
+    }
+
+    /**
+     * RFC 9052 section 9: "Applications MUST NOT parse and process messages with the same label used twice as a key
+     * in a single map." Rejection comes from spomky-labs/cbor-php 3.3.4 or later (GHSA-388j-mw2g-rx5f).
+     *
+     * @param class-string $class
+     */
+    #[Test]
+    #[DataProvider('getTagClasses')]
+    public function aProtectedHeaderRepeatingALabelIsRejected(string $class, int $tagId, int $items): void
+    {
+        // Given: {1: -7, 1: -8}
+        $tag = self::tagWithProtectedHeader($class, $tagId, $items, "\xa2\x01\x26\x01\x27");
+
+        // Then
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The key "1" is defined more than once in the map.');
+        $tag->getProtectedHeaderAsMap();
+    }
+
+    /**
+     * A protected header nested thousands of levels deep used to exhaust the memory of the process, which no
+     * try/catch around the decoding can recover from.
+     *
+     * @param class-string $class
+     */
+    #[Test]
+    #[DataProvider('getTagClasses')]
+    public function anExcessivelyNestedProtectedHeaderIsRejected(string $class, int $tagId, int $items): void
+    {
+        // Given: {1: [[[ ... ]]]}, 5000 levels deep
+        $tag = self::tagWithProtectedHeader($class, $tagId, $items, self::deeplyNestedHeader(5000));
+
+        // Then
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Maximum nesting depth of 32 exceeded.');
+        $tag->getProtectedHeaderAsMap();
+    }
+
+    /**
+     * The bound applies to the decoder built here; a caller who needs another one passes it, or passes its own
+     * decoder, and nothing else changes.
+     *
+     * @param class-string $class
+     */
+    #[Test]
+    #[DataProvider('getTagClasses')]
+    public function theNestingBoundCanBeChanged(string $class, int $tagId, int $items): void
+    {
+        // Given: a header nested deeper than the default bound
+        $tag = self::tagWithProtectedHeader($class, $tagId, $items, self::deeplyNestedHeader(40));
+
+        // Then
+        static::assertSame(32, $class::DEFAULT_PROTECTED_HEADER_MAX_DEPTH);
+        static::assertCount(1, $tag->getProtectedHeaderAsMap(null, 128));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Maximum nesting depth of 32 exceeded.');
+        $tag->getProtectedHeaderAsMap();
+    }
+
+    /**
+     * A caller-provided decoder keeps its own bound: the $maxDepth argument is then ignored.
+     *
+     * @param class-string $class
+     */
+    #[Test]
+    #[DataProvider('getTagClasses')]
+    public function aCallerProvidedDecoderKeepsItsOwnBound(string $class, int $tagId, int $items): void
+    {
+        // Given
+        $tag = self::tagWithProtectedHeader($class, $tagId, $items, self::deeplyNestedHeader(40));
+        $decoder = Decoder::create(TagManager::create(), OtherObjectManager::create(), 128);
+
+        // Then
+        static::assertCount(1, $tag->getProtectedHeaderAsMap($decoder, 1));
+    }
+
+    /**
+     * @return iterable<string, array{class-string, int, int}>
+     */
+    public static function getTagClasses(): iterable
+    {
+        yield 'COSE_Sign1' => [CoseSign1Tag::class, 18, 4];
+        yield 'COSE_Sign' => [CoseSignTag::class, 98, 4];
+        yield 'COSE_Mac0' => [CoseMac0Tag::class, 17, 4];
+        yield 'COSE_Mac' => [CoseMacTag::class, 97, 5];
+        yield 'COSE_Encrypt0' => [CoseEncrypt0Tag::class, 16, 3];
+        yield 'COSE_Encrypt' => [CoseEncryptTag::class, 96, 4];
+    }
+
+    /**
+     * A protected header that is a valid map at the top level — {1: [[[ ... ]]]} — whose only value is $levels
+     * nested one-element arrays.
+     */
+    private static function deeplyNestedHeader(int $levels): string
+    {
+        return "\xa1\x01" . str_repeat("\x81", $levels) . "\xa0";
+    }
+
+    /**
+     * Builds the tag object of $class around the given protected header bytes, as the decoder would.
+     *
+     * @param class-string $class
+     */
+    private static function tagWithProtectedHeader(string $class, int $tagId, int $items, string $header): Tag
+    {
+        $list = [ByteStringObject::create($header), MapObject::create()];
+        // The last item of COSE_Sign, COSE_Mac and COSE_Encrypt is an array (signatures or recipients); every other
+        // item of every structure is a byte string.
+        $trailingList = in_array($class, [CoseSignTag::class, CoseMacTag::class, CoseEncryptTag::class], true);
+        while (count($list) < $items) {
+            $last = count($list) === $items - 1;
+            $list[] = $last && $trailingList ? ListObject::create() : ByteStringObject::create('');
+        }
+        $components = $tagId <= 23 ? [$tagId, null] : [Tag::LENGTH_1_BYTE, chr($tagId)];
+
+        $tag = $class::createFromLoadedData($components[0], $components[1], ListObject::create($list));
+        static::assertInstanceOf(CBORObject::class, $tag);
+
+        return $tag;
+    }
+}

--- a/tests/Signature/DocumentedVerifierTest.php
+++ b/tests/Signature/DocumentedVerifierTest.php
@@ -1,0 +1,269 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cose\Tests\Signature;
+
+use CBOR\ByteStringObject;
+use CBOR\Decoder;
+use CBOR\ListObject;
+use CBOR\MapItem;
+use CBOR\MapObject;
+use CBOR\NegativeIntegerObject;
+use CBOR\OtherObject\OtherObjectManager;
+use CBOR\StringStream;
+use CBOR\Tag\TagManager;
+use CBOR\UnsignedIntegerObject;
+use Cose\Algorithm\Signature\ECDSA\ES256;
+use Cose\Key\Ec2Key;
+use Cose\Signature\CoseSign1Tag;
+use Cose\Signature\Signature1;
+use function hex2bin;
+use function in_array;
+use InvalidArgumentException;
+use const OPENSSL_KEYTYPE_EC;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use const STR_PAD_LEFT;
+
+/**
+ * The COSE_Sign1 verifier documented in README.md and doc/Usage.md, run as it is written there.
+ *
+ * The library verifies signatures; RFC 9052 section 3.1 leaves the binding of "alg" and the processing of "crit" to
+ * the application. Every message below is genuinely signed with ES256, so what is exercised is what the documented
+ * snippet does with the header, not the signature primitive.
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc9052#section-3.1
+ * @see https://github.com/web-auth/cose-lib/issues/171
+ */
+final class DocumentedVerifierTest extends TestCase
+{
+    /**
+     * The protected header labels the documented application processes: 1 = alg, 2 = crit.
+     */
+    private const UNDERSTOOD_LABELS = [1, 2];
+
+    private const PAYLOAD = 'Live long and Prosper.';
+
+    #[Test]
+    public function aGenuineMessageIsAccepted(): void
+    {
+        // Given
+        $key = self::signingKey();
+        $message = self::sign($key, ES256::identifier(), null, self::PAYLOAD);
+
+        // Then
+        static::assertTrue(self::documentedVerifier($message, $key->toPublic()));
+    }
+
+    #[Test]
+    public function aTamperedPayloadIsRejected(): void
+    {
+        // Given
+        $key = self::signingKey();
+        $message = self::sign($key, ES256::identifier(), null, self::PAYLOAD);
+        $tampered = self::replacePayload($message, 'Live long and prosper.');
+
+        // Then
+        static::assertFalse(self::documentedVerifier($tampered, $key->toPublic()));
+    }
+
+    /**
+     * RFC 9052 section 3.1: "alg" MUST be authenticated where the ability to do so exists. A verifier that hard-codes
+     * its algorithm and never looks at the header accepts a message announcing another one.
+     */
+    #[Test]
+    public function aMessageAnnouncingAnotherAlgorithmIsRejected(): void
+    {
+        // Given
+        $key = self::signingKey();
+        $message = self::sign($key, -37 /* PS256 */, null, self::PAYLOAD);
+
+        // Then
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unexpected or missing "alg" in the protected header');
+        self::documentedVerifier($message, $key->toPublic());
+    }
+
+    #[Test]
+    public function aMessageWithoutAnAlgorithmIsRejected(): void
+    {
+        // Given
+        $key = self::signingKey();
+        $message = self::sign($key, null, null, self::PAYLOAD);
+
+        // Then
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unexpected or missing "alg" in the protected header');
+        self::documentedVerifier($message, $key->toPublic());
+    }
+
+    /**
+     * RFC 9052 section 3.1: the parameters listed in "crit" are those the recipient is required to understand.
+     */
+    #[Test]
+    public function aMessageWithAnUnknownCriticalParameterIsRejected(): void
+    {
+        // Given
+        $key = self::signingKey();
+        $message = self::sign($key, ES256::identifier(), [999], self::PAYLOAD);
+
+        // Then
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unsupported critical header parameter');
+        self::documentedVerifier($message, $key->toPublic());
+    }
+
+    #[Test]
+    public function aMessageWhoseCriticalParametersAreAllUnderstoodIsAccepted(): void
+    {
+        // Given
+        $key = self::signingKey();
+        $message = self::sign($key, ES256::identifier(), [1], self::PAYLOAD);
+
+        // Then
+        static::assertTrue(self::documentedVerifier($message, $key->toPublic()));
+    }
+
+    #[Test]
+    public function aMessageWhoseCritIsNotAnArrayIsRejected(): void
+    {
+        // Given
+        $key = self::signingKey();
+        $header = MapObject::create([
+            MapItem::create(UnsignedIntegerObject::create(1), NegativeIntegerObject::create(ES256::identifier())),
+            MapItem::create(UnsignedIntegerObject::create(2), UnsignedIntegerObject::create(1)),
+        ]);
+        $message = self::signHeader($key, $header, self::PAYLOAD);
+
+        // Then
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('"crit" is not an array');
+        self::documentedVerifier($message, $key->toPublic());
+    }
+
+    /**
+     * RFC 9052 sections 3 and 9: a label used twice in a header map makes the message malformed. The rule is enforced
+     * by the CBOR decoder, which is why this package declares a floor on spomky-labs/cbor-php.
+     */
+    #[Test]
+    public function aMessageWhoseProtectedHeaderRepeatsALabelIsRejected(): void
+    {
+        // Given: protected header {1: -7, 1: -8}, empty unprotected map, payload "abc", 1-byte signature
+        $message = hex2bin('d28445a201260127a0436162634100');
+        static::assertNotFalse($message);
+
+        // Then
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The key "1" is defined more than once in the map.');
+        self::documentedVerifier($message, self::signingKey()->toPublic());
+    }
+
+    /**
+     * The verifier of README.md and doc/Usage.md, copied as it is documented.
+     */
+    private static function documentedVerifier(string $encodedData, Ec2Key $key): bool
+    {
+        $algorithm = ES256::create();
+        $understoodLabels = self::UNDERSTOOD_LABELS;
+
+        $tagManager = TagManager::create()
+            ->add(CoseSign1Tag::class);
+        $decoder = Decoder::create($tagManager, OtherObjectManager::create());
+
+        $coseSign1 = $decoder->decode(new StringStream($encodedData));
+        $header = $coseSign1->getProtectedHeaderAsMap();
+
+        // RFC 9052 §3.1: bind the signature to the algorithm the protected header declares.
+        if (! $header->has(1) || (int) $header->get(1)->normalize() !== $algorithm::identifier()) {
+            throw new RuntimeException('Unexpected or missing "alg" in the protected header');
+        }
+
+        // RFC 9052 §3.1: every parameter listed in "crit" must be processed, or the message must be rejected.
+        if ($header->has(2)) {
+            $crit = $header->get(2);
+            if (! $crit instanceof ListObject) {
+                throw new RuntimeException('"crit" is not an array');
+            }
+            foreach ($crit as $label) {
+                if (! in_array((int) $label->normalize(), $understoodLabels, true)) {
+                    throw new RuntimeException('Unsupported critical header parameter');
+                }
+            }
+        }
+
+        $sigStructure = Signature1::create($coseSign1->getProtectedHeader(), $coseSign1->getPayload());
+
+        return $algorithm->verify((string) $sigStructure, $key, $coseSign1->getSignature()->getValue());
+    }
+
+    /**
+     * @param array<int>|null $crit
+     */
+    private static function sign(Ec2Key $key, ?int $alg, ?array $crit, string $payload): string
+    {
+        $items = [];
+        if ($alg !== null) {
+            $items[] = MapItem::create(UnsignedIntegerObject::create(1), NegativeIntegerObject::create($alg));
+        }
+        if ($crit !== null) {
+            $labels = [];
+            foreach ($crit as $label) {
+                $labels[] = UnsignedIntegerObject::create($label);
+            }
+            $items[] = MapItem::create(UnsignedIntegerObject::create(2), ListObject::create($labels));
+        }
+
+        return self::signHeader($key, MapObject::create($items), $payload);
+    }
+
+    private static function signHeader(Ec2Key $key, MapObject $protectedHeader, string $payload): string
+    {
+        $protectedHeaderAsBytes = ByteStringObject::create((string) $protectedHeader);
+        $payloadObject = ByteStringObject::create($payload);
+        $toBeSigned = Signature1::create($protectedHeaderAsBytes, $payloadObject);
+        $signature = ES256::create()
+            ->sign((string) $toBeSigned, $key);
+
+        return (string) CoseSign1Tag::create(
+            $protectedHeader,
+            MapObject::create(),
+            $payloadObject,
+            ByteStringObject::create($signature)
+        );
+    }
+
+    private static function replacePayload(string $message, string $payload): string
+    {
+        $tagManager = TagManager::create()
+            ->add(CoseSign1Tag::class);
+        $decoder = Decoder::create($tagManager, OtherObjectManager::create());
+        $coseSign1 = $decoder->decode(new StringStream($message));
+
+        return (string) CoseSign1Tag::create(
+            $coseSign1->getProtectedHeaderAsMap(),
+            $coseSign1->getUnprotectedHeader(),
+            ByteStringObject::create($payload),
+            $coseSign1->getSignature()
+        );
+    }
+
+    private static function signingKey(): Ec2Key
+    {
+        $details = openssl_pkey_get_details(openssl_pkey_new([
+            'private_key_type' => OPENSSL_KEYTYPE_EC,
+            'curve_name' => 'prime256v1',
+        ]))['ec'];
+        // OpenSSL strips the leading zero bytes of the coordinates; COSE requires them to be fixed size.
+        $pad = static fn (string $value): string => str_pad($value, 32, "\x00", STR_PAD_LEFT);
+
+        return Ec2Key::create([
+            Ec2Key::TYPE => Ec2Key::TYPE_EC2,
+            Ec2Key::DATA_CURVE => Ec2Key::CURVE_P256,
+            Ec2Key::DATA_X => $pad($details['x']),
+            Ec2Key::DATA_Y => $pad($details['y']),
+            Ec2Key::DATA_D => $pad($details['d']),
+        ]);
+    }
+}


### PR DESCRIPTION
Target branch: 4.8.x
Resolves #171

- [x] It is a Bug fix
- [x] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

Packaging and documentation fixes for the six defects of #171, plus the two pieces of runtime hardening the issue
proposes. No BC break: nothing that used to install still fails to install, and no public signature loses an
argument.

## What changed

**1. `ext-sodium` (finding 1).** Already fixed on 4.8.x by `6daf54e`: the extension is declared in `suggest`, and
every EdDSA algorithm now settles availability in its constructor (`EdDSA::isSupported()`, `RuntimeException`
otherwise) instead of reporting a valid Ed25519 signature as invalid. **The issue proposed moving it into `require`;
this PR keeps it a suggestion**, because a hard platform requirement would make the package uninstallable on a build
without sodium — a break for consumers who use nothing but ECDSA/RSA — while the fail-fast constructor already names
the platform rather than the signature. `tests/PackagingTest.php` now pins the declaration, which was added and
reverted five minutes later in 2019 with nothing to notice.

`EdDSA::verify()` additionally stops catching `Throwable`: only the `SodiumException` raised by a mis-sized signature
or public key becomes `false`, and an engine error propagates.

**2. cbor-php floor (finding 2).** `conflict: {"spomky-labs/cbor-php": "<3.3.4"}` — `require-dev` is never read
downstream, so the `conflict` entry is what makes the floor binding, without turning the optional dependency into a
hard one. `require-dev` and the suggestion follow. Duplicate labels are rejected since 3.3.4 (GHSA-388j-mw2g-rx5f),
the depth bound exists since 3.3.3, and nothing in `src/` re-checks either rule. The `--prefer-lowest` CI job now
exercises 3.3.4 rather than 3.2.2.

The optional hardening the issue suggests comes with it: the decoder the six tag classes build when the caller gives
none is bounded to `DEFAULT_PROTECTED_HEADER_MAX_DEPTH` (32) instead of the cbor-php default of 1000, with the bound
exposed as a new optional `$maxDepth` argument of `getProtectedHeaderAsMap()` for the header that legitimately needs
another one. A caller-provided decoder keeps its own bound.

**3. Project files (finding 3).** `SECURITY.md` no longer carries a matrix of its own: it points at the one in
`RELEASES.md`, which now lists 4.8.x/4.7.x supported, 4.6.x/4.5.x security-fix-only, `< 4.5.x` unsupported. Both
mention GitHub private vulnerability reporting next to the address. The pull request template routes security reports
there instead of the Gitter room. README links `.github/CONTRIBUTING.md` (the `doc/Contributing.md` link was dead) and
`composer test` now exists.

**4. Verification examples (finding 4).** The README and `doc/Usage.md` snippets ran into an undefined
`$derSignature` and a `$publicKey` from nowhere; once made runnable they accepted a message carrying `crit: [999]`, a
header announcing `alg = -37` or `-8` over an ES256 signature, and a header with no `alg` at all. Both examples now
verify with the library's own objects, read `alg` from the protected header and refuse any `crit` label the
application does not process (RFC 9052 §3.1), and a "What the application must check" paragraph says why those two
checks are the caller's. `tests/Signature/DocumentedVerifierTest.php` runs that code.

**5. Ed512/Ed256 (finding 5).** `doc/Usage.md` described `Ed512` as "Ed448 … EdDSA with Curve448"; it is Ed25519 over
a SHA-512 digest, and an Ed448 key makes it throw. Docs, class docblocks and `Algorithms.php` now say what -260 and
-261 are — non-standard pre-hash variants, registered to WalnutDSA and TurboSHAKE128 respectively — and point at
`FullySpecified\Ed448` (-53) for Curve448. The README `Ed25519` row carries its identifier. No runtime change: these
are non-standard rather than weak, so the insecure-algorithm policy (warning plus acknowledgement flag) does not
apply.

**6. `CONTRIBUTING.md` (finding 6).** `curl -s http://getcomposer.org/installer | php` is gone; the guide points at
the official download page and its SHA-384 verification.

## Tests

- `tests/Signature/DocumentedVerifierTest.php` — the documented verifier, run against a genuine ES256 message, a
  tampered payload, `crit: [999]`, an understood `crit`, a non-array `crit`, `alg = -37`, no `alg`, and a protected
  header repeating label 1.
- `tests/ProtectedHeaderDecodingTest.php` — over the six tag classes: a well-formed header decodes, a header
  repeating a label is rejected, a 5 000-level header is rejected instead of exhausting memory, the bound is
  configurable and a caller-provided decoder keeps its own.
- `tests/PackagingTest.php` — `ext-sodium` declared, the cbor-php `conflict`/`require-dev`/`suggest` floor, the
  `test` script, the documented files exist, security reports go to a private channel, no installer piped into `php`.

520 tests / 1962 assertions green on PHP 8.2, 8.4 and with `--prefer-lowest` (cbor-php 3.3.4); ECS, PHPStan (max),
Rector, deptrac, parallel-lint, `composer validate --strict` and `composer normalize` all clean.

## Note on the version floor

The comment on #171 says that if #176 (deprecating the six tag classes in favour of the ones cbor-php 3.4.0 ships)
lands in the same release, the floor should be `^3.4` / `<3.4.0`. cbor-php 3.4.0 is not released yet (latest is
3.3.5), so this PR uses 3.3.4 — the version that actually brings the two rules — and the constraint can be raised
when #176 lands.
