### PR TITLE
feat(structures): deprecate the COSE tag classes and keep the RFC 9052 layer (#166, #176)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,24 @@ This library implements:
 
 ## Features
 
-✅ **Complete COSE Tag Support**
-- COSE_Sign1 (tag 18) - Single signature
-- COSE_Sign (tag 98) - Multiple signatures
-- COSE_Encrypt0 (tag 16) - Single recipient encryption
-- COSE_Encrypt (tag 96) - Multiple recipients encryption
-- COSE_Mac0 (tag 17) - MAC without recipients
-- COSE_Mac (tag 97) - MAC with recipients
+✅ **RFC 9052 Cryptographic Structures**
+- `Sig_structure`: `Signature1` (§4.4) and `Signature`, which also covers the signer's own protected header
+- `MAC_structure`: `Mac0Structure` and `MacStructure` (§6.3) — a MAC tag covers this, never the bare payload
+- `Enc_structure`: `Encrypt0Structure`, `EncryptStructure` and `RecipientStructure` (§5.3)
+- Each takes the optional `external_aad`, defaulting to the zero-length byte string the RFC prescribes
+
+✅ **RFC 9052 Header and Structure Rules**
+- `CoseHeaders` reads the two buckets of any COSE message: a label is an integer *or* a text string (§1.5) and the
+  two never answer for each other, the zero-length protected header is accepted (§3), trailing bytes in the
+  protected bucket are not, and the protected value wins a combined lookup
+- `CoseSignature` and `CoseRecipient` are the checked views over the `signatures` and `recipients` lists (`[+ ...]`)
+- Works on the COSE message classes of spomky-labs/cbor-php 3.4.0
+
+✅ **COSE Tag Support** (via [spomky-labs/cbor-php](https://github.com/Spomky-Labs/cbor-php) 3.4.0)
+- `CBOR\Tag\CoseSign1Tag` (18), `CoseSignTag` (98), `CoseEncrypt0Tag` (16), `CoseEncryptTag` (96),
+  `CoseMac0Tag` (17), `CoseMacTag` (97), plus `CwtTag` (61), all registered in the default decoder
+- The `Cose\...Tag` classes of this library are **deprecated since 4.8.0** and removed in 5.0.0; see
+  [Upgrading](doc/Usage.md#upgrading-from-the-cosetag-classes)
 
 ✅ **Cryptographic Algorithms**
 - **Signatures**: ECDSA (ES256, ES384, ES512, ES256K), EdDSA (Ed25519, Ed448), RSA (RS256/384/512, PS256/384/512)
@@ -52,9 +63,10 @@ For COSE tag support (Sign, Encrypt, Mac operations), also install:
 composer require "spomky-labs/cbor-php:^3.3.4"
 ```
 
-3.3.4 is the floor this library declares (`conflict: <3.3.4`): the CBOR decoder is what enforces the header-map rules
-of [RFC 9052](https://datatracker.ietf.org/doc/html/rfc9052) — a label appearing twice in a map makes the message
-malformed (§3, §9), and nesting is bounded so that a crafted header cannot exhaust the memory of the process.
+3.4.0 is the floor this library declares (`conflict: <3.4.0`). Two things come from there rather than from here: the
+CBOR decoder enforces the header-map rules of [RFC 9052](https://datatracker.ietf.org/doc/html/rfc9052) — a label
+appearing twice in a map makes the message malformed (§3, §9), and nesting is bounded so that a crafted header cannot
+exhaust the memory of the process — and, since 3.4.0, the six COSE message classes themselves.
 
 ## Quick Start
 
@@ -63,13 +75,13 @@ malformed (§3, §9), and nesting is bounded so that a crafted header cannot exh
 ```php
 use CBOR\Decoder;
 use CBOR\ListObject;
-use CBOR\OtherObject\OtherObjectManager;
+use CBOR\OtherObject\NullObject;
 use CBOR\StringStream;
-use CBOR\Tag\TagManager;
+use CBOR\Tag\CoseSign1Tag;
 use Cose\Algorithm\Signature\ECDSA\ES256;
 use Cose\Key\Ec2Key;
-use Cose\Signature\CoseSign1Tag;
 use Cose\Signature\Signature1;
+use Cose\Structure\CoseHeaders;
 
 // The key of the signer you trust, and the algorithm you expect it to be used with.
 $key = Ec2Key::create($theCoseKeyYouPinned);
@@ -77,22 +89,26 @@ $algorithm = ES256::create();
 // The protected header labels this application knows how to process (1 = alg, 2 = crit).
 $understoodLabels = [1, 2];
 
-// Setup decoder with COSE tag support
-$tagManager = TagManager::create()->add(CoseSign1Tag::class);
-$decoder = Decoder::create($tagManager, OtherObjectManager::create());
+// cbor-php 3.4.0 registers the six COSE tags in the default decoder: tag 18 resolves on its own.
+$coseSign1 = Decoder::create()->decode(new StringStream($encodedData));
+if (! $coseSign1 instanceof CoseSign1Tag) {
+    throw new RuntimeException('Not a COSE_Sign1 message');
+}
 
-// Decode COSE_Sign1 message
-$coseSign1 = $decoder->decode(new StringStream($encodedData));
-$header = $coseSign1->getProtectedHeaderAsMap();
+// cbor-php carries the header buckets; this library reads them the way RFC 9052 defines them.
+$headers = CoseHeaders::fromMessage($coseSign1);
 
 // RFC 9052 §3.1: bind the signature to the algorithm the protected header declares.
-if (! $header->has(1) || (int) $header->get(1)->normalize() !== $algorithm::identifier()) {
+// The label is matched by type as well as by value, so the text string "1" — a different label under §1.5 —
+// never answers a lookup for the integer label 1.
+$alg = $headers->getProtectedHeaderParameter(1);
+if ($alg === null || (int) $alg->normalize() !== $algorithm::identifier()) {
     throw new RuntimeException('Unexpected or missing "alg" in the protected header');
 }
 
 // RFC 9052 §3.1: every parameter listed in "crit" must be processed, or the message must be rejected.
-if ($header->has(2)) {
-    $crit = $header->get(2);
+$crit = $headers->getProtectedHeaderParameter(2);
+if ($crit !== null) {
     if (! $crit instanceof ListObject) {
         throw new RuntimeException('"crit" is not an array');
     }
@@ -103,8 +119,14 @@ if ($header->has(2)) {
     }
 }
 
+// RFC 9052 §4.2: a nil payload is detached and the application supplies the content itself.
+$payload = $coseSign1->getPayload();
+if ($payload instanceof NullObject) {
+    throw new RuntimeException('The payload is detached; supply it from the application');
+}
+
 // Verify the Sig_structure the signature covers
-$sigStructure = Signature1::create($coseSign1->getProtectedHeader(), $coseSign1->getPayload());
+$sigStructure = Signature1::create($coseSign1->getProtectedHeader(), $payload);
 $isValid = $algorithm->verify((string) $sigStructure, $key, $coseSign1->getSignature()->getValue());
 ```
 
@@ -122,7 +144,7 @@ use CBOR\MapItem;
 use CBOR\MapObject;
 use CBOR\NegativeIntegerObject;
 use CBOR\UnsignedIntegerObject;
-use Cose\Signature\CoseSign1Tag;
+use CBOR\Tag\CoseSign1Tag;
 
 // Define headers
 $protectedHeader = MapObject::create([
@@ -140,7 +162,7 @@ $unprotectedHeader = MapObject::create([
 ]);
 
 // Create COSE_Sign1
-$coseSign1 = CoseSign1Tag::create(
+$coseSign1 = CoseSign1Tag::createFromComponents(
     $protectedHeader,
     $unprotectedHeader,
     ByteStringObject::create('Message to sign'),

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -21,3 +21,37 @@ This matrix is the single source of truth for the branches under support; [SECUR
 | 4.6.x   | :white_check_mark: (security fix only) |
 | 4.5.x   | :white_check_mark: (security fix only) |
 | < 4.5.x | :x:                                    |
+
+## Upgrading
+
+### 4.7.x to 4.8.x
+
+**The six COSE message classes are deprecated.** `Cose\Signature\CoseSign1Tag`, `Cose\Signature\CoseSignTag`,
+`Cose\Mac\CoseMac0Tag`, `Cose\Mac\CoseMacTag`, `Cose\Encryption\CoseEncrypt0Tag` and `Cose\Encryption\CoseEncryptTag`
+raise an `E_USER_DEPRECATED` on construction and are removed in 5.0.0. They were ported into
+spomky-labs/cbor-php 3.4.0, as `CBOR\Tag\CoseSign1Tag` and its siblings, which is where a description of a CBOR
+structure belongs. The wire format is identical, so a message written by a deprecated class is read by its
+replacement and the reverse; the migration is documented in
+[doc/Usage.md](doc/Usage.md#upgrading-from-the-cosetag-classes). Two points are not mechanical: the four-argument
+`create()` becomes `createFromComponents()`, and the header accessors move to `Cose\Structure\CoseHeaders`.
+
+Their behaviour is otherwise frozen for the whole 4.8.x line: a deprecation is not the place to change what a class
+accepts.
+
+**The cbor-php floor moves to 3.4.0** (`conflict: <3.4.0`), so the classes the deprecation points at are guaranteed
+to be installable.
+
+**New: the RFC 9052 rules that sit above the CBOR shape.** These are what stays in this library after 5.0.0, and they
+work on the upstream message classes:
+
+- `Cose\Structure\CoseHeaders` reads the two header buckets of any COSE message. A label is an integer *or* a text
+  string (§1.5) and the two never answer for each other, even though cbor-php normalizes them to the same map offset;
+  the zero-length protected header is accepted (§3) and trailing bytes inside the protected bucket are not; the
+  protected value wins a combined lookup.
+- `Cose\Signature\CoseSignature` and `Cose\Structure\CoseRecipient` are the checked views over the `signatures` and
+  `recipients` lists, applying the `[+ ...]` rule of §§4.1 and 5.1, nested recipients included.
+- `Cose\Structure\HeaderMapHelper` holds the same rules as static functions, including `encodeProtected()` (which
+  emits the `h''` §3 prefers for an empty map) and `assertTagNumber()`.
+- The cryptographic structures are complete: `Signature` (§4.4, with `sign_protected`), `Mac0Structure` and
+  `MacStructure` (§6.3), `Encrypt0Structure`, `EncryptStructure` and `RecipientStructure` (§5.3) join `Signature1`,
+  which gained the optional `external_aad` every structure now takes.

--- a/composer.json
+++ b/composer.json
@@ -26,19 +26,19 @@
         "spomky-labs/pki-framework": "^1.0"
     },
     "require-dev": {
-        "spomky-labs/cbor-php": "^3.3.4"
+        "spomky-labs/cbor-php": "^3.4"
     },
     "replace": {
         "symfony/polyfill-php81": "*"
     },
     "conflict": {
-        "spomky-labs/cbor-php": "<3.3.4"
+        "spomky-labs/cbor-php": "<3.4.0"
     },
     "suggest": {
         "ext-bcmath": "Recommended: without GMP or BCMath, signing with RSASSA-PSS (PS256/PS384/PS512) blinds its private exponentiation in pure PHP",
         "ext-gmp": "Recommended: without GMP or BCMath, signing with RSASSA-PSS (PS256/PS384/PS512) blinds its private exponentiation in pure PHP",
         "ext-sodium": "Required by the EdDSA/Ed25519 signature algorithms (-8, -19, -260, -261) and to recompute an OKP public key from its private key",
-        "spomky-labs/cbor-php": "Required by the COSE_Sign/COSE_Encrypt/COSE_Mac tag classes. 3.3.4 or later: the decoder is what enforces the RFC 9052 label uniqueness and nesting bounds this library relies on"
+        "spomky-labs/cbor-php": "Required by the RFC 9052 header reader and cryptographic structures. 3.4.0 or later: it ships the six COSE message classes (CBOR\\Tag\\CoseSign1Tag and its siblings) that replace the deprecated Cose\\...Tag classes, and its decoder is what enforces the RFC 9052 label uniqueness and nesting bounds this library relies on"
     },
     "autoload": {
         "psr-4": {

--- a/doc/Usage.md
+++ b/doc/Usage.md
@@ -1,6 +1,10 @@
 # How to Use COSE Library
 
-This library provides full support for COSE (CBOR Object Signing and Encryption) as defined in [RFC 9052](https://datatracker.ietf.org/doc/html/rfc9052) and [RFC 9053](https://datatracker.ietf.org/doc/html/rfc9053).
+This library implements COSE (CBOR Object Signing and Encryption) as defined in [RFC 9052](https://datatracker.ietf.org/doc/html/rfc9052) and [RFC 9053](https://datatracker.ietf.org/doc/html/rfc9053): the COSE key types, the signature and MAC algorithms, the cryptographic structures a signature or a MAC is computed over, and the header rules that decide what a message says.
+
+The six COSE message types themselves come from [spomky-labs/cbor-php](https://github.com/Spomky-Labs/cbor-php) 3.4.0 or later, as `CBOR\Tag\CoseSign1Tag` and its siblings. The `Cose\...Tag` classes this library used to ship are deprecated since 4.8.0 and removed in 5.0.0 — see [Upgrading from the Cose\...Tag classes](#upgrading-from-the-cosetag-classes).
+
+Content encryption itself is not implemented: the encryption tags carry a ciphertext the application produced, and `Enc_structure` gives that application the additional authenticated data to feed its AEAD.
 
 ## Table of Contents
 
@@ -15,6 +19,9 @@ This library provides full support for COSE (CBOR Object Signing and Encryption)
 - [MAC Operations](#mac-operations)
   - [COSE_Mac0 (Without Recipients)](#cose_mac0-without-recipients)
   - [COSE_Mac (With Recipients)](#cose_mac-with-recipients)
+  - [Detached Content](#detached-content)
+  - [External Additional Authenticated Data](#external-additional-authenticated-data)
+- [Upgrading from the Cose\...Tag classes](#upgrading-from-the-cosetag-classes)
 - [Supported Algorithms](#supported-algorithms)
   - [Fully-Specified Algorithms](#fully-specified-algorithms)
   - [Signature Verification Contract](#signature-verification-contract)
@@ -51,14 +58,18 @@ Every Ed25519 algorithm needs `ext-sodium`, which ships with PHP and is enabled 
 
 COSE defines six main tags for different cryptographic operations:
 
-| Tag | Value | Description |
-|-----|-------|-------------|
-| COSE_Sign1 | 18 | Single signature structure |
-| COSE_Sign | 98 | Multiple signatures structure |
-| COSE_Encrypt0 | 16 | Single recipient encrypted message |
-| COSE_Encrypt | 96 | Multiple recipients encrypted message |
-| COSE_Mac0 | 17 | MAC without recipients |
-| COSE_Mac | 97 | MAC with recipients |
+| Tag | Value | Class (cbor-php 3.4.0+) | Description |
+|-----|-------|--------------------------|-------------|
+| COSE_Encrypt0 | 16 | `CBOR\Tag\CoseEncrypt0Tag` | Single recipient encrypted message |
+| COSE_Mac0 | 17 | `CBOR\Tag\CoseMac0Tag` | MAC without recipients |
+| COSE_Sign1 | 18 | `CBOR\Tag\CoseSign1Tag` | Single signature structure |
+| CWT | 61 | `CBOR\Tag\CwtTag` | CBOR Web Token ([RFC 8392](https://datatracker.ietf.org/doc/html/rfc8392)) |
+| COSE_Encrypt | 96 | `CBOR\Tag\CoseEncryptTag` | Multiple recipients encrypted message |
+| COSE_Mac | 97 | `CBOR\Tag\CoseMacTag` | MAC with recipients |
+| COSE_Sign | 98 | `CBOR\Tag\CoseSignTag` | Multiple signatures structure |
+
+All seven are registered in the default decoder, so `Decoder::create()` resolves them without any `TagManager`
+configuration.
 
 ## Signature Operations
 
@@ -73,8 +84,8 @@ use CBOR\ByteStringObject;
 use CBOR\MapItem;
 use CBOR\MapObject;
 use CBOR\NegativeIntegerObject;
+use CBOR\Tag\CoseSign1Tag;
 use CBOR\UnsignedIntegerObject;
-use Cose\Signature\CoseSign1Tag;
 
 // Create headers
 $protectedHeader = MapObject::create([
@@ -98,7 +109,7 @@ $payload = ByteStringObject::create('Message to sign');
 $signature = ByteStringObject::create($yourSignatureBytes);
 
 // Create the COSE_Sign1 tag
-$coseSign1 = CoseSign1Tag::create(
+$coseSign1 = CoseSign1Tag::createFromComponents(
     $protectedHeader,
     $unprotectedHeader,
     $payload,
@@ -109,6 +120,29 @@ $coseSign1 = CoseSign1Tag::create(
 $encoded = (string) $coseSign1;
 ```
 
+> [!IMPORTANT]
+> `createFromComponents()` encodes the protected map itself. A signer computes its `Sig_structure` over the *bytes* of
+> that bucket, so build them once and pass them to both, using `create()` when the bytes have to travel verbatim:
+>
+> ```php
+> use CBOR\ListObject;
+> use Cose\Structure\HeaderMapHelper;
+>
+> // HeaderMapHelper applies RFC 9052 §3 on the way out: an empty map becomes h'' rather than h'a0', and the labels
+> // are checked (§1.5, §9).
+> $protectedHeaderAsBytes = HeaderMapHelper::encodeProtected($protectedHeader);
+>
+> $toBeSigned = Signature1::create($protectedHeaderAsBytes, $payload);
+> $signature = ByteStringObject::create($algorithm->sign((string) $toBeSigned, $key));
+>
+> $coseSign1 = CoseSign1Tag::create(ListObject::create([
+>     $protectedHeaderAsBytes,
+>     $unprotectedHeader,
+>     $payload,
+>     $signature,
+> ]));
+> ```
+
 #### Decoding and Verifying a COSE_Sign1 Message
 
 ```php
@@ -116,26 +150,27 @@ use CBOR\Decoder;
 use CBOR\ListObject;
 use CBOR\OtherObject\OtherObjectManager;
 use CBOR\StringStream;
-use CBOR\Tag\TagManager;
+use CBOR\Tag\CoseSign1Tag;
 use Cose\Algorithm\Signature\ECDSA\ES256;
 use Cose\Key\Ec2Key;
-use Cose\Signature\CoseSign1Tag;
 use Cose\Signature\Signature1;
+use Cose\Structure\CoseHeaders;
 
-// Setup decoder
-$tagManager = TagManager::create()->add(CoseSign1Tag::class);
-$decoder = Decoder::create($tagManager, OtherObjectManager::create());
-
-// Decode CBOR data
+// Decode CBOR data — the COSE tags are in the default decoder since cbor-php 3.4.0
 $stream = new StringStream($encodedData);
-$coseSign1 = $decoder->decode($stream);
+$coseSign1 = Decoder::create()->decode($stream);
 
 // Access components
-$protectedHeader = $coseSign1->getProtectedHeader(); // ByteStringObject
-$protectedHeaderMap = $coseSign1->getProtectedHeaderAsMap(); // MapObject (decoded)
+$protectedHeader = $coseSign1->getProtectedHeader(); // ByteStringObject: what the signature covers verbatim
 $unprotectedHeader = $coseSign1->getUnprotectedHeader(); // MapObject
-$payload = $coseSign1->getPayload(); // ByteStringObject
+$payload = $coseSign1->getPayload(); // ByteStringObject, or NullObject when detached
 $signature = $coseSign1->getSignature(); // ByteStringObject
+
+// The headers, read the way RFC 9052 defines them
+$headers = CoseHeaders::fromMessage($coseSign1);
+$protectedHeaderMap = $headers->getProtectedHeaderAsMap(); // MapObject, checked
+$alg = $headers->getProtectedHeaderParameter(1);           // ?CBORObject
+$kid = $headers->getHeaderParameter(4);                    // ?CBORObject, protected bucket first
 
 // The key of the signer you trust, and the algorithm you expect it to be used with
 $key = Ec2Key::create($theCoseKeyYouPinned);
@@ -144,14 +179,16 @@ $algorithm = ES256::create();
 $understoodLabels = [1, 2];
 
 // RFC 9052 §3.1: bind the signature to the algorithm the protected header declares
-if (! $protectedHeaderMap->has(1)
-    || (int) $protectedHeaderMap->get(1)->normalize() !== $algorithm::identifier()) {
+// The label is matched by type as well as by value, so the text string "1" — a different label under §1.5 —
+// never answers a lookup for the integer label 1.
+$alg = $headers->getProtectedHeaderParameter(1);
+if ($alg === null || (int) $alg->normalize() !== $algorithm::identifier()) {
     throw new RuntimeException('Unexpected or missing "alg" in the protected header');
 }
 
 // RFC 9052 §3.1: every parameter listed in "crit" must be processed, or the message must be rejected
-if ($protectedHeaderMap->has(2)) {
-    $crit = $protectedHeaderMap->get(2);
+$crit = $headers->getProtectedHeaderParameter(2);
+if ($crit !== null) {
     if (! $crit instanceof ListObject) {
         throw new RuntimeException('"crit" is not an array');
     }
@@ -183,10 +220,9 @@ both are in the snippet above:
 - **`crit` (label 2)** — it lists the protected header parameters a recipient is *required* to understand. Any label
   in that list your application does not process makes the message unusable: reject it instead of verifying it.
 
-The protected header itself is decoded with a decoder bounded to
-`CoseSign1Tag::DEFAULT_PROTECTED_HEADER_MAX_DEPTH` (32) levels of nesting. Pass your own `Decoder` to
-`getProtectedHeaderAsMap()` when a header carries custom CBOR tags, or a different `$maxDepth` when 32 is not the
-right bound:
+The protected header is decoded with a decoder bounded to `CoseHeaders::DEFAULT_PROTECTED_HEADER_MAX_DEPTH` (32)
+levels of nesting. Pass your own `Decoder` when a header carries custom CBOR tags, or a different `$maxDepth` when 32
+is not the right bound:
 
 ```php
 // Use a custom decoder for the protected header (e.g. with custom CBOR tags)
@@ -195,7 +231,7 @@ $customDecoder = Decoder::create(
     OtherObjectManager::create(),
     32
 );
-$protectedHeaderMap = $coseSign1->getProtectedHeaderAsMap($customDecoder);
+$headers = CoseHeaders::fromMessage($coseSign1, $customDecoder);
 ```
 
 ### COSE_Sign (Multiple Signers)
@@ -206,7 +242,8 @@ The `COSE_Sign` structure supports multiple signatures from different signers.
 use CBOR\ByteStringObject;
 use CBOR\ListObject;
 use CBOR\MapObject;
-use Cose\Signature\CoseSignTag;
+use CBOR\Tag\CoseSignTag;
+use Cose\Signature\CoseSignature;
 
 $protectedHeader = MapObject::create();
 $unprotectedHeader = MapObject::create();
@@ -226,13 +263,40 @@ $signatures = ListObject::create([
     ]),
 ]);
 
-$coseSign = CoseSignTag::create(
+$coseSign = CoseSignTag::createFromComponents(
     $protectedHeader,
     $unprotectedHeader,
     $payload,
     $signatures
 );
+
+// Reading them back as checked views rather than raw lists
+foreach (CoseSignature::all($coseSign->getSignatures()) as $signer) {
+    $signerProtectedHeader = $signer->getProtectedHeader();   // ByteStringObject
+    $kid = $signer->getUnprotectedHeaderParameter(4);         // ?CBORObject
+    $signatureValue = $signer->getSignature();                // ByteStringObject
+}
 ```
+
+> [!IMPORTANT]
+> Each signature of a `COSE_Sign` covers the `Signature` structure of
+> [RFC 9052 §4.4](https://datatracker.ietf.org/doc/html/rfc9052#section-4.4), which carries the protected bucket of the
+> message **and** the one of the signer's own entry — not the `Signature1` structure a `COSE_Sign1` uses:
+>
+> ```php
+> use Cose\Signature\Signature;
+>
+> $toBeSigned = Signature::create(
+>     $coseSign->getProtectedHeader(),   // body_protected
+>     $signer->getProtectedHeader(),     // sign_protected
+>     $coseSign->getPayload(),
+> );
+> $isValid = $algorithm->verify((string) $toBeSigned, $key, $signer->getSignature()->getValue());
+> ```
+>
+> RFC 9052 §4.1 writes the list as `[+ COSE_Signature]`: at least one entry, each a `[bstr, map, bstr]` array. The CBOR
+> layer only checks that the item is a list, so `CoseSignature::all()` is where that rule is applied — it rejects an
+> empty list and any entry of another shape.
 
 ## Encryption Operations
 
@@ -241,13 +305,13 @@ $coseSign = CoseSignTag::create(
 ```php
 use CBOR\ByteStringObject;
 use CBOR\MapObject;
-use Cose\Encryption\CoseEncrypt0Tag;
+use CBOR\Tag\CoseEncrypt0Tag;
 
 $protectedHeader = MapObject::create([/* algorithm, etc. */]);
 $unprotectedHeader = MapObject::create([/* IV, kid, etc. */]);
 $ciphertext = ByteStringObject::create($encryptedData);
 
-$coseEncrypt0 = CoseEncrypt0Tag::create(
+$coseEncrypt0 = CoseEncrypt0Tag::createFromComponents(
     $protectedHeader,
     $unprotectedHeader,
     $ciphertext
@@ -258,20 +322,46 @@ $coseEncrypt0 = CoseEncrypt0Tag::create(
 
 ```php
 use CBOR\ListObject;
-use Cose\Encryption\CoseEncryptTag;
+use CBOR\Tag\CoseEncryptTag;
+use Cose\Structure\CoseRecipient;
 
 $recipients = ListObject::create([
     ListObject::create([/* recipient 1 structure */]),
     ListObject::create([/* recipient 2 structure */]),
 ]);
 
-$coseEncrypt = CoseEncryptTag::create(
+$coseEncrypt = CoseEncryptTag::createFromComponents(
     $protectedHeader,
     $unprotectedHeader,
     $ciphertext,
     $recipients
 );
+
+// Reading them back as checked views; a recipient may carry recipients of its own
+foreach (CoseRecipient::all($coseEncrypt->getRecipients()) as $recipient) {
+    $kid = $recipient->getUnprotectedHeaderParameter(4);
+    $wrappedKey = $recipient->hasDetachedCiphertext() ? null : $recipient->getCiphertext();
+    $nested = $recipient->getRecipients(); // list<CoseRecipient>
+}
 ```
+
+> [!IMPORTANT]
+> The additional authenticated data of the content encryption is the `Enc_structure` of
+> [RFC 9052 §5.3](https://datatracker.ietf.org/doc/html/rfc9052#section-5.3), not the protected header on its own:
+>
+> ```php
+> use Cose\Encryption\Encrypt0Structure;
+> use Cose\Encryption\EncryptStructure;
+> use Cose\Encryption\RecipientStructure;
+>
+> $aad = (string) EncryptStructure::create($coseEncrypt->getProtectedHeader());               // "Encrypt"
+> $aad = (string) Encrypt0Structure::create($coseEncrypt0->getProtectedHeader());             // "Encrypt0"
+> $aad = (string) RecipientStructure::forEncryptRecipient($recipient->getProtectedHeader());  // "Enc_Recipient"
+> ```
+>
+> RFC 9052 §5.1 writes the list as `[+COSE_recipient]`: at least one entry, each a
+> `[bstr, map, bstr / nil, ? [+ COSE_recipient]]` array. `CoseRecipient::all()` applies that rule, nested levels
+> included.
 
 ## MAC Operations
 
@@ -280,14 +370,14 @@ $coseEncrypt = CoseEncryptTag::create(
 ```php
 use CBOR\ByteStringObject;
 use CBOR\MapObject;
-use Cose\Mac\CoseMac0Tag;
+use CBOR\Tag\CoseMac0Tag;
 
 $protectedHeader = MapObject::create([/* algorithm */]);
 $unprotectedHeader = MapObject::create();
 $payload = ByteStringObject::create('Data to authenticate');
 $tag = ByteStringObject::create($macTag);
 
-$coseMac0 = CoseMac0Tag::create(
+$coseMac0 = CoseMac0Tag::createFromComponents(
     $protectedHeader,
     $unprotectedHeader,
     $payload,
@@ -299,11 +389,11 @@ $coseMac0 = CoseMac0Tag::create(
 
 ```php
 use CBOR\ListObject;
-use Cose\Mac\CoseMacTag;
+use CBOR\Tag\CoseMacTag;
 
 $recipients = ListObject::create([/* recipient structures */]);
 
-$coseMac = CoseMacTag::create(
+$coseMac = CoseMacTag::createFromComponents(
     $protectedHeader,
     $unprotectedHeader,
     $payload,
@@ -311,6 +401,112 @@ $coseMac = CoseMacTag::create(
     $recipients
 );
 ```
+
+> [!IMPORTANT]
+> The `$macTag` of both examples above is **not** a MAC of the payload. It is computed over the `MAC_structure` of
+> [RFC 9052 §6.3](https://datatracker.ietf.org/doc/html/rfc9052#section-6.3), which binds the tag to the protected
+> header and to the message type:
+>
+> ```php
+> use Cose\Mac\Mac0Structure;
+> use Cose\Mac\MacStructure;
+>
+> // COSE_Mac0: context "MAC0"
+> $toBeMaced = Mac0Structure::create($coseMac0->getProtectedHeader(), $coseMac0->getPayload());
+> $macTag = $algorithm->hash((string) $toBeMaced, $key);
+>
+> // COSE_Mac: context "MAC" — the same header and payload give a different tag
+> $toBeMaced = MacStructure::create($coseMac->getProtectedHeader(), $coseMac->getPayload());
+> $isValid = $algorithm->verify((string) $toBeMaced, $key, $coseMac->getTag()->getValue());
+> ```
+>
+> `Cose\Algorithm\Mac\Mac::hash()` and `verify()` authenticate exactly the bytes they are given, so passing
+> `getPayload()->getValue()` straight to them produces a tag bound to nothing and interoperable with no other
+> implementation.
+
+### Detached Content
+
+[RFC 9052 §4.1](https://datatracker.ietf.org/doc/html/rfc9052#section-4.1) lets the payload — or the ciphertext of an
+encrypted message — travel outside the message, as a `nil` in its place:
+
+```php
+use CBOR\OtherObject\NullObject;
+
+// Sending
+$coseSign1 = CoseSign1Tag::createFromComponents(
+    $protectedHeader,
+    $unprotectedHeader,
+    NullObject::create(),
+    $signature
+);
+
+// Receiving: the application supplies the content it transported separately
+$payload = $coseSign1->getPayload();
+if ($payload instanceof NullObject) {
+    $payload = ByteStringObject::create($contentYouTransportedSeparately);
+}
+
+$toBeSigned = Signature1::create($coseSign1->getProtectedHeader(), $payload);
+```
+
+### External Additional Authenticated Data
+
+Every structure takes the optional `external_aad` of
+[RFC 9052 §4.4](https://datatracker.ietf.org/doc/html/rfc9052#section-4.4) as its last argument. It defaults to the
+zero-length byte string the RFC prescribes:
+
+```php
+$toBeSigned = Signature1::create(
+    $coseSign1->getProtectedHeader(),
+    $payload,
+    ByteStringObject::create($applicationSuppliedData),
+);
+```
+
+## Upgrading from the `Cose\...Tag` classes
+
+The six COSE message classes were ported into
+[spomky-labs/cbor-php](https://github.com/Spomky-Labs/cbor-php) 3.4.0, which is where they belong: they describe the
+shape of a CBOR structure and nothing more. The `Cose\...Tag` classes of this library are **deprecated since 4.8.0**,
+raise an `E_USER_DEPRECATED` on construction, and are **removed in 5.0.0**.
+
+| Deprecated | Replacement |
+|---|---|
+| `Cose\Signature\CoseSign1Tag` | `CBOR\Tag\CoseSign1Tag` |
+| `Cose\Signature\CoseSignTag` | `CBOR\Tag\CoseSignTag` |
+| `Cose\Mac\CoseMac0Tag` | `CBOR\Tag\CoseMac0Tag` |
+| `Cose\Mac\CoseMacTag` | `CBOR\Tag\CoseMacTag` |
+| `Cose\Encryption\CoseEncrypt0Tag` | `CBOR\Tag\CoseEncrypt0Tag` |
+| `Cose\Encryption\CoseEncryptTag` | `CBOR\Tag\CoseEncryptTag` |
+| — | `CBOR\Tag\CwtTag` (tag 61, new) |
+
+Nothing else changes: the wire format is identical, so a message written by a deprecated class is read by its
+replacement and the reverse. What the migration has to handle:
+
+- **`create()` becomes `createFromComponents()`.** This is the one point where renaming the class is not enough:
+  upstream `create()` also exists, and takes the whole `ListObject` instead of the four parts. A leftover
+  four-argument `create()` call raises an `ArgumentCountError` rather than misbehaving quietly.
+- **Registering the tags is no longer needed.** `Decoder::create()` resolves all seven on its own;
+  `TagManager::create()->add(...)` was only ever needed because the classes lived here.
+- **`getPayload()` can return `NullObject`.** Detached content is representable now, so the return type is
+  `ByteStringObject|IndefiniteLengthByteStringObject|NullObject`.
+- **The accessors also return the `IndefiniteLength...` variants**, which the deprecated classes rejected outright.
+- **The header accessors move to `CoseHeaders`.** `getProtectedHeaderAsMap()` exists upstream but applies only the
+  CBOR rules; the RFC 9052 ones — label typing, trailing data, the protected-first lookup — stay here:
+
+  ```php
+  // before
+  $map = $coseSign1->getProtectedHeaderAsMap();
+  $alg = $map->has(1) ? $map->get(1) : null;
+
+  // after
+  $alg = CoseHeaders::fromMessage($coseSign1)->getProtectedHeaderParameter(1);
+  ```
+
+- **`getSignatures()` and `getRecipients()` still return raw lists.** Wrap them in `CoseSignature::all()` or
+  `CoseRecipient::all()` to get the `[+ ...]` rule of RFC 9052 and typed entries.
+
+`Signature1` and the other structure builders are **not** superseded and need no change.
 
 ## Supported Algorithms
 

--- a/src/Encryption/CoseEncrypt0Tag.php
+++ b/src/Encryption/CoseEncrypt0Tag.php
@@ -12,9 +12,34 @@ use CBOR\MapObject;
 use CBOR\OtherObject\OtherObjectManager;
 use CBOR\StringStream;
 use CBOR\Tag;
+use CBOR\Tag\CoseEncrypt0Tag as UpstreamTag;
 use CBOR\Tag\TagManager;
+use const E_USER_DEPRECATED;
 use InvalidArgumentException;
+use function sprintf;
+use function trigger_error;
 
+/**
+ * A tagged COSE_Encrypt0 (RFC 9052, CBOR tag 16).
+ *
+ * @deprecated since 4.8.0, use \CBOR\Tag\CoseEncrypt0Tag from spomky-labs/cbor-php 3.4.0 or later instead. Will be removed
+ * in 5.0.0.
+ *
+ * The six COSE structures were ported upstream in cbor-php 3.4.0, where they share AbstractCoseTag and are
+ * registered in the default decoder, so Decoder::create() resolves tag 16 on its own. The replacement accepts what
+ * this class rejects -- a zero-length protected header, a detached (nil) payload, the indefinite-length encodings --
+ * and reads every item through the list it carries, so its accessors cannot drift from the bytes it serializes.
+ *
+ * What does not move upstream is the RFC 9052 layer above the CBOR shape, and that stays here: {@see \Cose\Structure\CoseHeaders}
+ * for header labels typed as RFC 9052 section 1.5 defines them, and the Sig_structure, MAC_structure and
+ * Enc_structure builders that a signature or a MAC is actually computed over. Both work on the upstream classes.
+ *
+ * Migrating: the class name changes, and the four-argument create() becomes createFromComponents() -- upstream
+ * create() takes the whole list instead.
+ *
+ * @see https://github.com/web-auth/cose-lib/issues/176
+ * @see \Cose\Tests\Structure\DeprecatedTagClassesTest
+ */
 final class CoseEncrypt0Tag extends Tag
 {
     /**
@@ -34,6 +59,12 @@ final class CoseEncrypt0Tag extends Tag
 
     public function __construct(int $additionalInformation, ?string $data, CBORObject $object)
     {
+        trigger_error(sprintf(
+            'The class "%s" is deprecated since 4.8.0 and will be removed in 5.0.0. Use "%s" from spomky-labs/cbor-php 3.4.0 or later instead.',
+            self::class,
+            UpstreamTag::class
+        ), E_USER_DEPRECATED);
+
         if (! $object instanceof ListObject) {
             throw new InvalidArgumentException('Not a valid CoseEncrypt0 object. No list.');
         }

--- a/src/Encryption/CoseEncryptTag.php
+++ b/src/Encryption/CoseEncryptTag.php
@@ -12,9 +12,34 @@ use CBOR\MapObject;
 use CBOR\OtherObject\OtherObjectManager;
 use CBOR\StringStream;
 use CBOR\Tag;
+use CBOR\Tag\CoseEncryptTag as UpstreamTag;
 use CBOR\Tag\TagManager;
+use const E_USER_DEPRECATED;
 use InvalidArgumentException;
+use function sprintf;
+use function trigger_error;
 
+/**
+ * A tagged COSE_Encrypt (RFC 9052, CBOR tag 96).
+ *
+ * @deprecated since 4.8.0, use \CBOR\Tag\CoseEncryptTag from spomky-labs/cbor-php 3.4.0 or later instead. Will be removed
+ * in 5.0.0.
+ *
+ * The six COSE structures were ported upstream in cbor-php 3.4.0, where they share AbstractCoseTag and are
+ * registered in the default decoder, so Decoder::create() resolves tag 96 on its own. The replacement accepts what
+ * this class rejects -- a zero-length protected header, a detached (nil) payload, the indefinite-length encodings --
+ * and reads every item through the list it carries, so its accessors cannot drift from the bytes it serializes.
+ *
+ * What does not move upstream is the RFC 9052 layer above the CBOR shape, and that stays here: {@see \Cose\Structure\CoseHeaders}
+ * for header labels typed as RFC 9052 section 1.5 defines them, and the Sig_structure, MAC_structure and
+ * Enc_structure builders that a signature or a MAC is actually computed over. Both work on the upstream classes.
+ *
+ * Migrating: the class name changes, and the four-argument create() becomes createFromComponents() -- upstream
+ * create() takes the whole list instead.
+ *
+ * @see https://github.com/web-auth/cose-lib/issues/176
+ * @see \Cose\Tests\Structure\DeprecatedTagClassesTest
+ */
 final class CoseEncryptTag extends Tag
 {
     /**
@@ -36,6 +61,12 @@ final class CoseEncryptTag extends Tag
 
     public function __construct(int $additionalInformation, ?string $data, CBORObject $object)
     {
+        trigger_error(sprintf(
+            'The class "%s" is deprecated since 4.8.0 and will be removed in 5.0.0. Use "%s" from spomky-labs/cbor-php 3.4.0 or later instead.',
+            self::class,
+            UpstreamTag::class
+        ), E_USER_DEPRECATED);
+
         if (! $object instanceof ListObject) {
             throw new InvalidArgumentException('Not a valid CoseEncrypt object. No list.');
         }

--- a/src/Encryption/Encrypt0Structure.php
+++ b/src/Encryption/Encrypt0Structure.php
@@ -2,34 +2,34 @@
 
 declare(strict_types=1);
 
-namespace Cose\Signature;
+namespace Cose\Encryption;
 
 use CBOR\ByteStringObject;
 use CBOR\IndefiniteLengthByteStringObject;
 use Cose\Structure\CoseStructure;
 
 /**
- * The Sig_structure of a COSE_Sign1 (RFC 9052 section 4.4).
+ * The Enc_structure of a COSE_Encrypt0 (RFC 9052 section 5.3).
  *
- * Sig_structure = [ "Signature1", body_protected : empty_or_serialized_map, external_aad : bstr, payload : bstr ]
+ * Enc_structure = [ "Encrypt0", protected : empty_or_serialized_map, external_aad : bstr ]
  *
- * The payload is a parameter rather than something read back from the message so that a detached payload -- the nil
- * form of RFC 9052 section 4.2 -- is supplied by the application, which is what the RFC requires of it.
+ * This is the additional authenticated data of the content encryption. Unlike the signature and MAC structures it
+ * carries no payload: the content itself is what the AEAD encrypts, and this structure is what it authenticates
+ * alongside it.
  *
  *
  * The fields a decoded message supplies are typed to accept the indefinite-length byte strings the cbor-php
  * accessors can hand back, and are kept exactly as they were given: a cryptographic structure has to embed the
  * protected bucket byte for byte, or the signature the sender computed over it no longer verifies.
- * @see https://www.rfc-editor.org/rfc/rfc9052#section-4.4
- * @see \Cose\Tests\Signature\CoseSign1CreateAndVerifyTest
+ * @see https://www.rfc-editor.org/rfc/rfc9052#section-5.3
+ * @see \Cose\Tests\Structure\CoseStructureTest
  */
-final class Signature1 extends CoseStructure
+final class Encrypt0Structure extends CoseStructure
 {
     private readonly ByteStringObject $externalAad;
 
     public function __construct(
         private readonly ByteStringObject|IndefiniteLengthByteStringObject $protectedHeader,
-        private readonly ByteStringObject|IndefiniteLengthByteStringObject $payload,
         ?ByteStringObject $externalAad = null
     ) {
         $this->externalAad = $externalAad ?? self::emptyExternalAad();
@@ -37,20 +37,14 @@ final class Signature1 extends CoseStructure
 
     public static function create(
         ByteStringObject|IndefiniteLengthByteStringObject $protectedHeader,
-        ByteStringObject|IndefiniteLengthByteStringObject $payload,
         ?ByteStringObject $externalAad = null
     ): self {
-        return new self($protectedHeader, $payload, $externalAad);
+        return new self($protectedHeader, $externalAad);
     }
 
     public function getProtectedHeader(): ByteStringObject|IndefiniteLengthByteStringObject
     {
         return $this->protectedHeader;
-    }
-
-    public function getPayload(): ByteStringObject|IndefiniteLengthByteStringObject
-    {
-        return $this->payload;
     }
 
     public function getExternalAad(): ByteStringObject
@@ -60,11 +54,11 @@ final class Signature1 extends CoseStructure
 
     protected function context(): string
     {
-        return 'Signature1';
+        return 'Encrypt0';
     }
 
     protected function items(): array
     {
-        return [$this->protectedHeader, $this->externalAad, $this->payload];
+        return [$this->protectedHeader, $this->externalAad];
     }
 }

--- a/src/Encryption/EncryptStructure.php
+++ b/src/Encryption/EncryptStructure.php
@@ -2,34 +2,34 @@
 
 declare(strict_types=1);
 
-namespace Cose\Signature;
+namespace Cose\Encryption;
 
 use CBOR\ByteStringObject;
 use CBOR\IndefiniteLengthByteStringObject;
 use Cose\Structure\CoseStructure;
 
 /**
- * The Sig_structure of a COSE_Sign1 (RFC 9052 section 4.4).
+ * The Enc_structure of a COSE_Encrypt (RFC 9052 section 5.3).
  *
- * Sig_structure = [ "Signature1", body_protected : empty_or_serialized_map, external_aad : bstr, payload : bstr ]
+ * Enc_structure = [ "Encrypt", protected : empty_or_serialized_map, external_aad : bstr ]
  *
- * The payload is a parameter rather than something read back from the message so that a detached payload -- the nil
- * form of RFC 9052 section 4.2 -- is supplied by the application, which is what the RFC requires of it.
+ * This is the additional authenticated data of the content encryption. Unlike the signature and MAC structures it
+ * carries no payload: the content itself is what the AEAD encrypts, and this structure is what it authenticates
+ * alongside it.
  *
  *
  * The fields a decoded message supplies are typed to accept the indefinite-length byte strings the cbor-php
  * accessors can hand back, and are kept exactly as they were given: a cryptographic structure has to embed the
  * protected bucket byte for byte, or the signature the sender computed over it no longer verifies.
- * @see https://www.rfc-editor.org/rfc/rfc9052#section-4.4
- * @see \Cose\Tests\Signature\CoseSign1CreateAndVerifyTest
+ * @see https://www.rfc-editor.org/rfc/rfc9052#section-5.3
+ * @see \Cose\Tests\Structure\CoseStructureTest
  */
-final class Signature1 extends CoseStructure
+final class EncryptStructure extends CoseStructure
 {
     private readonly ByteStringObject $externalAad;
 
     public function __construct(
         private readonly ByteStringObject|IndefiniteLengthByteStringObject $protectedHeader,
-        private readonly ByteStringObject|IndefiniteLengthByteStringObject $payload,
         ?ByteStringObject $externalAad = null
     ) {
         $this->externalAad = $externalAad ?? self::emptyExternalAad();
@@ -37,20 +37,14 @@ final class Signature1 extends CoseStructure
 
     public static function create(
         ByteStringObject|IndefiniteLengthByteStringObject $protectedHeader,
-        ByteStringObject|IndefiniteLengthByteStringObject $payload,
         ?ByteStringObject $externalAad = null
     ): self {
-        return new self($protectedHeader, $payload, $externalAad);
+        return new self($protectedHeader, $externalAad);
     }
 
     public function getProtectedHeader(): ByteStringObject|IndefiniteLengthByteStringObject
     {
         return $this->protectedHeader;
-    }
-
-    public function getPayload(): ByteStringObject|IndefiniteLengthByteStringObject
-    {
-        return $this->payload;
     }
 
     public function getExternalAad(): ByteStringObject
@@ -60,11 +54,11 @@ final class Signature1 extends CoseStructure
 
     protected function context(): string
     {
-        return 'Signature1';
+        return 'Encrypt';
     }
 
     protected function items(): array
     {
-        return [$this->protectedHeader, $this->externalAad, $this->payload];
+        return [$this->protectedHeader, $this->externalAad];
     }
 }

--- a/src/Encryption/RecipientStructure.php
+++ b/src/Encryption/RecipientStructure.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cose\Encryption;
+
+use CBOR\ByteStringObject;
+use CBOR\IndefiniteLengthByteStringObject;
+use Cose\Structure\CoseStructure;
+
+/**
+ * The Enc_structure of a recipient (RFC 9052 section 5.3).
+ *
+ * Enc_structure = [ context : "Enc_Recipient" / "Mac_Recipient" / "Rec_Recipient", protected :
+ * empty_or_serialized_map, external_aad : bstr ]
+ *
+ * The three remaining contexts of Enc_structure name where the key being wrapped comes from: the recipient of a
+ * COSE_Encrypt, the recipient of a COSE_Mac, or a recipient nested inside another recipient. Binding the context is
+ * what stops a wrapped key from being replayed at a different level of the same structure, so it is a named
+ * constructor rather than a free string.
+ *
+ *
+ * The fields a decoded message supplies are typed to accept the indefinite-length byte strings the cbor-php
+ * accessors can hand back, and are kept exactly as they were given: a cryptographic structure has to embed the
+ * protected bucket byte for byte, or the signature the sender computed over it no longer verifies.
+ * @see https://www.rfc-editor.org/rfc/rfc9052#section-5.3
+ * @see \Cose\Tests\Structure\CoseStructureTest
+ */
+final class RecipientStructure extends CoseStructure
+{
+    /**
+     * The recipient of a COSE_Encrypt.
+     */
+    public const CONTEXT_ENC_RECIPIENT = 'Enc_Recipient';
+
+    /**
+     * The recipient of a COSE_Mac.
+     */
+    public const CONTEXT_MAC_RECIPIENT = 'Mac_Recipient';
+
+    /**
+     * A recipient nested inside another recipient.
+     */
+    public const CONTEXT_REC_RECIPIENT = 'Rec_Recipient';
+
+    private readonly ByteStringObject $externalAad;
+
+    private function __construct(
+        private readonly string $context,
+        private readonly ByteStringObject|IndefiniteLengthByteStringObject $protectedHeader,
+        ?ByteStringObject $externalAad = null
+    ) {
+        $this->externalAad = $externalAad ?? self::emptyExternalAad();
+    }
+
+    public static function forEncryptRecipient(
+        ByteStringObject|IndefiniteLengthByteStringObject $protectedHeader,
+        ?ByteStringObject $externalAad = null
+    ): self {
+        return new self(self::CONTEXT_ENC_RECIPIENT, $protectedHeader, $externalAad);
+    }
+
+    public static function forMacRecipient(
+        ByteStringObject|IndefiniteLengthByteStringObject $protectedHeader,
+        ?ByteStringObject $externalAad = null
+    ): self {
+        return new self(self::CONTEXT_MAC_RECIPIENT, $protectedHeader, $externalAad);
+    }
+
+    public static function forNestedRecipient(
+        ByteStringObject|IndefiniteLengthByteStringObject $protectedHeader,
+        ?ByteStringObject $externalAad = null
+    ): self {
+        return new self(self::CONTEXT_REC_RECIPIENT, $protectedHeader, $externalAad);
+    }
+
+    public function getProtectedHeader(): ByteStringObject|IndefiniteLengthByteStringObject
+    {
+        return $this->protectedHeader;
+    }
+
+    public function getExternalAad(): ByteStringObject
+    {
+        return $this->externalAad;
+    }
+
+    protected function context(): string
+    {
+        return $this->context;
+    }
+
+    protected function items(): array
+    {
+        return [$this->protectedHeader, $this->externalAad];
+    }
+}

--- a/src/Mac/CoseMac0Tag.php
+++ b/src/Mac/CoseMac0Tag.php
@@ -12,9 +12,34 @@ use CBOR\MapObject;
 use CBOR\OtherObject\OtherObjectManager;
 use CBOR\StringStream;
 use CBOR\Tag;
+use CBOR\Tag\CoseMac0Tag as UpstreamTag;
 use CBOR\Tag\TagManager;
+use const E_USER_DEPRECATED;
 use InvalidArgumentException;
+use function sprintf;
+use function trigger_error;
 
+/**
+ * A tagged COSE_Mac0 (RFC 9052, CBOR tag 17).
+ *
+ * @deprecated since 4.8.0, use \CBOR\Tag\CoseMac0Tag from spomky-labs/cbor-php 3.4.0 or later instead. Will be removed
+ * in 5.0.0.
+ *
+ * The six COSE structures were ported upstream in cbor-php 3.4.0, where they share AbstractCoseTag and are
+ * registered in the default decoder, so Decoder::create() resolves tag 17 on its own. The replacement accepts what
+ * this class rejects -- a zero-length protected header, a detached (nil) payload, the indefinite-length encodings --
+ * and reads every item through the list it carries, so its accessors cannot drift from the bytes it serializes.
+ *
+ * What does not move upstream is the RFC 9052 layer above the CBOR shape, and that stays here: {@see \Cose\Structure\CoseHeaders}
+ * for header labels typed as RFC 9052 section 1.5 defines them, and the Sig_structure, MAC_structure and
+ * Enc_structure builders that a signature or a MAC is actually computed over. Both work on the upstream classes.
+ *
+ * Migrating: the class name changes, and the four-argument create() becomes createFromComponents() -- upstream
+ * create() takes the whole list instead.
+ *
+ * @see https://github.com/web-auth/cose-lib/issues/176
+ * @see \Cose\Tests\Structure\DeprecatedTagClassesTest
+ */
 final class CoseMac0Tag extends Tag
 {
     /**
@@ -36,6 +61,12 @@ final class CoseMac0Tag extends Tag
 
     public function __construct(int $additionalInformation, ?string $data, CBORObject $object)
     {
+        trigger_error(sprintf(
+            'The class "%s" is deprecated since 4.8.0 and will be removed in 5.0.0. Use "%s" from spomky-labs/cbor-php 3.4.0 or later instead.',
+            self::class,
+            UpstreamTag::class
+        ), E_USER_DEPRECATED);
+
         if (! $object instanceof ListObject) {
             throw new InvalidArgumentException('Not a valid CoseMac0 object. No list.');
         }

--- a/src/Mac/CoseMacTag.php
+++ b/src/Mac/CoseMacTag.php
@@ -12,9 +12,34 @@ use CBOR\MapObject;
 use CBOR\OtherObject\OtherObjectManager;
 use CBOR\StringStream;
 use CBOR\Tag;
+use CBOR\Tag\CoseMacTag as UpstreamTag;
 use CBOR\Tag\TagManager;
+use const E_USER_DEPRECATED;
 use InvalidArgumentException;
+use function sprintf;
+use function trigger_error;
 
+/**
+ * A tagged COSE_Mac (RFC 9052, CBOR tag 97).
+ *
+ * @deprecated since 4.8.0, use \CBOR\Tag\CoseMacTag from spomky-labs/cbor-php 3.4.0 or later instead. Will be removed
+ * in 5.0.0.
+ *
+ * The six COSE structures were ported upstream in cbor-php 3.4.0, where they share AbstractCoseTag and are
+ * registered in the default decoder, so Decoder::create() resolves tag 97 on its own. The replacement accepts what
+ * this class rejects -- a zero-length protected header, a detached (nil) payload, the indefinite-length encodings --
+ * and reads every item through the list it carries, so its accessors cannot drift from the bytes it serializes.
+ *
+ * What does not move upstream is the RFC 9052 layer above the CBOR shape, and that stays here: {@see \Cose\Structure\CoseHeaders}
+ * for header labels typed as RFC 9052 section 1.5 defines them, and the Sig_structure, MAC_structure and
+ * Enc_structure builders that a signature or a MAC is actually computed over. Both work on the upstream classes.
+ *
+ * Migrating: the class name changes, and the four-argument create() becomes createFromComponents() -- upstream
+ * create() takes the whole list instead.
+ *
+ * @see https://github.com/web-auth/cose-lib/issues/176
+ * @see \Cose\Tests\Structure\DeprecatedTagClassesTest
+ */
 final class CoseMacTag extends Tag
 {
     /**
@@ -38,6 +63,12 @@ final class CoseMacTag extends Tag
 
     public function __construct(int $additionalInformation, ?string $data, CBORObject $object)
     {
+        trigger_error(sprintf(
+            'The class "%s" is deprecated since 4.8.0 and will be removed in 5.0.0. Use "%s" from spomky-labs/cbor-php 3.4.0 or later instead.',
+            self::class,
+            UpstreamTag::class
+        ), E_USER_DEPRECATED);
+
         if (! $object instanceof ListObject) {
             throw new InvalidArgumentException('Not a valid CoseMac object. No list.');
         }

--- a/src/Mac/Mac0Structure.php
+++ b/src/Mac/Mac0Structure.php
@@ -2,28 +2,29 @@
 
 declare(strict_types=1);
 
-namespace Cose\Signature;
+namespace Cose\Mac;
 
 use CBOR\ByteStringObject;
 use CBOR\IndefiniteLengthByteStringObject;
 use Cose\Structure\CoseStructure;
 
 /**
- * The Sig_structure of a COSE_Sign1 (RFC 9052 section 4.4).
+ * The MAC_structure of a COSE_Mac0 (RFC 9052 section 6.3).
  *
- * Sig_structure = [ "Signature1", body_protected : empty_or_serialized_map, external_aad : bstr, payload : bstr ]
+ * MAC_structure = [ "MAC0", protected : empty_or_serialized_map, external_aad : bstr, payload : bstr ]
  *
- * The payload is a parameter rather than something read back from the message so that a detached payload -- the nil
- * form of RFC 9052 section 4.2 -- is supplied by the application, which is what the RFC requires of it.
+ * This is what the MAC algorithm authenticates. MACing the payload on its own instead binds the tag neither to the
+ * protected header -- the algorithm and the key identifier the sender chose -- nor to the message type, so a tag
+ * computed for a COSE_Mac0 would be accepted for a COSE_Mac and the reverse.
  *
  *
  * The fields a decoded message supplies are typed to accept the indefinite-length byte strings the cbor-php
  * accessors can hand back, and are kept exactly as they were given: a cryptographic structure has to embed the
  * protected bucket byte for byte, or the signature the sender computed over it no longer verifies.
- * @see https://www.rfc-editor.org/rfc/rfc9052#section-4.4
- * @see \Cose\Tests\Signature\CoseSign1CreateAndVerifyTest
+ * @see https://www.rfc-editor.org/rfc/rfc9052#section-6.3
+ * @see \Cose\Tests\Structure\CoseStructureTest
  */
-final class Signature1 extends CoseStructure
+final class Mac0Structure extends CoseStructure
 {
     private readonly ByteStringObject $externalAad;
 
@@ -60,7 +61,7 @@ final class Signature1 extends CoseStructure
 
     protected function context(): string
     {
-        return 'Signature1';
+        return 'MAC0';
     }
 
     protected function items(): array

--- a/src/Mac/MacStructure.php
+++ b/src/Mac/MacStructure.php
@@ -2,28 +2,29 @@
 
 declare(strict_types=1);
 
-namespace Cose\Signature;
+namespace Cose\Mac;
 
 use CBOR\ByteStringObject;
 use CBOR\IndefiniteLengthByteStringObject;
 use Cose\Structure\CoseStructure;
 
 /**
- * The Sig_structure of a COSE_Sign1 (RFC 9052 section 4.4).
+ * The MAC_structure of a COSE_Mac (RFC 9052 section 6.3).
  *
- * Sig_structure = [ "Signature1", body_protected : empty_or_serialized_map, external_aad : bstr, payload : bstr ]
+ * MAC_structure = [ "MAC", protected : empty_or_serialized_map, external_aad : bstr, payload : bstr ]
  *
- * The payload is a parameter rather than something read back from the message so that a detached payload -- the nil
- * form of RFC 9052 section 4.2 -- is supplied by the application, which is what the RFC requires of it.
+ * This is what the MAC algorithm authenticates, over the body protected header of the message. The context string
+ * is the only difference with {@see Mac0Structure}, and it is what keeps a tag computed for a multi-recipient
+ * COSE_Mac from being accepted on a COSE_Mac0 built over the same header and payload.
  *
  *
  * The fields a decoded message supplies are typed to accept the indefinite-length byte strings the cbor-php
  * accessors can hand back, and are kept exactly as they were given: a cryptographic structure has to embed the
  * protected bucket byte for byte, or the signature the sender computed over it no longer verifies.
- * @see https://www.rfc-editor.org/rfc/rfc9052#section-4.4
- * @see \Cose\Tests\Signature\CoseSign1CreateAndVerifyTest
+ * @see https://www.rfc-editor.org/rfc/rfc9052#section-6.3
+ * @see \Cose\Tests\Structure\CoseStructureTest
  */
-final class Signature1 extends CoseStructure
+final class MacStructure extends CoseStructure
 {
     private readonly ByteStringObject $externalAad;
 
@@ -60,7 +61,7 @@ final class Signature1 extends CoseStructure
 
     protected function context(): string
     {
-        return 'Signature1';
+        return 'MAC';
     }
 
     protected function items(): array

--- a/src/Signature/CoseSign1Tag.php
+++ b/src/Signature/CoseSign1Tag.php
@@ -12,9 +12,34 @@ use CBOR\MapObject;
 use CBOR\OtherObject\OtherObjectManager;
 use CBOR\StringStream;
 use CBOR\Tag;
+use CBOR\Tag\CoseSign1Tag as UpstreamTag;
 use CBOR\Tag\TagManager;
+use const E_USER_DEPRECATED;
 use InvalidArgumentException;
+use function sprintf;
+use function trigger_error;
 
+/**
+ * A tagged COSE_Sign1 (RFC 9052, CBOR tag 18).
+ *
+ * @deprecated since 4.8.0, use \CBOR\Tag\CoseSign1Tag from spomky-labs/cbor-php 3.4.0 or later instead. Will be removed
+ * in 5.0.0.
+ *
+ * The six COSE structures were ported upstream in cbor-php 3.4.0, where they share AbstractCoseTag and are
+ * registered in the default decoder, so Decoder::create() resolves tag 18 on its own. The replacement accepts what
+ * this class rejects -- a zero-length protected header, a detached (nil) payload, the indefinite-length encodings --
+ * and reads every item through the list it carries, so its accessors cannot drift from the bytes it serializes.
+ *
+ * What does not move upstream is the RFC 9052 layer above the CBOR shape, and that stays here: {@see \Cose\Structure\CoseHeaders}
+ * for header labels typed as RFC 9052 section 1.5 defines them, and the Sig_structure, MAC_structure and
+ * Enc_structure builders that a signature or a MAC is actually computed over. Both work on the upstream classes.
+ *
+ * Migrating: the class name changes, and the four-argument create() becomes createFromComponents() -- upstream
+ * create() takes the whole list instead.
+ *
+ * @see https://github.com/web-auth/cose-lib/issues/176
+ * @see \Cose\Tests\Structure\DeprecatedTagClassesTest
+ */
 final class CoseSign1Tag extends Tag
 {
     /**
@@ -36,6 +61,12 @@ final class CoseSign1Tag extends Tag
 
     public function __construct(int $additionalInformation, ?string $data, CBORObject $object)
     {
+        trigger_error(sprintf(
+            'The class "%s" is deprecated since 4.8.0 and will be removed in 5.0.0. Use "%s" from spomky-labs/cbor-php 3.4.0 or later instead.',
+            self::class,
+            UpstreamTag::class
+        ), E_USER_DEPRECATED);
+
         if (! $object instanceof ListObject) {
             throw new InvalidArgumentException('Not a valid CoseSign1 object. No list.');
         }

--- a/src/Signature/CoseSignTag.php
+++ b/src/Signature/CoseSignTag.php
@@ -12,9 +12,34 @@ use CBOR\MapObject;
 use CBOR\OtherObject\OtherObjectManager;
 use CBOR\StringStream;
 use CBOR\Tag;
+use CBOR\Tag\CoseSignTag as UpstreamTag;
 use CBOR\Tag\TagManager;
+use const E_USER_DEPRECATED;
 use InvalidArgumentException;
+use function sprintf;
+use function trigger_error;
 
+/**
+ * A tagged COSE_Sign (RFC 9052, CBOR tag 98).
+ *
+ * @deprecated since 4.8.0, use \CBOR\Tag\CoseSignTag from spomky-labs/cbor-php 3.4.0 or later instead. Will be removed
+ * in 5.0.0.
+ *
+ * The six COSE structures were ported upstream in cbor-php 3.4.0, where they share AbstractCoseTag and are
+ * registered in the default decoder, so Decoder::create() resolves tag 98 on its own. The replacement accepts what
+ * this class rejects -- a zero-length protected header, a detached (nil) payload, the indefinite-length encodings --
+ * and reads every item through the list it carries, so its accessors cannot drift from the bytes it serializes.
+ *
+ * What does not move upstream is the RFC 9052 layer above the CBOR shape, and that stays here: {@see \Cose\Structure\CoseHeaders}
+ * for header labels typed as RFC 9052 section 1.5 defines them, and the Sig_structure, MAC_structure and
+ * Enc_structure builders that a signature or a MAC is actually computed over. Both work on the upstream classes.
+ *
+ * Migrating: the class name changes, and the four-argument create() becomes createFromComponents() -- upstream
+ * create() takes the whole list instead.
+ *
+ * @see https://github.com/web-auth/cose-lib/issues/176
+ * @see \Cose\Tests\Structure\DeprecatedTagClassesTest
+ */
 final class CoseSignTag extends Tag
 {
     /**
@@ -36,6 +61,12 @@ final class CoseSignTag extends Tag
 
     public function __construct(int $additionalInformation, ?string $data, CBORObject $object)
     {
+        trigger_error(sprintf(
+            'The class "%s" is deprecated since 4.8.0 and will be removed in 5.0.0. Use "%s" from spomky-labs/cbor-php 3.4.0 or later instead.',
+            self::class,
+            UpstreamTag::class
+        ), E_USER_DEPRECATED);
+
         if (! $object instanceof ListObject) {
             throw new InvalidArgumentException('Not a valid CoseSign object. No list.');
         }

--- a/src/Signature/CoseSignature.php
+++ b/src/Signature/CoseSignature.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cose\Signature;
+
+use CBOR\ByteStringObject;
+use CBOR\CBORObject;
+use CBOR\IndefiniteLengthByteStringObject;
+use CBOR\IndefiniteLengthListObject;
+use CBOR\IndefiniteLengthMapObject;
+use CBOR\ListObject;
+use CBOR\MapObject;
+use Cose\Structure\CoseHeaders;
+use Cose\Structure\HeaderMapHelper;
+use InvalidArgumentException;
+
+/**
+ * One entry of the "signatures" list of a COSE_Sign (RFC 9052 section 4.1).
+ *
+ * COSE_Signature = [ Headers, signature : bstr ]
+ *
+ * The raw list a message carries says nothing about what is inside it, and neither cbor-php nor the deprecated
+ * Cose\Signature\CoseSignTag looks: both accept an empty list and entries of any shape. This view is the checked
+ * form, and it carries the same header reader as the message, because a signer of a COSE_Sign has a protected
+ * bucket of its own that its signature commits to.
+ *
+ * ```php
+ * foreach ($message->getSignatures() as $entry) {
+ *     $signer = CoseSignature::create($entry);
+ *     $toBeSigned = Signature::create(
+ *         $message->getProtectedHeader(),
+ *         $signer->getProtectedHeader(),
+ *         $message->getPayload(),
+ *     );
+ * }
+ * ```
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc9052#section-4.1
+ * @see \Cose\Tests\Structure\CoseSignatureTest
+ */
+final class CoseSignature
+{
+    private readonly ByteStringObject|IndefiniteLengthByteStringObject $protectedHeader;
+
+    private readonly MapObject|IndefiniteLengthMapObject $unprotectedHeader;
+
+    private readonly ByteStringObject|IndefiniteLengthByteStringObject $signature;
+
+    public function __construct(ListObject|IndefiniteLengthListObject $signature)
+    {
+        HeaderMapHelper::assertSignatureList(ListObject::create([$signature]));
+
+        /** @var ByteStringObject|IndefiniteLengthByteStringObject $protectedHeader */
+        $protectedHeader = $signature->get(0);
+        /** @var IndefiniteLengthMapObject|MapObject $unprotectedHeader */
+        $unprotectedHeader = $signature->get(1);
+        /** @var ByteStringObject|IndefiniteLengthByteStringObject $signatureValue */
+        $signatureValue = $signature->get(2);
+
+        $this->protectedHeader = $protectedHeader;
+        $this->unprotectedHeader = $unprotectedHeader;
+        $this->signature = $signatureValue;
+    }
+
+    public static function create(ListObject|IndefiniteLengthListObject $signature): self
+    {
+        return new self($signature);
+    }
+
+    /**
+     * Every entry of a "signatures" list, checked and wrapped.
+     *
+     * @return list<self>
+     */
+    public static function all(ListObject|IndefiniteLengthListObject $signatures): array
+    {
+        HeaderMapHelper::assertSignatureList($signatures);
+
+        $result = [];
+        foreach ($signatures as $signature) {
+            if (! $signature instanceof ListObject && ! $signature instanceof IndefiniteLengthListObject) {
+                throw new InvalidArgumentException('Not a valid COSE_Signature object. It shall be a List object.');
+            }
+            $result[] = new self($signature);
+        }
+
+        return $result;
+    }
+
+    /**
+     * The protected bucket of this signer, as it is carried: what its Sig_structure covers verbatim.
+     */
+    public function getProtectedHeader(): ByteStringObject|IndefiniteLengthByteStringObject
+    {
+        return $this->protectedHeader;
+    }
+
+    public function getUnprotectedHeader(): MapObject|IndefiniteLengthMapObject
+    {
+        return $this->unprotectedHeader;
+    }
+
+    /**
+     * The headers of this signer, read the way RFC 9052 defines them.
+     */
+    public function headers(): CoseHeaders
+    {
+        return CoseHeaders::of($this->protectedHeader, $this->unprotectedHeader);
+    }
+
+    public function getProtectedHeaderParameter(int|string $label): ?CBORObject
+    {
+        return $this->headers()
+            ->getProtectedHeaderParameter($label);
+    }
+
+    public function getUnprotectedHeaderParameter(int|string $label): ?CBORObject
+    {
+        return $this->headers()
+            ->getUnprotectedHeaderParameter($label);
+    }
+
+    public function getSignature(): ByteStringObject|IndefiniteLengthByteStringObject
+    {
+        return $this->signature;
+    }
+
+    /**
+     * The list this view was built from, rebuilt so that nothing the caller does to it reaches the message.
+     */
+    public function toListObject(): ListObject
+    {
+        return ListObject::create([$this->protectedHeader, $this->unprotectedHeader, $this->signature]);
+    }
+}

--- a/src/Signature/Signature.php
+++ b/src/Signature/Signature.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cose\Signature;
+
+use CBOR\ByteStringObject;
+use CBOR\IndefiniteLengthByteStringObject;
+use Cose\Structure\CoseStructure;
+
+/**
+ * The Sig_structure of one signer of a COSE_Sign (RFC 9052 section 4.4).
+ *
+ * Sig_structure = [ "Signature", body_protected : empty_or_serialized_map, sign_protected : empty_or_serialized_map,
+ * external_aad : bstr, payload : bstr ]
+ *
+ * The sign_protected field is what tells this structure apart from {@see Signature1}: a signature of a COSE_Sign
+ * commits to the protected bucket of the message *and* to the one of its own COSE_Signature entry. Without it, a
+ * per-signer signature would be byte-identical to a COSE_Sign1 signature over the same header and payload.
+ *
+ *
+ * The fields a decoded message supplies are typed to accept the indefinite-length byte strings the cbor-php
+ * accessors can hand back, and are kept exactly as they were given: a cryptographic structure has to embed the
+ * protected bucket byte for byte, or the signature the sender computed over it no longer verifies.
+ * @see https://www.rfc-editor.org/rfc/rfc9052#section-4.4
+ * @see \Cose\Tests\Structure\CoseStructureTest
+ */
+final class Signature extends CoseStructure
+{
+    private readonly ByteStringObject $externalAad;
+
+    public function __construct(
+        private readonly ByteStringObject|IndefiniteLengthByteStringObject $bodyProtectedHeader,
+        private readonly ByteStringObject|IndefiniteLengthByteStringObject $signProtectedHeader,
+        private readonly ByteStringObject|IndefiniteLengthByteStringObject $payload,
+        ?ByteStringObject $externalAad = null
+    ) {
+        $this->externalAad = $externalAad ?? self::emptyExternalAad();
+    }
+
+    public static function create(
+        ByteStringObject|IndefiniteLengthByteStringObject $bodyProtectedHeader,
+        ByteStringObject|IndefiniteLengthByteStringObject $signProtectedHeader,
+        ByteStringObject|IndefiniteLengthByteStringObject $payload,
+        ?ByteStringObject $externalAad = null
+    ): self {
+        return new self($bodyProtectedHeader, $signProtectedHeader, $payload, $externalAad);
+    }
+
+    public function getBodyProtectedHeader(): ByteStringObject|IndefiniteLengthByteStringObject
+    {
+        return $this->bodyProtectedHeader;
+    }
+
+    public function getSignProtectedHeader(): ByteStringObject|IndefiniteLengthByteStringObject
+    {
+        return $this->signProtectedHeader;
+    }
+
+    public function getPayload(): ByteStringObject|IndefiniteLengthByteStringObject
+    {
+        return $this->payload;
+    }
+
+    public function getExternalAad(): ByteStringObject
+    {
+        return $this->externalAad;
+    }
+
+    protected function context(): string
+    {
+        return 'Signature';
+    }
+
+    protected function items(): array
+    {
+        return [$this->bodyProtectedHeader, $this->signProtectedHeader, $this->externalAad, $this->payload];
+    }
+}

--- a/src/Structure/CoseHeaders.php
+++ b/src/Structure/CoseHeaders.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cose\Structure;
+
+use CBOR\ByteStringObject;
+use CBOR\CBORObject;
+use CBOR\DecoderInterface;
+use CBOR\IndefiniteLengthByteStringObject;
+use CBOR\IndefiniteLengthMapObject;
+use CBOR\MapObject;
+use CBOR\Tag\AbstractCoseTag;
+
+/**
+ * The two header buckets of a COSE message, read the way RFC 9052 defines them.
+ *
+ * cbor-php 3.4.0 owns the shape of a COSE message and hands back the buckets as they were encoded. What it does not
+ * do -- and what a CBOR library has no business doing -- is apply the header rules of RFC 9052 sections 1.5 and 3 on
+ * top: a label is an integer or a text string and nothing else, the two are distinct even when they normalize to the
+ * same map offset, a label appears at most once, and the protected bucket holds exactly one CBOR item.
+ *
+ * That is what this reads. It works on any COSE message: the upstream classes through fromMessage(), the deprecated
+ * Cose\...Tag classes and the per-signer or per-recipient entries through of().
+ *
+ * ```php
+ * $message = Decoder::create()->decode(StringStream::create($bytes)); // CBOR\Tag\CoseSign1Tag
+ * $headers = CoseHeaders::fromMessage($message);
+ *
+ * $alg = $headers->getProtectedHeaderParameter(1);   // never answered by the text string "1"
+ * $kid = $headers->getHeaderParameter(4);            // protected bucket first
+ * ```
+ *
+ * The protected bucket is decoded once, on first use.
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc9052#section-3
+ * @see https://github.com/web-auth/cose-lib/issues/166
+ * @see \Cose\Tests\Structure\CoseHeadersTest
+ */
+final class CoseHeaders
+{
+    public const DEFAULT_PROTECTED_HEADER_MAX_DEPTH = HeaderMapHelper::DEFAULT_PROTECTED_HEADER_MAX_DEPTH;
+
+    private ?MapObject $decodedProtectedHeader = null;
+
+    private function __construct(
+        private readonly ByteStringObject|IndefiniteLengthByteStringObject $protectedHeader,
+        private readonly MapObject|IndefiniteLengthMapObject $unprotectedHeader,
+        private readonly ?DecoderInterface $decoder,
+        private readonly int $maxDepth
+    ) {
+    }
+
+    /**
+     * The buckets of a COSE message, given as they are carried.
+     *
+     * This is the form to use for a per-signer COSE_Signature or a COSE_recipient -- {@see CoseSignature} and
+     * {@see CoseRecipient} build it for you -- and for the deprecated Cose\...Tag classes.
+     */
+    public static function of(
+        ByteStringObject|IndefiniteLengthByteStringObject $protectedHeader,
+        MapObject|IndefiniteLengthMapObject $unprotectedHeader,
+        ?DecoderInterface $decoder = null,
+        int $maxDepth = self::DEFAULT_PROTECTED_HEADER_MAX_DEPTH
+    ): self {
+        return new self($protectedHeader, $unprotectedHeader, $decoder, $maxDepth);
+    }
+
+    /**
+     * The buckets of one of the six COSE messages of cbor-php 3.4.0 or later.
+     *
+     * The nesting bound only applies to the decoder built when none is given: a caller passing its own $decoder sets
+     * its own bound, and $maxDepth is then ignored.
+     */
+    public static function fromMessage(
+        AbstractCoseTag $message,
+        ?DecoderInterface $decoder = null,
+        int $maxDepth = self::DEFAULT_PROTECTED_HEADER_MAX_DEPTH
+    ): self {
+        return new self($message->getProtectedHeader(), $message->getUnprotectedHeader(), $decoder, $maxDepth);
+    }
+
+    /**
+     * The protected bucket as it is carried: the byte string the cryptographic structure covers verbatim.
+     */
+    public function getProtectedHeader(): ByteStringObject|IndefiniteLengthByteStringObject
+    {
+        return $this->protectedHeader;
+    }
+
+    /**
+     * The protected bucket, decoded and checked: the zero-length byte string of RFC 9052 section 3 is an empty
+     * header, trailing bytes after the header map are rejected, and every key is a label.
+     */
+    public function getProtectedHeaderAsMap(): MapObject
+    {
+        return $this->decodedProtectedHeader ??= HeaderMapHelper::decodeProtected(
+            $this->protectedHeader,
+            $this->decoder,
+            $this->maxDepth
+        );
+    }
+
+    /**
+     * The unprotected bucket, with its labels checked.
+     */
+    public function getUnprotectedHeaderAsMap(): MapObject
+    {
+        return HeaderMapHelper::assertValidLabels($this->unprotectedHeader);
+    }
+
+    /**
+     * The unprotected bucket as it is carried.
+     */
+    public function getUnprotectedHeader(): MapObject|IndefiniteLengthMapObject
+    {
+        return $this->unprotectedHeader;
+    }
+
+    /**
+     * The value of a label in the protected bucket, or null when the bucket does not carry it.
+     *
+     * The label is matched by type as well as by value, so the integer 1 -- the algorithm -- is never answered by
+     * the text string "1" or by a byte string that happens to normalize the same way.
+     */
+    public function getProtectedHeaderParameter(int|string $label): ?CBORObject
+    {
+        return HeaderMapHelper::findLabel($this->getProtectedHeaderAsMap(), $label);
+    }
+
+    /**
+     * The value of a label in the unprotected bucket, or null when the bucket does not carry it.
+     */
+    public function getUnprotectedHeaderParameter(int|string $label): ?CBORObject
+    {
+        return HeaderMapHelper::findLabel($this->unprotectedHeader, $label);
+    }
+
+    /**
+     * The value of a label, looked up in the protected bucket first.
+     *
+     * A parameter found there is the one the signature or the MAC commits to, so it wins over an unprotected copy of
+     * the same label. A message carrying a label in both buckets is malformed anyway (RFC 9052 section 3: "The same
+     * label MUST NOT occur in both buckets"); preferring the protected value keeps the answer on the authenticated
+     * side of that mistake.
+     */
+    public function getHeaderParameter(int|string $label): ?CBORObject
+    {
+        return $this->getProtectedHeaderParameter($label) ?? $this->getUnprotectedHeaderParameter($label);
+    }
+}

--- a/src/Structure/CoseRecipient.php
+++ b/src/Structure/CoseRecipient.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cose\Structure;
+
+use CBOR\ByteStringObject;
+use CBOR\CBORObject;
+use CBOR\IndefiniteLengthByteStringObject;
+use CBOR\IndefiniteLengthListObject;
+use CBOR\IndefiniteLengthMapObject;
+use CBOR\ListObject;
+use CBOR\MapObject;
+use CBOR\OtherObject\NullObject;
+use InvalidArgumentException;
+use LogicException;
+
+/**
+ * One entry of the "recipients" list of a COSE_Encrypt or of a COSE_Mac (RFC 9052 sections 5.1 and 6.1).
+ *
+ * COSE_recipient = [ Headers, ciphertext : bstr / nil, ? recipients : [+COSE_recipient] ]
+ *
+ * The raw list a message carries says nothing about what is inside it, and neither cbor-php nor the deprecated
+ * Cose\...Tag classes look: both accept an empty list and entries of any shape. This view is the checked form.
+ *
+ * A recipient may itself carry recipients, which is how RFC 9052 expresses key layering; getRecipients() walks that
+ * tree one level at a time and each level is a view of the same kind.
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc9052#section-5.1
+ * @see \Cose\Tests\Structure\CoseRecipientTest
+ */
+final class CoseRecipient
+{
+    private readonly ByteStringObject|IndefiniteLengthByteStringObject $protectedHeader;
+
+    private readonly MapObject|IndefiniteLengthMapObject $unprotectedHeader;
+
+    private readonly ByteStringObject|IndefiniteLengthByteStringObject|null $ciphertext;
+
+    private readonly ListObject|IndefiniteLengthListObject|null $recipients;
+
+    public function __construct(ListObject|IndefiniteLengthListObject $recipient)
+    {
+        HeaderMapHelper::assertRecipientList(ListObject::create([$recipient]));
+
+        /** @var ByteStringObject|IndefiniteLengthByteStringObject $protectedHeader */
+        $protectedHeader = $recipient->get(0);
+        /** @var IndefiniteLengthMapObject|MapObject $unprotectedHeader */
+        $unprotectedHeader = $recipient->get(1);
+        // assertRecipientList() has just ruled out everything but a byte string and nil at this position.
+        /** @var ByteStringObject|IndefiniteLengthByteStringObject|null $ciphertext */
+        $ciphertext = HeaderMapHelper::isNil($recipient->get(2)) ? null : $recipient->get(2);
+
+        $this->protectedHeader = $protectedHeader;
+        $this->unprotectedHeader = $unprotectedHeader;
+        $this->ciphertext = $ciphertext;
+
+        $nested = $recipient->count() === 4 ? $recipient->get(3) : null;
+        $this->recipients = $nested instanceof ListObject || $nested instanceof IndefiniteLengthListObject
+            ? $nested
+            : null;
+    }
+
+    public static function create(ListObject|IndefiniteLengthListObject $recipient): self
+    {
+        return new self($recipient);
+    }
+
+    /**
+     * Every entry of a "recipients" list, checked and wrapped.
+     *
+     * @return list<self>
+     */
+    public static function all(ListObject|IndefiniteLengthListObject $recipients): array
+    {
+        HeaderMapHelper::assertRecipientList($recipients);
+
+        $result = [];
+        foreach ($recipients as $recipient) {
+            if (! $recipient instanceof ListObject && ! $recipient instanceof IndefiniteLengthListObject) {
+                throw new InvalidArgumentException('Not a valid COSE_recipient object. It shall be a List object.');
+            }
+            $result[] = new self($recipient);
+        }
+
+        return $result;
+    }
+
+    /**
+     * The protected bucket of this recipient, as it is carried.
+     */
+    public function getProtectedHeader(): ByteStringObject|IndefiniteLengthByteStringObject
+    {
+        return $this->protectedHeader;
+    }
+
+    public function getUnprotectedHeader(): MapObject|IndefiniteLengthMapObject
+    {
+        return $this->unprotectedHeader;
+    }
+
+    /**
+     * The headers of this recipient, read the way RFC 9052 defines them.
+     */
+    public function headers(): CoseHeaders
+    {
+        return CoseHeaders::of($this->protectedHeader, $this->unprotectedHeader);
+    }
+
+    public function getProtectedHeaderParameter(int|string $label): ?CBORObject
+    {
+        return $this->headers()
+            ->getProtectedHeaderParameter($label);
+    }
+
+    public function getUnprotectedHeaderParameter(int|string $label): ?CBORObject
+    {
+        return $this->headers()
+            ->getUnprotectedHeaderParameter($label);
+    }
+
+    /**
+     * Whether the ciphertext of this recipient travels outside the message.
+     */
+    public function hasDetachedCiphertext(): bool
+    {
+        return $this->ciphertext === null;
+    }
+
+    /**
+     * @throws LogicException when the ciphertext is detached; hasDetachedCiphertext() tells the two cases apart
+     */
+    public function getCiphertext(): ByteStringObject|IndefiniteLengthByteStringObject
+    {
+        return $this->ciphertext ?? throw new LogicException(
+            'The ciphertext of this COSE_recipient is detached (RFC 9052 section 5.1); the application supplies it separately.'
+        );
+    }
+
+    public function hasRecipients(): bool
+    {
+        return $this->recipients !== null;
+    }
+
+    /**
+     * The recipients nested under this one, empty when it carries none.
+     *
+     * @return list<self>
+     */
+    public function getRecipients(): array
+    {
+        return $this->recipients === null ? [] : self::all($this->recipients);
+    }
+
+    /**
+     * The list this view was built from, rebuilt so that nothing the caller does to it reaches the message.
+     */
+    public function toListObject(): ListObject
+    {
+        $items = [$this->protectedHeader, $this->unprotectedHeader, $this->ciphertext ?? NullObject::create()];
+        if ($this->recipients !== null) {
+            $items[] = $this->recipients;
+        }
+
+        return ListObject::create($items);
+    }
+}

--- a/src/Structure/CoseStructure.php
+++ b/src/Structure/CoseStructure.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cose\Structure;
+
+use CBOR\ByteStringObject;
+use CBOR\CBORObject;
+use CBOR\ListObject;
+use CBOR\TextStringObject;
+use Stringable;
+
+/**
+ * The shape every RFC 9052 cryptographic structure has: a context string that names what is being computed,
+ * followed by the fields that structure commits to.
+ *
+ * These are the byte strings that are signed, MACed or fed as additional authenticated data -- never the payload on
+ * its own. Casting an instance to string yields the CBOR encoding to hand to the algorithm.
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc9052#section-4.4
+ * @see https://www.rfc-editor.org/rfc/rfc9052#section-5.3
+ * @see https://www.rfc-editor.org/rfc/rfc9052#section-6.3
+ */
+abstract class CoseStructure implements Stringable
+{
+    /**
+     * RFC 9052 section 4.4 on external_aad: "If this field is not supplied, it defaults to a zero-length byte
+     * string."
+     */
+    public static function emptyExternalAad(): ByteStringObject
+    {
+        return ByteStringObject::create('');
+    }
+
+    public function __toString(): string
+    {
+        return (string) ListObject::create([TextStringObject::create($this->context()), ...$this->items()]);
+    }
+
+    /**
+     * The context string of this structure, as RFC 9052 spells it.
+     */
+    abstract protected function context(): string;
+
+    /**
+     * The fields following the context, in the order the CDDL gives them.
+     *
+     * @return list<CBORObject>
+     */
+    abstract protected function items(): array;
+}

--- a/src/Structure/HeaderMapHelper.php
+++ b/src/Structure/HeaderMapHelper.php
@@ -1,0 +1,341 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cose\Structure;
+
+use CBOR\ByteStringObject;
+use CBOR\CBORObject;
+use CBOR\Decoder;
+use CBOR\DecoderInterface;
+use CBOR\IndefiniteLengthByteStringObject;
+use CBOR\IndefiniteLengthListObject;
+use CBOR\IndefiniteLengthMapObject;
+use CBOR\IndefiniteLengthTextStringObject;
+use CBOR\ListObject;
+use CBOR\MapObject;
+use CBOR\NegativeIntegerObject;
+use CBOR\OtherObject\OtherObjectInterface;
+use CBOR\StringStream;
+use CBOR\TextStringObject;
+use CBOR\UnsignedIntegerObject;
+use function in_array;
+use InvalidArgumentException;
+use function is_int;
+use function ord;
+use function sprintf;
+use function strlen;
+
+/**
+ * The RFC 9052 rules that sit above the CBOR shape of a COSE message: how a protected bucket is encoded and decoded,
+ * what a header label may be, which CBOR tag number a message type carries, and the shape of the signature and
+ * recipient lists.
+ *
+ * These are deliberately static functions over plain CBOR objects rather than methods on a message class. Since
+ * spomky-labs/cbor-php 3.4.0 the six COSE structures live upstream, as CBOR\Tag\CoseSign1Tag and its siblings: that
+ * library owns the shape of a message, this one owns what RFC 9052 says the shape means. Everything here therefore
+ * applies to an upstream message, to the deprecated Cose\...Tag classes, and to a header map a caller assembled
+ * itself.
+ *
+ * {@see CoseHeaders} is the ergonomic form of the header half of this: it reads the two buckets of a message once
+ * and answers label lookups against them.
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc9052#section-3
+ * @see https://www.rfc-editor.org/rfc/rfc9052#section-1.5
+ * @see https://github.com/web-auth/cose-lib/issues/166
+ * @see \Cose\Tests\Structure\HeaderMapHelperTest
+ */
+final class HeaderMapHelper
+{
+    /**
+     * A COSE header is a flat map of a handful of parameters whose values nest a couple of levels at most, so the
+     * decoder built when none is given is bounded far below the cbor-php default of 1000: a protected header crafted
+     * to nest thousands of levels is rejected instead of being walked.
+     */
+    public const DEFAULT_PROTECTED_HEADER_MAX_DEPTH = 32;
+
+    /**
+     * Decode the protected bucket, strictly.
+     *
+     * Three RFC 9052 rules the upstream accessor does not apply, in one place:
+     *
+     * - Section 3: "Recipients MUST accept both a zero-length byte string and a zero-length map encoded in a byte
+     *   string." The zero-length byte string is the form senders are told to prefer, and decoding it as CBOR yields
+     *   nothing at all, hence the guard before the decoder runs.
+     * - Section 3 CDDL: "empty_or_serialized_map = bstr .cbor header_map / bstr .size 0". The ".cbor" control of
+     *   RFC 8610 section 3.8.4 carries exactly one data item, so trailing bytes make the bucket malformed.
+     * - Section 1.5: a key that is neither an integer nor a text string is not a label at all.
+     */
+    public static function decodeProtected(
+        ByteStringObject|IndefiniteLengthByteStringObject $protectedHeader,
+        ?DecoderInterface $decoder = null,
+        int $maxDepth = self::DEFAULT_PROTECTED_HEADER_MAX_DEPTH
+    ): MapObject {
+        $raw = $protectedHeader->getValue();
+        if ($raw === '') {
+            return MapObject::create();
+        }
+
+        $stream = new StringStream($raw);
+        $decoder ??= Decoder::create(null, null, $maxDepth);
+        $decoded = $decoder->decode($stream);
+
+        // cbor-php exposes no end-of-stream predicate, so the probe is a read that has to fail.
+        $trailing = true;
+        try {
+            $stream->read(1);
+        } catch (InvalidArgumentException) {
+            $trailing = false;
+        }
+        if ($trailing) {
+            throw new InvalidArgumentException(
+                'Invalid protected header. The byte string carries trailing data after the header map.'
+            );
+        }
+
+        if (! $decoded instanceof MapObject && ! $decoded instanceof IndefiniteLengthMapObject) {
+            throw new InvalidArgumentException('Protected header is not a valid Map object.');
+        }
+
+        return self::assertValidLabels($decoded);
+    }
+
+    /**
+     * Encode the protected bucket.
+     *
+     * RFC 9052 section 3: "Senders SHOULD encode a zero-length map as a zero-length byte string rather than as a
+     * zero-length map (encoded as h'a0')." Upstream createFromComponents() emits h'a0'; a sender that wants the
+     * preferred form passes the byte string this returns.
+     */
+    public static function encodeProtected(MapObject|IndefiniteLengthMapObject $protectedHeader): ByteStringObject
+    {
+        $checked = self::assertValidLabels($protectedHeader);
+
+        return ByteStringObject::create($checked->count() === 0 ? '' : (string) $checked);
+    }
+
+    /**
+     * Check that every key of a header map is a label and that no label appears twice, and hand back an equivalent
+     * definite-length map.
+     *
+     * RFC 9052 section 1.5: "label = int / tstr" and "the presence a label that is neither a text string nor an
+     * integer is an error". Section 3: "Labels in each of the maps MUST be unique. When processing messages, if a
+     * label appears multiple times, the message MUST be rejected as malformed." A byte string key is the case worth
+     * naming: cbor-php normalizes h'31' to the string "1", so without this check a byte string key would answer a
+     * lookup for the integer label 1, the algorithm parameter.
+     */
+    public static function assertValidLabels(MapObject|IndefiniteLengthMapObject $header): MapObject
+    {
+        $checked = MapObject::create();
+        foreach ($header as $item) {
+            $key = $item->getKey();
+            if (! self::isLabel($key)) {
+                throw new InvalidArgumentException(sprintf(
+                    'Invalid header label. A label shall be an integer or a text string, got "%s" (RFC 9052 section 1.5).',
+                    $key::class
+                ));
+            }
+            $checked->add($key, $item->getValue());
+        }
+
+        return $checked;
+    }
+
+    /**
+     * Look a label up by value *and* by type.
+     *
+     * The map accessors of cbor-php are keyed by the normalized key, and PHP turns the numeric string offset "1"
+     * into the integer 1, so int 1 and tstr "1" -- two distinct labels for RFC 9052 -- share one offset there. This
+     * lookup compares the major type as well, which is what makes a lookup for the label 1 mean the algorithm
+     * parameter and nothing else.
+     */
+    public static function findLabel(MapObject|IndefiniteLengthMapObject $header, int|string $label): ?CBORObject
+    {
+        foreach ($header as $item) {
+            $key = $item->getKey();
+            $matches = is_int($label)
+                ? ($key instanceof UnsignedIntegerObject || $key instanceof NegativeIntegerObject)
+                    && $key->normalize() === (string) $label
+                : ($key instanceof TextStringObject || $key instanceof IndefiniteLengthTextStringObject)
+                    && $key->normalize() === $label;
+            if ($matches) {
+                return $item->getValue();
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Check that the CBOR tag a message carries is the one its structure claims.
+     *
+     * RFC 9052 section 2 maps each message type to one tag number, and the decoder dispatches on that number, so
+     * this is for the paths that bypass it: a class constructed directly, or createFromLoadedData() called on the
+     * value of a GenericTag. Neither the upstream classes nor the deprecated ones check it, so a message can
+     * otherwise keep claiming to be a COSE_Sign1 while serializing as a COSE_Mac0.
+     *
+     * The comparison is on the decoded number, not on the raw components, so a non-minimal encoding of the right
+     * number stays acceptable exactly as it is on the decoder path (RFC 8949 allows it outside deterministic
+     * encoding).
+     */
+    public static function assertTagNumber(int $additionalInformation, ?string $data, int $expected, string $name): void
+    {
+        $number = self::tagNumber($additionalInformation, $data, $name);
+        if ($number !== $expected) {
+            throw new InvalidArgumentException(sprintf(
+                'Not a valid %s object. Expected the CBOR tag %d, got %d.',
+                $name,
+                $expected,
+                $number
+            ));
+        }
+    }
+
+    /**
+     * Check a "signatures" list against "signatures : [+ COSE_Signature]" and "COSE_Signature = [ Headers,
+     * signature : bstr ]" (RFC 9052 section 4.1), Headers being the protected byte string and the unprotected map.
+     */
+    public static function assertSignatureList(ListObject|IndefiniteLengthListObject $signatures): void
+    {
+        if ($signatures->count() === 0) {
+            throw new InvalidArgumentException(
+                'Not a valid CoseSign object. The signatures list shall hold at least one COSE_Signature (RFC 9052 section 4.1).'
+            );
+        }
+        foreach ($signatures as $signature) {
+            if (! self::isList($signature)
+                || $signature->count() !== 3
+                || ! self::isByteString($signature->get(0))
+                || ! self::isMap($signature->get(1))
+                || ! self::isByteString($signature->get(2))
+            ) {
+                throw new InvalidArgumentException(
+                    'Not a valid CoseSign object. Each signature shall be a COSE_Signature [bstr, map, bstr].'
+                );
+            }
+        }
+    }
+
+    /**
+     * Check a "recipients" list against "recipients : [+COSE_recipient]" and "COSE_recipient = [ Headers,
+     * ciphertext : bstr / nil, ? recipients : [+COSE_recipient] ]" (RFC 9052 section 5.1).
+     *
+     * The nested list is walked with the same rule, which is what bounds a recipient tree to well-formed levels
+     * rather than to whatever the decoder happened to accept.
+     */
+    public static function assertRecipientList(
+        ListObject|IndefiniteLengthListObject $recipients,
+        string $name = 'COSE_recipient'
+    ): void {
+        if ($recipients->count() === 0) {
+            throw new InvalidArgumentException(sprintf(
+                'Not a valid %s object. The recipients list shall hold at least one COSE_recipient (RFC 9052 section 5.1).',
+                $name
+            ));
+        }
+        foreach ($recipients as $recipient) {
+            if (! self::isList($recipient)
+                || ! in_array($recipient->count(), [3, 4], true)
+                || ! self::isByteString($recipient->get(0))
+                || ! self::isMap($recipient->get(1))
+                || ! (self::isByteString($recipient->get(2)) || self::isNil($recipient->get(2)))
+            ) {
+                throw new InvalidArgumentException(sprintf(
+                    'Not a valid %s object. Each recipient shall be a COSE_recipient [bstr, map, bstr / nil, ? [+ COSE_recipient]].',
+                    $name
+                ));
+            }
+            if ($recipient->count() === 4) {
+                $nested = $recipient->get(3);
+                if (! self::isList($nested)) {
+                    throw new InvalidArgumentException(sprintf(
+                        'Not a valid %s object. The nested recipients of a COSE_recipient shall be a List object.',
+                        $name
+                    ));
+                }
+                self::assertRecipientList($nested, $name);
+            }
+        }
+    }
+
+    /**
+     * Whether an item is the CBOR "nil" simple value, which is how RFC 9052 spells detached content.
+     *
+     * The decoder maps simple value 22 to NullObject only when the caller's OtherObjectManager knows that class; an
+     * empty manager yields a GenericObject carrying the same head. Both are nil on the wire, so both are nil here.
+     */
+    public static function isNil(CBORObject $object): bool
+    {
+        return $object instanceof OtherObjectInterface
+            && $object->getAdditionalInformation() === CBORObject::OBJECT_NULL;
+    }
+
+    /**
+     * @phpstan-assert-if-true IndefiniteLengthListObject|ListObject $object
+     */
+    private static function isList(CBORObject $object): bool
+    {
+        return $object instanceof ListObject || $object instanceof IndefiniteLengthListObject;
+    }
+
+    private static function isMap(CBORObject $object): bool
+    {
+        return $object instanceof MapObject || $object instanceof IndefiniteLengthMapObject;
+    }
+
+    private static function isByteString(CBORObject $object): bool
+    {
+        return $object instanceof ByteStringObject || $object instanceof IndefiniteLengthByteStringObject;
+    }
+
+    private static function isLabel(CBORObject $key): bool
+    {
+        return $key instanceof UnsignedIntegerObject
+            || $key instanceof NegativeIntegerObject
+            || $key instanceof TextStringObject
+            || $key instanceof IndefiniteLengthTextStringObject;
+    }
+
+    /**
+     * A tag number is the argument of a major type 6 head: the additional information carries it directly below 24,
+     * and announces its width above.
+     */
+    private static function tagNumber(int $additionalInformation, ?string $data, string $name): int
+    {
+        if ($additionalInformation < 24) {
+            return $additionalInformation;
+        }
+
+        $width = match ($additionalInformation) {
+            CBORObject::LENGTH_1_BYTE => 1,
+            CBORObject::LENGTH_2_BYTES => 2,
+            CBORObject::LENGTH_4_BYTES => 4,
+            CBORObject::LENGTH_8_BYTES => 8,
+            default => throw new InvalidArgumentException(sprintf(
+                'Not a valid %s object. The additional information %d is not a valid CBOR tag head.',
+                $name,
+                $additionalInformation
+            )),
+        };
+        if ($data === null || strlen($data) !== $width) {
+            throw new InvalidArgumentException(sprintf(
+                'Not a valid %s object. The CBOR tag head announces %d byte(s) of tag number.',
+                $name,
+                $width
+            ));
+        }
+
+        $number = 0;
+        for ($i = 0; $i < $width; ++$i) {
+            $number = ($number << 8) | ord($data[$i]);
+        }
+        if ($number < 0) {
+            throw new InvalidArgumentException(sprintf(
+                'Not a valid %s object. The CBOR tag number exceeds the platform integer range.',
+                $name
+            ));
+        }
+
+        return $number;
+    }
+}

--- a/tests/CoseInnerLists.php
+++ b/tests/CoseInnerLists.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cose\Tests;
+
+use CBOR\ByteStringObject;
+use CBOR\ListObject;
+use CBOR\MapItem;
+use CBOR\MapObject;
+use CBOR\OtherObject\NullObject;
+use CBOR\UnsignedIntegerObject;
+
+/**
+ * The one-entry "signatures" and "recipients" lists the multi-party messages need.
+ *
+ * RFC 9052 writes both as "[+ ...]": one or more. A test that only cares about the headers of the enclosing message
+ * still has to supply a well-formed entry, and building it in one place keeps the shape in a single spot.
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc9052#section-4.1
+ * @see https://www.rfc-editor.org/rfc/rfc9052#section-5.1
+ */
+trait CoseInnerLists
+{
+    /**
+     * COSE_Signature = [ Headers, signature : bstr ]
+     */
+    private static function signature(string $kid = 'signer', string $signatureValue = 'signature'): ListObject
+    {
+        return ListObject::create([
+            ByteStringObject::create(''),
+            MapObject::create([
+                MapItem::create(UnsignedIntegerObject::create(4), ByteStringObject::create($kid)),
+            ]),
+            ByteStringObject::create($signatureValue),
+        ]);
+    }
+
+    private static function signatures(string ...$kids): ListObject
+    {
+        $kids = $kids === [] ? ['signer'] : $kids;
+
+        return ListObject::create(array_map(static fn (string $kid): ListObject => self::signature($kid), $kids));
+    }
+
+    /**
+     * COSE_recipient = [ Headers, ciphertext : bstr / nil, ? recipients : [+COSE_recipient] ]
+     */
+    private static function recipient(string $kid = 'recipient', ?string $ciphertext = 'wrapped'): ListObject
+    {
+        return ListObject::create([
+            ByteStringObject::create(''),
+            MapObject::create([
+                MapItem::create(UnsignedIntegerObject::create(4), ByteStringObject::create($kid)),
+            ]),
+            $ciphertext === null ? NullObject::create() : ByteStringObject::create($ciphertext),
+        ]);
+    }
+
+    private static function recipients(string ...$kids): ListObject
+    {
+        $kids = $kids === [] ? ['recipient'] : $kids;
+
+        return ListObject::create(array_map(static fn (string $kid): ListObject => self::recipient($kid), $kids));
+    }
+}

--- a/tests/Encryption/CoseEncrypt0TagTest.php
+++ b/tests/Encryption/CoseEncrypt0TagTest.php
@@ -11,9 +11,16 @@ use CBOR\OtherObject\OtherObjectManager;
 use CBOR\StringStream;
 use CBOR\Tag\TagManager;
 use Cose\Encryption\CoseEncrypt0Tag;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * The class under test is deprecated since 4.8.0 in favour of its cbor-php 3.4.0 counterpart (issue #176). Its
+ * behaviour is frozen for the 4.8.x line, so these tests keep running against it with the deprecation silenced;
+ * {@see \Cose\Tests\Structure\DeprecatedTagClassesTest} is what asserts the notice is raised.
+ */
+#[IgnoreDeprecations]
 final class CoseEncrypt0TagTest extends TestCase
 {
     #[Test]

--- a/tests/Encryption/CoseEncryptTagTest.php
+++ b/tests/Encryption/CoseEncryptTagTest.php
@@ -12,9 +12,16 @@ use CBOR\OtherObject\OtherObjectManager;
 use CBOR\StringStream;
 use CBOR\Tag\TagManager;
 use Cose\Encryption\CoseEncryptTag;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * The class under test is deprecated since 4.8.0 in favour of its cbor-php 3.4.0 counterpart (issue #176). Its
+ * behaviour is frozen for the 4.8.x line, so these tests keep running against it with the deprecation silenced;
+ * {@see \Cose\Tests\Structure\DeprecatedTagClassesTest} is what asserts the notice is raised.
+ */
+#[IgnoreDeprecations]
 final class CoseEncryptTagTest extends TestCase
 {
     #[Test]

--- a/tests/Mac/CoseMac0TagTest.php
+++ b/tests/Mac/CoseMac0TagTest.php
@@ -11,9 +11,16 @@ use CBOR\OtherObject\OtherObjectManager;
 use CBOR\StringStream;
 use CBOR\Tag\TagManager;
 use Cose\Mac\CoseMac0Tag;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * The class under test is deprecated since 4.8.0 in favour of its cbor-php 3.4.0 counterpart (issue #176). Its
+ * behaviour is frozen for the 4.8.x line, so these tests keep running against it with the deprecation silenced;
+ * {@see \Cose\Tests\Structure\DeprecatedTagClassesTest} is what asserts the notice is raised.
+ */
+#[IgnoreDeprecations]
 final class CoseMac0TagTest extends TestCase
 {
     #[Test]

--- a/tests/Mac/CoseMacTagTest.php
+++ b/tests/Mac/CoseMacTagTest.php
@@ -12,9 +12,16 @@ use CBOR\OtherObject\OtherObjectManager;
 use CBOR\StringStream;
 use CBOR\Tag\TagManager;
 use Cose\Mac\CoseMacTag;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * The class under test is deprecated since 4.8.0 in favour of its cbor-php 3.4.0 counterpart (issue #176). Its
+ * behaviour is frozen for the 4.8.x line, so these tests keep running against it with the deprecation silenced;
+ * {@see \Cose\Tests\Structure\DeprecatedTagClassesTest} is what asserts the notice is raised.
+ */
+#[IgnoreDeprecations]
 final class CoseMacTagTest extends TestCase
 {
     #[Test]

--- a/tests/PackagingTest.php
+++ b/tests/PackagingTest.php
@@ -4,6 +4,12 @@ declare(strict_types=1);
 
 namespace Cose\Tests;
 
+use CBOR\Tag\CoseEncrypt0Tag;
+use CBOR\Tag\CoseEncryptTag;
+use CBOR\Tag\CoseMac0Tag;
+use CBOR\Tag\CoseMacTag;
+use CBOR\Tag\CoseSign1Tag;
+use CBOR\Tag\CoseSignTag;
 use function file_get_contents;
 use function is_array;
 use function is_string;
@@ -41,25 +47,50 @@ final class PackagingTest extends TestCase
     }
 
     /**
-     * RFC 9052 label uniqueness (sections 3 and 9) and the nesting bound are enforced by the CBOR decoder alone.
-     * Duplicate labels are rejected since spomky-labs/cbor-php 3.3.4 (GHSA-388j-mw2g-rx5f) and the depth bound
-     * exists since 3.3.3, so anything below 3.3.4 must not be installed next to this library. "require-dev" is never
-     * read downstream: only the "conflict" entry makes the floor binding.
+     * Two things this library does not implement itself come from the CBOR decoder: RFC 9052 label uniqueness
+     * (sections 3 and 9) and the nesting bound. Since 4.8.0 a third does -- the six COSE message classes the
+     * deprecated Cose\...Tag classes point at, which spomky-labs/cbor-php ships from 3.4.0.
+     *
+     * "require-dev" is never read downstream: only the "conflict" entry makes the floor binding, so a deprecation
+     * message naming CBOR\Tag\CoseSign1Tag is only honest while anything below 3.4.0 is excluded.
      */
     #[Test]
-    public function theCborDecoderFloorIsBinding(): void
+    public function theCborFloorIsBinding(): void
     {
         // Given
         $composer = self::composerJson();
 
         // Then
-        static::assertSame('<3.3.4', $composer['conflict']['spomky-labs/cbor-php'] ?? null);
-        static::assertSame('^3.3.4', $composer['require-dev']['spomky-labs/cbor-php'] ?? null);
+        static::assertSame('<3.4.0', $composer['conflict']['spomky-labs/cbor-php'] ?? null);
+        static::assertSame('^3.4', $composer['require-dev']['spomky-labs/cbor-php'] ?? null);
         static::assertStringContainsString(
-            '3.3.4',
+            '3.4.0',
             (string) ($composer['suggest']['spomky-labs/cbor-php'] ?? ''),
-            'The suggestion does not mention the version the header-map rules need'
+            'The suggestion does not mention the version the replacement classes need'
         );
+    }
+
+    /**
+     * The classes every deprecation message points at have to be installable next to this library, which is what
+     * the floor above buys. A message naming a class nobody can autoload is worse than no message.
+     */
+    #[Test]
+    public function theReplacementOfEveryDeprecatedClassExists(): void
+    {
+        // Given: the six classes deprecated in 4.8.0 (issue #176)
+        $replacements = [
+            CoseSign1Tag::class,
+            CoseSignTag::class,
+            CoseMac0Tag::class,
+            CoseMacTag::class,
+            CoseEncrypt0Tag::class,
+            CoseEncryptTag::class,
+        ];
+
+        // Then
+        foreach ($replacements as $replacement) {
+            static::assertTrue(class_exists($replacement), $replacement . ' is not installed');
+        }
     }
 
     /**

--- a/tests/ProtectedHeaderDecodingTest.php
+++ b/tests/ProtectedHeaderDecodingTest.php
@@ -26,6 +26,7 @@ use function count;
 use function in_array;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use function str_repeat;
@@ -40,6 +41,12 @@ use function str_repeat;
  * @see https://www.rfc-editor.org/rfc/rfc9052#section-9
  * @see https://github.com/web-auth/cose-lib/issues/171
  */
+/**
+ * The class under test is deprecated since 4.8.0 in favour of its cbor-php 3.4.0 counterpart (issue #176). Its
+ * behaviour is frozen for the 4.8.x line, so these tests keep running against it with the deprecation silenced;
+ * {@see \Cose\Tests\Structure\DeprecatedTagClassesTest} is what asserts the notice is raised.
+ */
+#[IgnoreDeprecations]
 final class ProtectedHeaderDecodingTest extends TestCase
 {
     /**

--- a/tests/Signature/CoseSign1CreateAndVerifyTest.php
+++ b/tests/Signature/CoseSign1CreateAndVerifyTest.php
@@ -16,6 +16,7 @@ use CBOR\UnsignedIntegerObject;
 use Cose\Algorithm\Signature\ECDSA\ECSignature;
 use Cose\Signature\CoseSign1Tag;
 use Cose\Signature\Signature1;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use function strlen;
@@ -23,6 +24,12 @@ use function strlen;
 /**
  * Basé sur l'exemple de https://github.com/Spomky-Labs/cbor-php/issues/32
  */
+/**
+ * The class under test is deprecated since 4.8.0 in favour of its cbor-php 3.4.0 counterpart (issue #176). Its
+ * behaviour is frozen for the 4.8.x line, so these tests keep running against it with the deprecation silenced;
+ * {@see \Cose\Tests\Structure\DeprecatedTagClassesTest} is what asserts the notice is raised.
+ */
+#[IgnoreDeprecations]
 final class CoseSign1CreateAndVerifyTest extends TestCase
 {
     #[Test]

--- a/tests/Signature/CoseSign1Test.php
+++ b/tests/Signature/CoseSign1Test.php
@@ -14,9 +14,16 @@ use Cose\Signature\CoseSign1Tag;
 use Cose\Signature\Signature1;
 use function openssl_verify;
 use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * The class under test is deprecated since 4.8.0 in favour of its cbor-php 3.4.0 counterpart (issue #176). Its
+ * behaviour is frozen for the 4.8.x line, so these tests keep running against it with the deprecation silenced;
+ * {@see \Cose\Tests\Structure\DeprecatedTagClassesTest} is what asserts the notice is raised.
+ */
+#[IgnoreDeprecations]
 final class CoseSign1Test extends TestCase
 {
     #[Test]

--- a/tests/Signature/CoseSignTagTest.php
+++ b/tests/Signature/CoseSignTagTest.php
@@ -15,9 +15,16 @@ use CBOR\StringStream;
 use CBOR\Tag\TagManager;
 use CBOR\UnsignedIntegerObject;
 use Cose\Signature\CoseSignTag;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * The class under test is deprecated since 4.8.0 in favour of its cbor-php 3.4.0 counterpart (issue #176). Its
+ * behaviour is frozen for the 4.8.x line, so these tests keep running against it with the deprecation silenced;
+ * {@see \Cose\Tests\Structure\DeprecatedTagClassesTest} is what asserts the notice is raised.
+ */
+#[IgnoreDeprecations]
 final class CoseSignTagTest extends TestCase
 {
     #[Test]

--- a/tests/Signature/DocumentedVerifierTest.php
+++ b/tests/Signature/DocumentedVerifierTest.php
@@ -10,14 +10,15 @@ use CBOR\ListObject;
 use CBOR\MapItem;
 use CBOR\MapObject;
 use CBOR\NegativeIntegerObject;
-use CBOR\OtherObject\OtherObjectManager;
+use CBOR\OtherObject\NullObject;
 use CBOR\StringStream;
-use CBOR\Tag\TagManager;
+use CBOR\Tag\CoseSign1Tag;
+use CBOR\TextStringObject;
 use CBOR\UnsignedIntegerObject;
 use Cose\Algorithm\Signature\ECDSA\ES256;
 use Cose\Key\Ec2Key;
-use Cose\Signature\CoseSign1Tag;
 use Cose\Signature\Signature1;
+use Cose\Structure\CoseHeaders;
 use function hex2bin;
 use function in_array;
 use InvalidArgumentException;
@@ -29,6 +30,10 @@ use const STR_PAD_LEFT;
 
 /**
  * The COSE_Sign1 verifier documented in README.md and doc/Usage.md, run as it is written there.
+ *
+ * It drives CBOR\Tag\CoseSign1Tag, the class that replaces the deprecated Cose\Signature\CoseSign1Tag in 4.8.0, so
+ * it doubles as the migration example: the message class comes from cbor-php, the header rules and the Sig_structure
+ * come from here.
  *
  * The library verifies signatures; RFC 9052 section 3.1 leaves the binding of "alg" and the processing of "crit" to
  * the application. Every message below is genuinely signed with ES256, so what is exercised is what the documented
@@ -144,6 +149,28 @@ final class DocumentedVerifierTest extends TestCase
     }
 
     /**
+     * RFC 9052 section 1.5: "label = int / tstr", so the text string "1" is not the algorithm parameter. cbor-php
+     * normalizes both keys to the same map offset, which is why the documented verifier reads the parameter through
+     * the typed accessor instead of MapObject::get(): a message whose only "alg" is a text-string label declares no
+     * algorithm at all and has to be turned down.
+     */
+    #[Test]
+    public function aMessageWhoseAlgorithmLabelIsATextStringIsRejected(): void
+    {
+        // Given: protected header {"1": -7} instead of {1: -7}
+        $key = self::signingKey();
+        $header = MapObject::create([
+            MapItem::create(TextStringObject::create('1'), NegativeIntegerObject::create(ES256::identifier())),
+        ]);
+        $message = self::signHeader($key, $header, self::PAYLOAD);
+
+        // Then
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unexpected or missing "alg" in the protected header');
+        self::documentedVerifier($message, $key->toPublic());
+    }
+
+    /**
      * RFC 9052 sections 3 and 9: a label used twice in a header map makes the message malformed. The rule is enforced
      * by the CBOR decoder, which is why this package declares a floor on spomky-labs/cbor-php.
      */
@@ -168,21 +195,27 @@ final class DocumentedVerifierTest extends TestCase
         $algorithm = ES256::create();
         $understoodLabels = self::UNDERSTOOD_LABELS;
 
-        $tagManager = TagManager::create()
-            ->add(CoseSign1Tag::class);
-        $decoder = Decoder::create($tagManager, OtherObjectManager::create());
+        // cbor-php 3.4.0 registers the six COSE tags in the default decoder, so tag 18 resolves on its own.
+        $coseSign1 = Decoder::create()
+            ->decode(new StringStream($encodedData));
+        if (! $coseSign1 instanceof CoseSign1Tag) {
+            throw new RuntimeException('Not a COSE_Sign1 message');
+        }
 
-        $coseSign1 = $decoder->decode(new StringStream($encodedData));
-        $header = $coseSign1->getProtectedHeaderAsMap();
+        // RFC 9052 reads the header buckets; the CBOR layer only carries them.
+        $headers = CoseHeaders::fromMessage($coseSign1);
 
         // RFC 9052 §3.1: bind the signature to the algorithm the protected header declares.
-        if (! $header->has(1) || (int) $header->get(1)->normalize() !== $algorithm::identifier()) {
+        // getProtectedHeaderParameter() matches the label by type as well as by value, so the text string "1" -- a
+        // different label for RFC 9052 §1.5 -- never answers a lookup for the integer label 1.
+        $alg = $headers->getProtectedHeaderParameter(1);
+        if ($alg === null || (int) $alg->normalize() !== $algorithm::identifier()) {
             throw new RuntimeException('Unexpected or missing "alg" in the protected header');
         }
 
         // RFC 9052 §3.1: every parameter listed in "crit" must be processed, or the message must be rejected.
-        if ($header->has(2)) {
-            $crit = $header->get(2);
+        $crit = $headers->getProtectedHeaderParameter(2);
+        if ($crit !== null) {
             if (! $crit instanceof ListObject) {
                 throw new RuntimeException('"crit" is not an array');
             }
@@ -193,7 +226,13 @@ final class DocumentedVerifierTest extends TestCase
             }
         }
 
-        $sigStructure = Signature1::create($coseSign1->getProtectedHeader(), $coseSign1->getPayload());
+        // RFC 9052 §4.2: a nil payload is detached, and the application supplies the content itself.
+        $payload = $coseSign1->getPayload();
+        if ($payload instanceof NullObject) {
+            throw new RuntimeException('The payload is detached; supply it from the application');
+        }
+
+        $sigStructure = Signature1::create($coseSign1->getProtectedHeader(), $payload);
 
         return $algorithm->verify((string) $sigStructure, $key, $coseSign1->getSignature()->getValue());
     }
@@ -226,7 +265,7 @@ final class DocumentedVerifierTest extends TestCase
         $signature = ES256::create()
             ->sign((string) $toBeSigned, $key);
 
-        return (string) CoseSign1Tag::create(
+        return (string) CoseSign1Tag::createFromComponents(
             $protectedHeader,
             MapObject::create(),
             $payloadObject,
@@ -236,17 +275,17 @@ final class DocumentedVerifierTest extends TestCase
 
     private static function replacePayload(string $message, string $payload): string
     {
-        $tagManager = TagManager::create()
-            ->add(CoseSign1Tag::class);
-        $decoder = Decoder::create($tagManager, OtherObjectManager::create());
-        $coseSign1 = $decoder->decode(new StringStream($message));
+        $coseSign1 = Decoder::create()
+            ->decode(new StringStream($message));
+        static::assertInstanceOf(CoseSign1Tag::class, $coseSign1);
 
-        return (string) CoseSign1Tag::create(
-            $coseSign1->getProtectedHeaderAsMap(),
+        // The protected bucket travels as it is: only the payload changes, which is the point of the case.
+        return (string) CoseSign1Tag::create(ListObject::create([
+            $coseSign1->getProtectedHeader(),
             $coseSign1->getUnprotectedHeader(),
             ByteStringObject::create($payload),
-            $coseSign1->getSignature()
-        );
+            $coseSign1->getSignature(),
+        ]));
     }
 
     private static function signingKey(): Ec2Key

--- a/tests/Structure/CoseHeadersTest.php
+++ b/tests/Structure/CoseHeadersTest.php
@@ -1,0 +1,281 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cose\Tests\Structure;
+
+use CBOR\ByteStringObject;
+use CBOR\CBORObject;
+use CBOR\Decoder;
+use CBOR\ListObject;
+use CBOR\MapItem;
+use CBOR\MapObject;
+use CBOR\NegativeIntegerObject;
+use CBOR\StringStream;
+use CBOR\Tag\AbstractCoseTag;
+use CBOR\Tag\CoseEncrypt0Tag;
+use CBOR\Tag\CoseEncryptTag;
+use CBOR\Tag\CoseMac0Tag;
+use CBOR\Tag\CoseMacTag;
+use CBOR\Tag\CoseSign1Tag;
+use CBOR\Tag\CoseSignTag;
+use CBOR\TextStringObject;
+use CBOR\UnsignedIntegerObject;
+use Cose\Structure\CoseHeaders;
+use Cose\Tests\CoseInnerLists;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The header reader, on the six COSE messages of cbor-php 3.4.0.
+ *
+ * The point of running one body against all six is that RFC 9052 defines the two header buckets once, for every
+ * message type; the reader has to answer the same way whether the message is a COSE_Sign1 or a COSE_Encrypt.
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc9052#section-3
+ * @see https://github.com/web-auth/cose-lib/issues/166
+ */
+final class CoseHeadersTest extends TestCase
+{
+    use CoseInnerLists;
+
+    /**
+     * The six upstream message classes.
+     *
+     * @return iterable<string, array{class-string<AbstractCoseTag>}>
+     */
+    public static function getMessageClasses(): iterable
+    {
+        yield 'COSE_Sign1' => [CoseSign1Tag::class];
+        yield 'COSE_Sign' => [CoseSignTag::class];
+        yield 'COSE_Mac0' => [CoseMac0Tag::class];
+        yield 'COSE_Mac' => [CoseMacTag::class];
+        yield 'COSE_Encrypt0' => [CoseEncrypt0Tag::class];
+        yield 'COSE_Encrypt' => [CoseEncryptTag::class];
+    }
+
+    /**
+     * RFC 9052 section 3: "Recipients MUST accept both a zero-length byte string and a zero-length map encoded in a
+     * byte string."
+     *
+     * @param class-string<AbstractCoseTag> $class
+     */
+    #[Test]
+    #[DataProvider('getMessageClasses')]
+    public function bothEncodingsOfAnEmptyProtectedHeaderAreRead(string $class): void
+    {
+        foreach (['', "\xa0"] as $bytes) {
+            // Given
+            $headers = CoseHeaders::fromMessage(self::message($class, ByteStringObject::create($bytes)));
+
+            // Then
+            static::assertCount(0, $headers->getProtectedHeaderAsMap());
+            static::assertNull($headers->getHeaderParameter(1));
+        }
+    }
+
+    /**
+     * @param class-string<AbstractCoseTag> $class
+     */
+    #[Test]
+    #[DataProvider('getMessageClasses')]
+    public function aLabelIsFoundInTheProtectedBucket(string $class): void
+    {
+        // Given: {1: -7}
+        $header = MapObject::create([
+            MapItem::create(UnsignedIntegerObject::create(1), NegativeIntegerObject::create(-7)),
+        ]);
+        $headers = CoseHeaders::fromMessage(self::message($class, ByteStringObject::create((string) $header)));
+
+        // Then
+        static::assertSame('-7', $headers->getProtectedHeaderParameter(1)?->normalize());
+        static::assertSame('-7', $headers->getHeaderParameter(1)?->normalize());
+        static::assertNull($headers->getUnprotectedHeaderParameter(1));
+    }
+
+    /**
+     * RFC 9052 section 1.5: the integer 1 and the text string "1" are different labels, even though cbor-php
+     * normalizes both to the same map offset.
+     *
+     * @param class-string<AbstractCoseTag> $class
+     */
+    #[Test]
+    #[DataProvider('getMessageClasses')]
+    public function aTextStringLabelDoesNotAnswerAnIntegerLookup(string $class): void
+    {
+        // Given: {"1": -7}
+        $header = MapObject::create([
+            MapItem::create(TextStringObject::create('1'), NegativeIntegerObject::create(-7)),
+        ]);
+        $headers = CoseHeaders::fromMessage(self::message($class, ByteStringObject::create((string) $header)));
+
+        // Then: the upstream map answers for the offset, the reader does not
+        static::assertTrue($headers->getProtectedHeaderAsMap()->has(1));
+        static::assertNull($headers->getProtectedHeaderParameter(1));
+        static::assertSame('-7', $headers->getProtectedHeaderParameter('1')?->normalize());
+    }
+
+    /**
+     * @param class-string<AbstractCoseTag> $class
+     */
+    #[Test]
+    #[DataProvider('getMessageClasses')]
+    public function trailingDataInTheProtectedHeaderIsRejected(string $class): void
+    {
+        // Given: {1: -7} followed by two stray bytes
+        $headers = CoseHeaders::fromMessage(self::message($class, ByteStringObject::create("\xa1\x01\x26\xff\xff")));
+
+        // Then
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('trailing data');
+        $headers->getProtectedHeaderAsMap();
+    }
+
+    /**
+     * @param class-string<AbstractCoseTag> $class
+     */
+    #[Test]
+    #[DataProvider('getMessageClasses')]
+    public function aByteStringLabelIsRejected(string $class): void
+    {
+        // Given: {h'31': -7}
+        $header = MapObject::create([
+            MapItem::create(ByteStringObject::create('1'), NegativeIntegerObject::create(-7)),
+        ]);
+        $headers = CoseHeaders::fromMessage(self::message($class, ByteStringObject::create((string) $header)));
+
+        // Then
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid header label');
+        $headers->getProtectedHeaderAsMap();
+    }
+
+    /**
+     * RFC 9052 section 3: a parameter in the protected bucket is the one the signature or the MAC commits to, so it
+     * wins over an unprotected copy of the same label.
+     *
+     * @param class-string<AbstractCoseTag> $class
+     */
+    #[Test]
+    #[DataProvider('getMessageClasses')]
+    public function theProtectedBucketWinsTheCombinedLookup(string $class): void
+    {
+        // Given: alg -7 protected, alg -8 and kid unprotected
+        $protectedHeader = MapObject::create([
+            MapItem::create(UnsignedIntegerObject::create(1), NegativeIntegerObject::create(-7)),
+        ]);
+        $unprotectedHeader = MapObject::create([
+            MapItem::create(UnsignedIntegerObject::create(1), NegativeIntegerObject::create(-8)),
+            MapItem::create(UnsignedIntegerObject::create(4), ByteStringObject::create('kid')),
+        ]);
+        $headers = CoseHeaders::fromMessage(
+            self::message($class, ByteStringObject::create((string) $protectedHeader), $unprotectedHeader)
+        );
+
+        // Then
+        static::assertSame('-7', $headers->getHeaderParameter(1)?->normalize());
+        static::assertSame('-8', $headers->getUnprotectedHeaderParameter(1)?->normalize());
+        static::assertSame('kid', $headers->getHeaderParameter(4)?->getValue());
+        static::assertNull($headers->getHeaderParameter(42));
+    }
+
+    /**
+     * The reader is what a caller uses on a real, decoded message. Since cbor-php 3.4.0 the default decoder resolves
+     * the COSE tags on its own, so nothing has to be registered for this to yield a CoseSign1Tag.
+     */
+    #[Test]
+    public function aDecodedMessageIsRead(): void
+    {
+        // Given: RFC 9052 Appendix C.2.1 -- 18([h'a10126', {4: '11'}, 'This is the content.', h'...'])
+        $bytes = (string) hex2bin(
+            'd28443a10126a10442313154546869732069732074686520636f6e74656e742e58408eb33e4ca31d1c465ab05aac34cc6b23'
+            . 'd58fef5c083106c4d25a91aef0b0117e2af9a291aa32e14ab834dc56ed2a223444547e01f11d3b0916e5a4c345cacb36'
+        );
+        $message = Decoder::create()
+            ->decode(StringStream::create($bytes));
+        static::assertInstanceOf(CoseSign1Tag::class, $message);
+
+        // When
+        $headers = CoseHeaders::fromMessage($message);
+
+        // Then
+        static::assertSame('-7', $headers->getProtectedHeaderParameter(1)?->normalize());
+        static::assertSame('11', $headers->getHeaderParameter(4)?->getValue());
+        static::assertNull($headers->getProtectedHeaderParameter(4));
+    }
+
+    /**
+     * The deprecated Cose\...Tag classes hand back the same two buckets, so the reader serves them through of().
+     */
+    #[Test]
+    public function theDeprecatedClassesAreReadThroughOf(): void
+    {
+        // Given
+        $protectedHeader = MapObject::create([
+            MapItem::create(UnsignedIntegerObject::create(1), NegativeIntegerObject::create(-7)),
+        ]);
+        $legacy = @\Cose\Signature\CoseSign1Tag::create(
+            $protectedHeader,
+            MapObject::create([MapItem::create(UnsignedIntegerObject::create(4), ByteStringObject::create('kid'))]),
+            ByteStringObject::create('content'),
+            ByteStringObject::create('signature')
+        );
+
+        // When
+        $headers = CoseHeaders::of($legacy->getProtectedHeader(), $legacy->getUnprotectedHeader());
+
+        // Then
+        static::assertSame('-7', $headers->getProtectedHeaderParameter(1)?->normalize());
+        static::assertSame('kid', $headers->getHeaderParameter(4)?->getValue());
+    }
+
+    /**
+     * The protected bucket is decoded once and reused.
+     */
+    #[Test]
+    public function theProtectedHeaderIsDecodedOnce(): void
+    {
+        // Given
+        $header = MapObject::create([
+            MapItem::create(UnsignedIntegerObject::create(1), NegativeIntegerObject::create(-7)),
+        ]);
+        $headers = CoseHeaders::fromMessage(
+            self::message(CoseSign1Tag::class, ByteStringObject::create((string) $header))
+        );
+
+        // Then
+        static::assertSame($headers->getProtectedHeaderAsMap(), $headers->getProtectedHeaderAsMap());
+    }
+
+    /**
+     * One upstream message of the given type, around the supplied protected header.
+     *
+     * @param class-string<AbstractCoseTag> $class
+     */
+    private static function message(
+        string $class,
+        CBORObject $protectedHeader,
+        ?MapObject $unprotectedHeader = null
+    ): AbstractCoseTag {
+        $unprotectedHeader ??= MapObject::create();
+        $content = ByteStringObject::create('content');
+        $head = [$protectedHeader, $unprotectedHeader, $content];
+
+        $items = match ($class) {
+            CoseSign1Tag::class => [...$head, ByteStringObject::create('signature')],
+            CoseSignTag::class => [...$head, self::signatures()],
+            CoseMac0Tag::class => [...$head, ByteStringObject::create('tag')],
+            CoseMacTag::class => [...$head, ByteStringObject::create('tag'), self::recipients()],
+            CoseEncrypt0Tag::class => $head,
+            CoseEncryptTag::class => [...$head, self::recipients()],
+            default => throw new InvalidArgumentException('Unknown message class ' . $class),
+        };
+
+        /** @var AbstractCoseTag $message */
+        $message = $class::create(ListObject::create($items));
+
+        return $message;
+    }
+}

--- a/tests/Structure/CoseRecipientTest.php
+++ b/tests/Structure/CoseRecipientTest.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cose\Tests\Structure;
+
+use CBOR\ByteStringObject;
+use CBOR\ListObject;
+use CBOR\MapItem;
+use CBOR\MapObject;
+use CBOR\NegativeIntegerObject;
+use CBOR\OtherObject\NullObject;
+use CBOR\Tag\CoseEncryptTag;
+use CBOR\UnsignedIntegerObject;
+use Cose\Structure\CoseRecipient;
+use Cose\Tests\CoseInnerLists;
+use InvalidArgumentException;
+use LogicException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The checked view over one entry of a "recipients" list.
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc9052#section-5.1
+ */
+final class CoseRecipientTest extends TestCase
+{
+    use CoseInnerLists;
+
+    #[Test]
+    public function aWellFormedEntryExposesItsHeadersAndCiphertext(): void
+    {
+        // Given
+        $entry = self::recipient('recipient-1', 'wrapped-key');
+
+        // When
+        $recipient = CoseRecipient::create($entry);
+
+        // Then
+        static::assertSame('recipient-1', $recipient->getUnprotectedHeaderParameter(4)?->getValue());
+        static::assertFalse($recipient->hasDetachedCiphertext());
+        static::assertSame('wrapped-key', $recipient->getCiphertext()->getValue());
+        static::assertFalse($recipient->hasRecipients());
+        static::assertSame([], $recipient->getRecipients());
+    }
+
+    /**
+     * RFC 9052 section 5.1 types the ciphertext of a recipient as "bstr / nil".
+     */
+    #[Test]
+    public function aDetachedCiphertextIsReported(): void
+    {
+        // Given
+        $recipient = CoseRecipient::create(self::recipient('r', null));
+
+        // Then
+        static::assertTrue($recipient->hasDetachedCiphertext());
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('detached');
+        $recipient->getCiphertext();
+    }
+
+    /**
+     * "? recipients : [+COSE_recipient]" -- a recipient may carry recipients of its own, which is how RFC 9052
+     * expresses key layering.
+     */
+    #[Test]
+    public function nestedRecipientsAreWalked(): void
+    {
+        // Given: one recipient carrying two of its own
+        $entry = ListObject::create([
+            ByteStringObject::create(''),
+            MapObject::create([MapItem::create(UnsignedIntegerObject::create(4), ByteStringObject::create('outer'))]),
+            NullObject::create(),
+            self::recipients('inner-1', 'inner-2'),
+        ]);
+
+        // When
+        $recipient = CoseRecipient::create($entry);
+
+        // Then
+        static::assertTrue($recipient->hasRecipients());
+        $nested = $recipient->getRecipients();
+        static::assertCount(2, $nested);
+        static::assertSame('inner-1', $nested[0]->getUnprotectedHeaderParameter(4)?->getValue());
+        static::assertSame('inner-2', $nested[1]->getUnprotectedHeaderParameter(4)?->getValue());
+        static::assertSame((string) $entry, (string) $recipient->toListObject());
+    }
+
+    #[Test]
+    public function everyEntryOfAMessageIsWrapped(): void
+    {
+        // Given
+        $message = CoseEncryptTag::createFromComponents(
+            MapObject::create(),
+            MapObject::create(),
+            ByteStringObject::create('ciphertext'),
+            self::recipients('a', 'b')
+        );
+
+        // When
+        $recipients = CoseRecipient::all($message->getRecipients());
+
+        // Then
+        static::assertCount(2, $recipients);
+        static::assertSame('a', $recipients[0]->getUnprotectedHeaderParameter(4)?->getValue());
+    }
+
+    #[Test]
+    public function anEmptyListIsRejected(): void
+    {
+        // Given: a message cbor-php decodes without complaint
+        $message = CoseEncryptTag::createFromComponents(
+            MapObject::create(),
+            MapObject::create(),
+            ByteStringObject::create('ciphertext'),
+            ListObject::create([])
+        );
+        static::assertCount(0, $message->getRecipients());
+
+        // Then
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('at least one COSE_recipient');
+        CoseRecipient::all($message->getRecipients());
+    }
+
+    #[Test]
+    public function aMalformedNestedLevelIsRejected(): void
+    {
+        // Given: a well-formed recipient whose nested list holds a text string
+        $entry = ListObject::create([
+            ByteStringObject::create(''),
+            MapObject::create(),
+            ByteStringObject::create('wrapped'),
+            ListObject::create([NegativeIntegerObject::create(-1)]),
+        ]);
+
+        // Then
+        $this->expectException(InvalidArgumentException::class);
+        CoseRecipient::create($entry);
+    }
+
+    #[Test]
+    public function anEntryOfTheWrongArityIsRejected(): void
+    {
+        // Then
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('shall be a COSE_recipient');
+
+        // When: five items, where the CDDL allows three or four
+        CoseRecipient::create(ListObject::create([
+            ByteStringObject::create(''),
+            MapObject::create(),
+            ByteStringObject::create('c'),
+            ListObject::create([]),
+            ByteStringObject::create('extra'),
+        ]));
+    }
+}

--- a/tests/Structure/CoseSignatureTest.php
+++ b/tests/Structure/CoseSignatureTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cose\Tests\Structure;
+
+use CBOR\ByteStringObject;
+use CBOR\ListObject;
+use CBOR\MapItem;
+use CBOR\MapObject;
+use CBOR\NegativeIntegerObject;
+use CBOR\Tag\CoseSignTag;
+use CBOR\UnsignedIntegerObject;
+use Cose\Signature\CoseSignature;
+use Cose\Tests\CoseInnerLists;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The checked view over one entry of a "signatures" list.
+ *
+ * cbor-php checks that the item is a list and stops there, so a COSE_Sign can carry an empty list or a list of
+ * integers and still decode. This view is where RFC 9052 section 4.1 is applied.
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc9052#section-4.1
+ */
+final class CoseSignatureTest extends TestCase
+{
+    use CoseInnerLists;
+
+    #[Test]
+    public function aWellFormedEntryExposesItsHeadersAndSignature(): void
+    {
+        // Given: a signer with its own protected bucket, as a COSE_Sign signer has
+        $signerProtectedHeader = MapObject::create([
+            MapItem::create(UnsignedIntegerObject::create(1), NegativeIntegerObject::create(-7)),
+        ]);
+        $entry = ListObject::create([
+            ByteStringObject::create((string) $signerProtectedHeader),
+            MapObject::create([MapItem::create(UnsignedIntegerObject::create(4), ByteStringObject::create('signer-1'))]),
+            ByteStringObject::create('the-signature'),
+        ]);
+
+        // When
+        $signature = CoseSignature::create($entry);
+
+        // Then
+        static::assertSame('-7', $signature->getProtectedHeaderParameter(1)?->normalize());
+        static::assertSame('signer-1', $signature->getUnprotectedHeaderParameter(4)?->getValue());
+        static::assertSame('the-signature', $signature->getSignature()->getValue());
+        static::assertSame((string) $entry, (string) $signature->toListObject());
+    }
+
+    /**
+     * The upstream class accepts a list of anything; walking it through the view is what turns that into a typed
+     * list of signers.
+     */
+    #[Test]
+    public function everyEntryOfAMessageIsWrapped(): void
+    {
+        // Given
+        $message = CoseSignTag::createFromComponents(
+            MapObject::create(),
+            MapObject::create(),
+            ByteStringObject::create('content'),
+            self::signatures('a', 'b')
+        );
+
+        // When
+        $signers = CoseSignature::all($message->getSignatures());
+
+        // Then
+        static::assertCount(2, $signers);
+        static::assertSame('a', $signers[0]->getUnprotectedHeaderParameter(4)?->getValue());
+        static::assertSame('b', $signers[1]->getUnprotectedHeaderParameter(4)?->getValue());
+    }
+
+    /**
+     * RFC 9052 section 4.1 writes the list as "[+ COSE_Signature]": at least one entry.
+     */
+    #[Test]
+    public function anEmptyListIsRejected(): void
+    {
+        // Given: a message cbor-php decodes without complaint
+        $message = CoseSignTag::createFromComponents(
+            MapObject::create(),
+            MapObject::create(),
+            ByteStringObject::create('content'),
+            ListObject::create([])
+        );
+        static::assertCount(0, $message->getSignatures());
+
+        // Then
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('at least one COSE_Signature');
+        CoseSignature::all($message->getSignatures());
+    }
+
+    #[Test]
+    public function anEntryOfTheWrongShapeIsRejected(): void
+    {
+        // Then
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('shall be a COSE_Signature');
+
+        // When: two items instead of three
+        CoseSignature::create(ListObject::create([ByteStringObject::create(''), MapObject::create()]));
+    }
+
+    #[Test]
+    public function anEntryThatIsNotAListIsRejected(): void
+    {
+        // Then
+        $this->expectException(InvalidArgumentException::class);
+
+        // When
+        CoseSignature::all(ListObject::create([UnsignedIntegerObject::create(1)]));
+    }
+}

--- a/tests/Structure/CoseStructureTest.php
+++ b/tests/Structure/CoseStructureTest.php
@@ -1,0 +1,317 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cose\Tests\Structure;
+
+use CBOR\ByteStringObject;
+use CBOR\CBORObject;
+use CBOR\Decoder;
+use CBOR\ListObject;
+use CBOR\OtherObject\NullObject;
+use CBOR\StringStream;
+use CBOR\Tag\CoseMacTag;
+use CBOR\Tag\CoseSign1Tag;
+use CBOR\Tag\CoseSignTag;
+use Cose\Algorithm\Mac\HS256;
+use Cose\Algorithm\Signature\ECDSA\ES256;
+use Cose\Encryption\Encrypt0Structure;
+use Cose\Encryption\EncryptStructure;
+use Cose\Encryption\RecipientStructure;
+use Cose\Key\Ec2Key;
+use Cose\Key\SymmetricKey;
+use Cose\Mac\Mac0Structure;
+use Cose\Mac\MacStructure;
+use Cose\Signature\CoseSignature;
+use Cose\Signature\Signature;
+use Cose\Signature\Signature1;
+use Cose\Structure\HeaderMapHelper;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The RFC 9052 cryptographic structures, against the examples of its Appendix C.
+ *
+ * A structure is only right if the algorithm agrees, so each vector here is checked by verifying the signature or
+ * the MAC the RFC published rather than by comparing bytes to bytes: a wrong context string, a missing external_aad
+ * or a dropped sign_protected all fail that check, and none of them would fail a length or a shape assertion.
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc9052#appendix-C
+ * @see https://github.com/web-auth/cose-lib/issues/166
+ */
+final class CoseStructureTest extends TestCase
+{
+    /**
+     * The ECDSA P-256 key of RFC 9052 Appendix C.1 ("11"), public part.
+     */
+    private const EC_X = 'bac5b11cad8f99f9c72b05cf4b9e26d244dc189f745228255a219a86d6a09eff';
+
+    private const EC_Y = '20138bf82dc1b6d562be0fa54ab7804a3a64b6d72ccfed6b6fb6ed28bbfc117e';
+
+    /**
+     * The 256-bit symmetric key of RFC 9052 Appendix C.1 ("our-secret").
+     */
+    private const SECRET = '849b57219dae48de646d07dbb533566e976686457c1491be3a76dcea6c427188';
+
+    /**
+     * RFC 9052 Appendix C.2.1: a signed message with one signer, ES256.
+     */
+    private const SIGN1_MESSAGE = 'd28443a10126a10442313154546869732069732074686520636f6e74656e742e58408eb33e'
+        . '4ca31d1c465ab05aac34cc6b23d58fef5c083106c4d25a91aef0b0117e2af9a291aa32e14ab834dc56ed2a223444547e01f11'
+        . 'd3b0916e5a4c345cacb36';
+
+    /**
+     * RFC 9052 Appendix C.1.1: a COSE_Sign with one signer, ES256. The body protected bucket is empty and the
+     * signer carries its own, which is exactly what tells Sig_structure "Signature" from "Signature1".
+     */
+    private const SIGN_MESSAGE = 'd8628440a054546869732069732074686520636f6e74656e742e818343a10126a10442313158'
+        . '40e2aeafd40d69d19dfe6e52077c5d7ff4e408282cbefb5d06cbf414af2e19d982ac45ac98b8544c908b4507de1e90b717c3d'
+        . '34816fe926a2b98f53afd2fa0f30a';
+
+    /**
+     * RFC 9052 Appendix C.5.1: a MACed message, HMAC-SHA-256, with one "direct" recipient.
+     */
+    private const MAC_MESSAGE = 'd8618543a10105a054546869732069732074686520636f6e74656e742e58202bdcc89f058216b8'
+        . 'a208ddc6d8b54aa91f48bd63484986565105c9ad5a6682f6818340a20125044a6f75722d73656372657440';
+
+    /**
+     * The Sig_structure of a COSE_Sign1 is what ES256 signed, so the published signature verifies over it and over
+     * nothing else.
+     */
+    #[Test]
+    public function theSignature1StructureMatchesTheRfcVector(): void
+    {
+        // Given
+        $message = self::decode(self::SIGN1_MESSAGE);
+        static::assertInstanceOf(CoseSign1Tag::class, $message);
+
+        // When
+        $structure = Signature1::create($message->getProtectedHeader(), $message->getPayload());
+
+        // Then
+        static::assertSame(
+            '846a5369676e61747572653143a101264054546869732069732074686520636f6e74656e742e',
+            bin2hex((string) $structure)
+        );
+        static::assertTrue(
+            ES256::create()->verify((string) $structure, self::ecKey(), $message->getSignature()->getValue())
+        );
+    }
+
+    /**
+     * RFC 9052 section 4.4: "Sig_structure = [ context, body_protected, ? sign_protected, external_aad, payload ]".
+     * A COSE_Sign signature commits to both protected buckets; building it as a Signature1 over the body one gives a
+     * different structure and the RFC signature does not verify over it.
+     */
+    #[Test]
+    public function theSignatureStructureCarriesTheSignerProtectedHeader(): void
+    {
+        // Given
+        $message = self::decode(self::SIGN_MESSAGE);
+        static::assertInstanceOf(CoseSignTag::class, $message);
+        $signer = CoseSignature::all($message->getSignatures())[0];
+
+        // When
+        $structure = Signature::create(
+            $message->getProtectedHeader(),
+            $signer->getProtectedHeader(),
+            $message->getPayload()
+        );
+
+        // Then
+        static::assertSame(
+            '85695369676e61747572654043a101264054546869732069732074686520636f6e74656e742e',
+            bin2hex((string) $structure)
+        );
+        static::assertTrue(
+            ES256::create()->verify((string) $structure, self::ecKey(), $signer->getSignature()->getValue())
+        );
+
+        // And: the COSE_Sign1 structure over the same header and payload is a different one
+        $asSign1 = Signature1::create($signer->getProtectedHeader(), $message->getPayload());
+        static::assertNotSame((string) $structure, (string) $asSign1);
+        static::assertFalse(
+            ES256::create()->verify((string) $asSign1, self::ecKey(), $signer->getSignature()->getValue())
+        );
+    }
+
+    /**
+     * The MAC_structure is what HMAC authenticated, not the payload: the RFC tag matches over the structure and not
+     * over the payload alone.
+     */
+    #[Test]
+    public function theMacStructureMatchesTheRfcVector(): void
+    {
+        // Given
+        $message = self::decode(self::MAC_MESSAGE);
+        static::assertInstanceOf(CoseMacTag::class, $message);
+        $key = self::symmetricKey();
+
+        // When
+        $structure = MacStructure::create($message->getProtectedHeader(), $message->getPayload());
+
+        // Then
+        static::assertSame(
+            '84634d414343a101054054546869732069732074686520636f6e74656e742e',
+            bin2hex((string) $structure)
+        );
+        static::assertTrue(HS256::create()->verify((string) $structure, $key, $message->getTag()->getValue()));
+
+        // And: the payload on its own is not what the tag covers
+        static::assertFalse(
+            HS256::create()->verify($message->getPayload()->getValue(), $key, $message->getTag()->getValue())
+        );
+    }
+
+    /**
+     * RFC 9052 section 6.3 gives MAC_structure the contexts "MAC" and "MAC0". The context is the only difference
+     * between the two, and it is what keeps a tag from being valid for the other message type.
+     */
+    #[Test]
+    public function theMac0ContextProducesADifferentTagThanTheMacContext(): void
+    {
+        // Given: the header and payload of the RFC COSE_Mac example
+        $message = self::decode(self::MAC_MESSAGE);
+        static::assertInstanceOf(CoseMacTag::class, $message);
+        $key = self::symmetricKey();
+
+        // When
+        $mac0 = Mac0Structure::create($message->getProtectedHeader(), $message->getPayload());
+
+        // Then
+        static::assertSame(
+            '84644d41433043a101054054546869732069732074686520636f6e74656e742e',
+            bin2hex((string) $mac0)
+        );
+        static::assertFalse(HS256::create()->verify((string) $mac0, $key, $message->getTag()->getValue()));
+    }
+
+    /**
+     * RFC 9052 section 4.4 on external_aad: "If this field is not supplied, it defaults to a zero-length byte
+     * string." Supplying one changes what is signed, which is the whole point of the parameter.
+     */
+    #[Test]
+    public function theExternalAadIsCarriedByEveryStructure(): void
+    {
+        // Given
+        $protectedHeader = ByteStringObject::create("\xa1\x01\x26");
+        $payload = ByteStringObject::create('This is the content.');
+        $aad = ByteStringObject::create('external');
+
+        // When / Then: the default is the zero-length byte string, and a supplied value replaces it
+        $structures = [
+            Signature1::create($protectedHeader, $payload),
+            Signature::create($protectedHeader, $protectedHeader, $payload),
+            Mac0Structure::create($protectedHeader, $payload),
+            MacStructure::create($protectedHeader, $payload),
+            Encrypt0Structure::create($protectedHeader),
+            EncryptStructure::create($protectedHeader),
+            RecipientStructure::forEncryptRecipient($protectedHeader),
+            RecipientStructure::forMacRecipient($protectedHeader),
+            RecipientStructure::forNestedRecipient($protectedHeader),
+        ];
+        $withAad = [
+            Signature1::create($protectedHeader, $payload, $aad),
+            Signature::create($protectedHeader, $protectedHeader, $payload, $aad),
+            Mac0Structure::create($protectedHeader, $payload, $aad),
+            MacStructure::create($protectedHeader, $payload, $aad),
+            Encrypt0Structure::create($protectedHeader, $aad),
+            EncryptStructure::create($protectedHeader, $aad),
+            RecipientStructure::forEncryptRecipient($protectedHeader, $aad),
+            RecipientStructure::forMacRecipient($protectedHeader, $aad),
+            RecipientStructure::forNestedRecipient($protectedHeader, $aad),
+        ];
+
+        foreach ($structures as $index => $structure) {
+            static::assertSame('', $structure->getExternalAad()->getValue());
+            static::assertStringContainsString("\x40", (string) $structure);
+            static::assertSame('external', $withAad[$index]->getExternalAad()->getValue());
+            static::assertStringContainsString('external', (string) $withAad[$index]);
+            static::assertNotSame((string) $structure, (string) $withAad[$index]);
+        }
+    }
+
+    /**
+     * RFC 9052 section 5.3: "Enc_structure = [ context, protected, external_aad ]" -- no payload, since the content
+     * is what the AEAD encrypts. The five contexts of that section produce five distinct structures.
+     */
+    #[Test]
+    public function everyEncStructureContextIsDistinct(): void
+    {
+        // Given
+        $protectedHeader = ByteStringObject::create("\xa1\x01\x01");
+
+        // When
+        $structures = [
+            'Encrypt0' => (string) Encrypt0Structure::create($protectedHeader),
+            'Encrypt' => (string) EncryptStructure::create($protectedHeader),
+            'Enc_Recipient' => (string) RecipientStructure::forEncryptRecipient($protectedHeader),
+            'Mac_Recipient' => (string) RecipientStructure::forMacRecipient($protectedHeader),
+            'Rec_Recipient' => (string) RecipientStructure::forNestedRecipient($protectedHeader),
+        ];
+
+        // Then
+        static::assertCount(5, array_unique($structures));
+        foreach ($structures as $context => $bytes) {
+            // A three-item array: the context, the protected bucket and the external_aad
+            static::assertSame("\x83", $bytes[0]);
+            static::assertStringContainsString($context, $bytes);
+            static::assertSame("\x43\xa1\x01\x01\x40", substr($bytes, -5));
+        }
+    }
+
+    /**
+     * A detached payload is supplied by the application, so the structure is built with it even though the message
+     * does not carry it (RFC 9052 section 4.2).
+     */
+    #[Test]
+    public function aStructureCanBeBuiltForADetachedPayload(): void
+    {
+        // Given: the RFC COSE_Sign1 message with its payload removed
+        $message = self::decode(self::SIGN1_MESSAGE);
+        static::assertInstanceOf(CoseSign1Tag::class, $message);
+        // create() takes the list as it stands, so the protected bytes the signature covers travel unchanged
+        $detached = CoseSign1Tag::create(ListObject::create([
+            $message->getProtectedHeader(),
+            $message->getUnprotectedHeader(),
+            NullObject::create(),
+            $message->getSignature(),
+        ]));
+
+        // When: the application supplies the content it transported separately
+        $structure = Signature1::create($detached->getProtectedHeader(), ByteStringObject::create('This is the content.'));
+
+        // Then
+        static::assertTrue(HeaderMapHelper::isNil($detached->getPayload()));
+        static::assertTrue(
+            ES256::create()->verify((string) $structure, self::ecKey(), $detached->getSignature()->getValue())
+        );
+    }
+
+    private static function ecKey(): Ec2Key
+    {
+        return Ec2Key::create([
+            Ec2Key::TYPE => Ec2Key::TYPE_EC2,
+            Ec2Key::DATA_CURVE => Ec2Key::CURVE_P256,
+            Ec2Key::DATA_X => (string) hex2bin(self::EC_X),
+            Ec2Key::DATA_Y => (string) hex2bin(self::EC_Y),
+        ]);
+    }
+
+    private static function symmetricKey(): SymmetricKey
+    {
+        return SymmetricKey::create([
+            SymmetricKey::TYPE => SymmetricKey::TYPE_OCT,
+            SymmetricKey::DATA_K => (string) hex2bin(self::SECRET),
+        ]);
+    }
+
+    /**
+     * Since cbor-php 3.4.0 the six COSE tags are registered in the default decoder, so nothing has to be added to it.
+     */
+    private static function decode(string $hex): CBORObject
+    {
+        return Decoder::create()
+            ->decode(new StringStream((string) hex2bin($hex)));
+    }
+}

--- a/tests/Structure/DeprecatedTagClassesTest.php
+++ b/tests/Structure/DeprecatedTagClassesTest.php
@@ -1,0 +1,210 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cose\Tests\Structure;
+
+use CBOR\ByteStringObject;
+use CBOR\Decoder;
+use CBOR\ListObject;
+use CBOR\MapObject;
+use CBOR\StringStream;
+use CBOR\Tag;
+use CBOR\Tag\CoseEncrypt0Tag as UpstreamCoseEncrypt0Tag;
+use CBOR\Tag\CoseEncryptTag as UpstreamCoseEncryptTag;
+use CBOR\Tag\CoseMac0Tag as UpstreamCoseMac0Tag;
+use CBOR\Tag\CoseMacTag as UpstreamCoseMacTag;
+use CBOR\Tag\CoseSign1Tag as UpstreamCoseSign1Tag;
+use CBOR\Tag\CoseSignTag as UpstreamCoseSignTag;
+use function chr;
+use function class_exists;
+use Cose\Encryption\CoseEncrypt0Tag;
+use Cose\Encryption\CoseEncryptTag;
+use Cose\Mac\CoseMac0Tag;
+use Cose\Mac\CoseMacTag;
+use Cose\Signature\CoseSign1Tag;
+use Cose\Signature\CoseSignTag;
+use const E_USER_DEPRECATED;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use function restore_error_handler;
+use function set_error_handler;
+
+/**
+ * The six COSE tag classes of this library are deprecated since 4.8.0 in favour of the ones cbor-php 3.4.0 ships,
+ * and are removed in 5.0.0.
+ *
+ * This is the checklist for that removal: one case per class asserting the notice is raised, one asserting the
+ * replacement exists and carries the same tag number, and one asserting that a message written by the deprecated
+ * class is read by the replacement -- which is what makes the deprecation window safe to sit in.
+ *
+ * @see https://github.com/web-auth/cose-lib/issues/176
+ */
+final class DeprecatedTagClassesTest extends TestCase
+{
+    /**
+     * The deprecated classes, their replacements and their tag numbers.
+     *
+     * @return iterable<string, array{class-string, class-string, int}>
+     */
+    public static function getDeprecatedClasses(): iterable
+    {
+        yield 'COSE_Encrypt0' => [CoseEncrypt0Tag::class, UpstreamCoseEncrypt0Tag::class, 16];
+        yield 'COSE_Mac0' => [CoseMac0Tag::class, UpstreamCoseMac0Tag::class, 17];
+        yield 'COSE_Sign1' => [CoseSign1Tag::class, UpstreamCoseSign1Tag::class, 18];
+        yield 'COSE_Encrypt' => [CoseEncryptTag::class, UpstreamCoseEncryptTag::class, 96];
+        yield 'COSE_Mac' => [CoseMacTag::class, UpstreamCoseMacTag::class, 97];
+        yield 'COSE_Sign' => [CoseSignTag::class, UpstreamCoseSignTag::class, 98];
+    }
+
+    /**
+     * @param class-string $class
+     */
+    #[Test]
+    #[DataProvider('getDeprecatedClasses')]
+    public function constructingTheClassRaisesTheDeprecation(string $class, string $replacement): void
+    {
+        // When
+        [$deprecations] = self::capture(static fn () => self::build($class));
+
+        // Then
+        static::assertCount(1, $deprecations);
+        static::assertStringContainsString($class, $deprecations[0]);
+        static::assertStringContainsString('deprecated since 4.8.0', $deprecations[0]);
+        static::assertStringContainsString('removed in 5.0.0', $deprecations[0]);
+        static::assertStringContainsString($replacement, $deprecations[0]);
+    }
+
+    /**
+     * The replacement the message points at has to exist, and stand for the same CBOR tag.
+     *
+     * @param class-string $class
+     * @param class-string $replacement
+     */
+    #[Test]
+    #[DataProvider('getDeprecatedClasses')]
+    public function theReplacementExistsAndCarriesTheSameTagNumber(
+        string $class,
+        string $replacement,
+        int $tagId
+    ): void {
+        // Then
+        static::assertTrue(class_exists($replacement), $replacement . ' is missing; cbor-php 3.4.0 or later is needed');
+        static::assertSame($tagId, $class::getTagId());
+        static::assertSame($tagId, $replacement::getTagId());
+    }
+
+    /**
+     * A message written by the deprecated class decodes as its replacement, byte for byte: the deprecation changes
+     * no wire format, so an application can migrate one side at a time.
+     *
+     * @param class-string $class
+     * @param class-string $replacement
+     */
+    #[Test]
+    #[DataProvider('getDeprecatedClasses')]
+    public function aMessageWrittenByTheDeprecatedClassIsReadByItsReplacement(
+        string $class,
+        string $replacement
+    ): void {
+        // Given
+        [, $built] = self::capture(static fn () => self::build($class));
+        static::assertInstanceOf(Tag::class, $built);
+
+        // When: the default decoder of cbor-php 3.4.0 resolves the COSE tags on its own
+        $decoded = Decoder::create()
+            ->decode(StringStream::create((string) $built));
+
+        // Then
+        static::assertInstanceOf($replacement, $decoded);
+        static::assertSame((string) $built, (string) $decoded);
+    }
+
+    /**
+     * The upstream classes raise nothing.
+     *
+     * @param class-string $class
+     * @param class-string $replacement
+     */
+    #[Test]
+    #[DataProvider('getDeprecatedClasses')]
+    public function theReplacementRaisesNoDeprecation(string $class, string $replacement): void
+    {
+        // When
+        [$deprecations] = self::capture(static fn () => $replacement::create(self::itemsFor($class)));
+
+        // Then
+        static::assertSame([], $deprecations);
+    }
+
+    /**
+     * One message of the given type, built through the deprecated factory.
+     *
+     * @param class-string $class
+     */
+    private static function build(string $class): Tag
+    {
+        [$additionalInformation, $data] = $class::getTagId() <= 23
+            ? [$class::getTagId(), null]
+            : [Tag::LENGTH_1_BYTE, chr($class::getTagId())];
+
+        return $class::createFromLoadedData($additionalInformation, $data, self::itemsFor($class));
+    }
+
+    /**
+     * The items of one message type. The deprecated classes require a byte string everywhere, which is the subset
+     * both they and their replacements accept.
+     *
+     * @param class-string $class
+     */
+    private static function itemsFor(string $class): ListObject
+    {
+        $head = [ByteStringObject::create(''), MapObject::create(), ByteStringObject::create('content')];
+        $inner = ListObject::create([
+            ListObject::create([
+                ByteStringObject::create(''),
+                MapObject::create(),
+                ByteStringObject::create('inner'),
+            ]),
+        ]);
+
+        return ListObject::create(match ($class) {
+            CoseSign1Tag::class => [...$head, ByteStringObject::create('signature')],
+            CoseSignTag::class => [...$head, $inner],
+            CoseMac0Tag::class => [...$head, ByteStringObject::create('tag')],
+            CoseMacTag::class => [...$head, ByteStringObject::create('tag'), $inner],
+            CoseEncrypt0Tag::class => $head,
+            CoseEncryptTag::class => [...$head, $inner],
+            default => throw new InvalidArgumentException('Unknown message class ' . $class),
+        });
+    }
+
+    /**
+     * Runs $callback with an error handler that records E_USER_DEPRECATED rather than letting PHPUnit fail the test
+     * on it, and hands back both the messages and the result.
+     *
+     * @return array{list<string>, mixed}
+     */
+    private static function capture(callable $callback): array
+    {
+        $deprecations = [];
+        set_error_handler(
+            static function (int $severity, string $message) use (&$deprecations): bool {
+                $deprecations[] = $message;
+
+                return true;
+            },
+            E_USER_DEPRECATED
+        );
+
+        try {
+            $result = $callback();
+        } finally {
+            restore_error_handler();
+        }
+
+        return [$deprecations, $result];
+    }
+}

--- a/tests/Structure/HeaderMapHelperTest.php
+++ b/tests/Structure/HeaderMapHelperTest.php
@@ -1,0 +1,347 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cose\Tests\Structure;
+
+use CBOR\ByteStringObject;
+use CBOR\IndefiniteLengthByteStringObject;
+use CBOR\ListObject;
+use CBOR\MapItem;
+use CBOR\MapObject;
+use CBOR\NegativeIntegerObject;
+use CBOR\OtherObject\NullObject;
+use CBOR\OtherObject\UndefinedObject;
+use CBOR\Tag;
+use CBOR\TextStringObject;
+use CBOR\UnsignedIntegerObject;
+use Cose\Structure\HeaderMapHelper;
+use Cose\Tests\CoseInnerLists;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The RFC 9052 rules this library keeps now that cbor-php 3.4.0 owns the shape of a COSE message.
+ *
+ * Each one is a rule the CBOR layer does not apply, on purpose: it describes the encoding, not what COSE reads into
+ * it. These are the primitives; {@see CoseHeadersTest} exercises them through the reader, on real messages.
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc9052
+ * @see https://github.com/web-auth/cose-lib/issues/166
+ */
+final class HeaderMapHelperTest extends TestCase
+{
+    use CoseInnerLists;
+
+    /**
+     * RFC 9052 section 3: "Recipients MUST accept both a zero-length byte string and a zero-length map encoded in a
+     * byte string."
+     */
+    #[Test]
+    public function bothEncodingsOfAnEmptyProtectedHeaderDecodeToAnEmptyMap(): void
+    {
+        // Given: the zero-length byte string senders are told to prefer, and the zero-length map
+        foreach (['', "\xa0"] as $bytes) {
+            // Then
+            static::assertCount(0, HeaderMapHelper::decodeProtected(ByteStringObject::create($bytes)));
+        }
+    }
+
+    /**
+     * The upstream accessors hand back the indefinite-length variants too, so the rules have to read them.
+     */
+    #[Test]
+    public function anIndefiniteLengthProtectedHeaderIsRead(): void
+    {
+        // Given: {1: -7} carried in an indefinite-length byte string
+        $bytes = IndefiniteLengthByteStringObject::create()
+            ->add(ByteStringObject::create("\xa1\x01"))
+            ->add(ByteStringObject::create("\x26"));
+
+        // Then
+        static::assertSame('-7', HeaderMapHelper::findLabel(HeaderMapHelper::decodeProtected($bytes), 1)?->normalize());
+    }
+
+    /**
+     * RFC 9052 section 3 CDDL: "empty_or_serialized_map = bstr .cbor header_map / bstr .size 0". The ".cbor" control
+     * of RFC 8610 section 3.8.4 carries exactly one data item.
+     *
+     * @param string $bytes the content of the protected byte string
+     */
+    #[Test]
+    #[DataProvider('getTrailingData')]
+    public function trailingDataAfterTheHeaderMapIsRejected(string $bytes): void
+    {
+        // Then
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('trailing data');
+
+        // When
+        HeaderMapHelper::decodeProtected(ByteStringObject::create($bytes));
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function getTrailingData(): iterable
+    {
+        yield '{1: -7} followed by two stray bytes' => ["\xa1\x01\x26\xff\xff"];
+        yield '{1: -7} followed by a second complete item' => ["\xa1\x01\x26\xa0"];
+        yield 'an empty map followed by a stray byte' => ["\xa0\x00"];
+    }
+
+    /**
+     * RFC 9052 section 1.5: "label = int / tstr". The integer 1 and the text string "1" are two labels, and only the
+     * first one is the algorithm parameter, even though cbor-php normalizes both to the same map offset.
+     */
+    #[Test]
+    public function anIntegerLabelAndATextStringLabelAreDistinct(): void
+    {
+        // Given: {"1": -7}
+        $header = MapObject::create([
+            MapItem::create(TextStringObject::create('1'), NegativeIntegerObject::create(-7)),
+        ]);
+
+        // Then
+        static::assertTrue($header->has(1), 'the premise of the defect: cbor-php answers for the offset 1');
+        static::assertNull(HeaderMapHelper::findLabel($header, 1));
+        static::assertSame('-7', HeaderMapHelper::findLabel($header, '1')?->normalize());
+    }
+
+    #[Test]
+    public function aNegativeIntegerLabelIsFound(): void
+    {
+        // Given: {-1: 6} -- a COSE key parameter shape
+        $header = MapObject::create([
+            MapItem::create(NegativeIntegerObject::create(-1), UnsignedIntegerObject::create(6)),
+        ]);
+
+        // Then
+        static::assertSame('6', HeaderMapHelper::findLabel($header, -1)?->normalize());
+        static::assertNull(HeaderMapHelper::findLabel($header, 1));
+        static::assertNull(HeaderMapHelper::findLabel($header, '-1'));
+    }
+
+    /**
+     * RFC 9052 section 1.5: "the presence a label that is neither a text string nor an integer is an error". A byte
+     * string key normalizes to a string in cbor-php, so h'31' would otherwise answer a lookup for the label 1.
+     */
+    #[Test]
+    public function aByteStringKeyIsNotALabel(): void
+    {
+        // Given: {h'31': -7}
+        $header = MapObject::create([
+            MapItem::create(ByteStringObject::create('1'), NegativeIntegerObject::create(-7)),
+        ]);
+
+        // Then
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid header label');
+        HeaderMapHelper::assertValidLabels($header);
+    }
+
+    /**
+     * RFC 9052 section 3: "Senders SHOULD encode a zero-length map as a zero-length byte string rather than as a
+     * zero-length map (encoded as h'a0')." Upstream createFromComponents() emits h'a0'.
+     */
+    #[Test]
+    public function anEmptyProtectedHeaderIsEncodedAsTheZeroLengthByteString(): void
+    {
+        // Then
+        static::assertSame('', HeaderMapHelper::encodeProtected(MapObject::create())->getValue());
+    }
+
+    #[Test]
+    public function aNonEmptyProtectedHeaderIsEncodedAsItsMap(): void
+    {
+        // Given: {1: -7}
+        $header = MapObject::create([
+            MapItem::create(UnsignedIntegerObject::create(1), NegativeIntegerObject::create(-7)),
+        ]);
+
+        // Then
+        static::assertSame("\xa1\x01\x26", HeaderMapHelper::encodeProtected($header)->getValue());
+    }
+
+    /**
+     * RFC 9052 section 9: "Applications MUST NOT generate messages with the same label used twice as a key in a
+     * single map."
+     */
+    #[Test]
+    public function aDuplicateLabelIsRejected(): void
+    {
+        // Then: on cbor-php 3.4 the map itself refuses to hold the pair, which is the same outcome one step earlier
+        $this->expectException(InvalidArgumentException::class);
+
+        // When: {1: -7, 1: -8}
+        $duplicate = MapObject::create([
+            MapItem::create(UnsignedIntegerObject::create(1), NegativeIntegerObject::create(-7)),
+            MapItem::create(UnsignedIntegerObject::create(1), NegativeIntegerObject::create(-8)),
+        ]);
+        HeaderMapHelper::encodeProtected($duplicate);
+    }
+
+    /**
+     * RFC 9052 section 2 gives each message type one CBOR tag. The decoder dispatches on it, so the check is for the
+     * paths that bypass the decoder.
+     */
+    #[Test]
+    public function aForeignTagNumberIsRejected(): void
+    {
+        // Then
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Expected the CBOR tag 18, got 17');
+
+        // When: tag 17 is COSE_Mac0, not COSE_Sign1
+        HeaderMapHelper::assertTagNumber(17, null, 18, 'CoseSign1');
+    }
+
+    /**
+     * RFC 8949 allows a non-minimal encoding of the tag number outside deterministic encoding, and the decoder
+     * accepts it, so the check compares the decoded number rather than the head bytes.
+     */
+    #[Test]
+    public function aNonMinimalEncodingOfTheRightTagNumberIsAccepted(): void
+    {
+        // When / Then: 18 on one, two, four and eight bytes
+        HeaderMapHelper::assertTagNumber(Tag::LENGTH_1_BYTE, "\x12", 18, 'CoseSign1');
+        HeaderMapHelper::assertTagNumber(Tag::LENGTH_2_BYTES, "\x00\x12", 18, 'CoseSign1');
+        HeaderMapHelper::assertTagNumber(Tag::LENGTH_4_BYTES, "\x00\x00\x00\x12", 18, 'CoseSign1');
+        HeaderMapHelper::assertTagNumber(Tag::LENGTH_8_BYTES, "\x00\x00\x00\x00\x00\x00\x00\x12", 18, 'CoseSign1');
+
+        // A tag number below 24 travels in the head itself
+        HeaderMapHelper::assertTagNumber(16, null, 16, 'CoseEncrypt0');
+        $this->expectNotToPerformAssertions();
+    }
+
+    #[Test]
+    public function aTagHeadWithoutItsNumberBytesIsRejected(): void
+    {
+        // Then
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('announces 2 byte(s) of tag number');
+
+        // When: the head says two bytes follow and none do
+        HeaderMapHelper::assertTagNumber(Tag::LENGTH_2_BYTES, null, 18, 'CoseSign1');
+    }
+
+    /**
+     * RFC 9052 section 4.1: "signatures : [+ COSE_Signature]" and "COSE_Signature = [ Headers, signature : bstr ]".
+     */
+    #[Test]
+    public function aWellFormedSignatureListIsAccepted(): void
+    {
+        HeaderMapHelper::assertSignatureList(self::signatures('a', 'b'));
+        $this->expectNotToPerformAssertions();
+    }
+
+    /**
+     * @param ListObject $signatures a list RFC 9052 does not allow
+     */
+    #[Test]
+    #[DataProvider('getInvalidSignatureLists')]
+    public function anInvalidSignatureListIsRejected(ListObject $signatures, string $message): void
+    {
+        // Then
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage($message);
+
+        // When
+        HeaderMapHelper::assertSignatureList($signatures);
+    }
+
+    /**
+     * @return iterable<string, array{ListObject, string}>
+     */
+    public static function getInvalidSignatureLists(): iterable
+    {
+        yield 'empty' => [ListObject::create([]), 'at least one COSE_Signature'];
+        yield 'arbitrary objects' => [
+            ListObject::create([UnsignedIntegerObject::create(1), TextStringObject::create('x'), MapObject::create()]),
+            'shall be a COSE_Signature',
+        ];
+        yield 'two items instead of three' => [
+            ListObject::create([ListObject::create([ByteStringObject::create(''), MapObject::create()])]),
+            'shall be a COSE_Signature',
+        ];
+        yield 'a map where the protected header belongs' => [
+            ListObject::create([
+                ListObject::create([MapObject::create(), MapObject::create(), ByteStringObject::create('s')]),
+            ]),
+            'shall be a COSE_Signature',
+        ];
+        yield 'a nil signature' => [
+            ListObject::create([
+                ListObject::create([ByteStringObject::create(''), MapObject::create(), NullObject::create()]),
+            ]),
+            'shall be a COSE_Signature',
+        ];
+    }
+
+    /**
+     * RFC 9052 section 5.1: "COSE_recipient = [ Headers, ciphertext : bstr / nil, ? recipients :
+     * [+COSE_recipient] ]".
+     */
+    #[Test]
+    public function aWellFormedRecipientListIsAccepted(): void
+    {
+        // Given: a detached ciphertext and a nested level, both of which the CDDL allows
+        $nested = ListObject::create([
+            ListObject::create([
+                ByteStringObject::create(''),
+                MapObject::create(),
+                NullObject::create(),
+                self::recipients('inner'),
+            ]),
+        ]);
+
+        HeaderMapHelper::assertRecipientList($nested);
+        $this->expectNotToPerformAssertions();
+    }
+
+    #[Test]
+    public function anEmptyRecipientListIsRejected(): void
+    {
+        // Then
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('at least one COSE_recipient');
+
+        // When
+        HeaderMapHelper::assertRecipientList(ListObject::create([]));
+    }
+
+    /**
+     * A malformed level anywhere in the tree makes the whole tree malformed.
+     */
+    #[Test]
+    public function aMalformedNestedRecipientIsRejected(): void
+    {
+        // Given: a well-formed recipient whose nested list holds an integer
+        $tree = ListObject::create([
+            ListObject::create([
+                ByteStringObject::create(''),
+                MapObject::create(),
+                ByteStringObject::create('wrapped'),
+                ListObject::create([UnsignedIntegerObject::create(1)]),
+            ]),
+        ]);
+
+        // Then
+        $this->expectException(InvalidArgumentException::class);
+        HeaderMapHelper::assertRecipientList($tree);
+    }
+
+    /**
+     * The decoder maps simple value 22 to NullObject only when the caller's OtherObjectManager knows that class; an
+     * empty manager yields a GenericObject carrying the same head. Both are nil on the wire.
+     */
+    #[Test]
+    public function nilIsRecognisedWhateverTheDecoderBuilt(): void
+    {
+        static::assertTrue(HeaderMapHelper::isNil(NullObject::create()));
+        static::assertFalse(HeaderMapHelper::isNil(UndefinedObject::create()));
+        static::assertFalse(HeaderMapHelper::isNil(ByteStringObject::create('')));
+    }
+}


### PR DESCRIPTION
Closes #166. Closes #176.

## What changes

cbor-php 3.4.0 ships the six COSE structures (`CBOR\Tag\CoseSign1Tag` and siblings, plus `CwtTag` for tag 61), registered in the default decoder. The six `Cose\...Tag` classes are therefore **deprecated** (`E_USER_DEPRECATED` on construction) and removed in 5.0.0. Their behaviour is frozen — a deprecation does not change what a class accepts.

What RFC 9052 reads into that shape stays here, and works on the upstream messages:

| New | Does |
|---|---|
| `Cose\Structure\CoseHeaders` | Reads both header buckets: a label is an `int` *or* a `tstr` (§1.5) and the two never answer for each other, a byte-string key is not a label, `h''` is accepted and trailing bytes are not, protected wins a combined lookup |
| `Cose\Signature\CoseSignature`, `Cose\Structure\CoseRecipient` | Checked views over `signatures` / `recipients`, applying `[+ ...]` (§§4.1, 5.1), nested recipients included |
| `Cose\Structure\HeaderMapHelper` | The same rules as static functions, plus `encodeProtected()` (the `h''` §3 prefers) and `assertTagNumber()` |
| `Signature`, `Mac0Structure`, `MacStructure`, `Encrypt0Structure`, `EncryptStructure`, `RecipientStructure` | The structures that were missing next to `Signature1`, which gains the optional `external_aad` |

cbor-php floor moves to `<3.4.0` so every class a deprecation message names is installable.

## On #166

Three of its eight items are already right in the upstream classes (`h''` decode, detached `nil` payload, `getValue()` mutation). The other five are covered by the layer above. Six rules the upstream classes could apply themselves — `h''` on write, trailing data, label typing, duplicate labels via `create()`, tag number, inner lists — belong in a cbor-php issue; a draft with a verified reproduction against 3.4.0 is ready to file.

## Tests

1119 tests. Header rules run against all six upstream message classes. The structures are checked against RFC 9052 Appendix C by **verifying the signatures and MAC the RFC published**, not by comparing bytes: C.2.1 → `Signature1`, C.1.1 → `Signature` (where `sign_protected` earns its place), C.5.1 → `MacStructure`. The same header and payload under `"MAC0"` produce a tag the RFC vector rejects.

Green on PHP 8.2 and 8.5, cbor-php 3.4.0. ECS, PHPStan, Rector, Deptrac, parallel-lint clean.

## Migration

`create()` → `createFromComponents()` is the only non-mechanical rename (upstream `create()` takes the whole list). `getPayload()` can return `NullObject`. Header accessors move to `CoseHeaders`. Wire format is unchanged. Full table in [doc/Usage.md](doc/Usage.md#upgrading-from-the-cosetag-classes).


## Docs

`examples/` holds nine runnable programs — one per topic, from COSE_Sign1 to CWT to the migration off the deprecated classes — each failing loudly if a check does not hold; `ExamplesTest` runs them all under `E_ALL`. The old creation snippet ended at an undefined `$yourSignatureBytes`. `doc/Usage.md` gains **Cryptographic Structures** (the nine context strings in one table) and **Reading Headers** (`CoseHeaders` and the four rules it applies), plus a **CWT** section; detached content and `external_aad` move out of "MAC Operations" to top level. `DocumentedSignerTest` and `CwtTest` keep the published code executable.

