### PR TITLE
docs: add a runnable examples/ directory and document the RFC 9052 layer

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,3 +9,4 @@
 /.gitattributes export-ignore
 /.gitignore export-ignore
 /castor.php export-ignore
+/examples export-ignore

--- a/README.md
+++ b/README.md
@@ -140,41 +140,64 @@ $isValid = $algorithm->verify((string) $sigStructure, $key, $coseSign1->getSigna
 
 ```php
 use CBOR\ByteStringObject;
+use CBOR\ListObject;
 use CBOR\MapItem;
 use CBOR\MapObject;
 use CBOR\NegativeIntegerObject;
-use CBOR\UnsignedIntegerObject;
 use CBOR\Tag\CoseSign1Tag;
+use CBOR\UnsignedIntegerObject;
+use Cose\Algorithm\Signature\ECDSA\ES256;
+use Cose\Key\Ec2Key;
+use Cose\Signature\Signature1;
+use Cose\Structure\HeaderMapHelper;
+
+$algorithm = ES256::create();
+$key = Ec2Key::create($yourPrivateCoseKey);
 
 // Define headers
 $protectedHeader = MapObject::create([
     MapItem::create(
-        UnsignedIntegerObject::create(1), // alg
-        NegativeIntegerObject::create(-7) // ES256
+        UnsignedIntegerObject::create(1),                  // alg
+        NegativeIntegerObject::create(ES256::identifier()) // ES256 (-7)
     ),
 ]);
-
 $unprotectedHeader = MapObject::create([
     MapItem::create(
-        UnsignedIntegerObject::create(4), // kid
+        UnsignedIntegerObject::create(4),                  // kid
         ByteStringObject::create('my-key-id')
     ),
 ]);
+$payload = ByteStringObject::create('Message to sign');
 
-// Create COSE_Sign1
-$coseSign1 = CoseSign1Tag::createFromComponents(
-    $protectedHeader,
+// The signature covers the Sig_structure, never the payload on its own. Encode the protected bucket once, so the
+// bytes that are signed are the bytes the message carries. HeaderMapHelper applies RFC 9052 §3 on the way out: an
+// empty map becomes h'' rather than h'a0', and the labels are checked (§1.5, §9).
+$protectedHeaderAsBytes = HeaderMapHelper::encodeProtected($protectedHeader);
+$toBeSigned = Signature1::create($protectedHeaderAsBytes, $payload);
+$signature = ByteStringObject::create($algorithm->sign((string) $toBeSigned, $key));
+
+// Assemble the message around those exact bytes
+$coseSign1 = CoseSign1Tag::create(ListObject::create([
+    $protectedHeaderAsBytes,
     $unprotectedHeader,
-    ByteStringObject::create('Message to sign'),
-    ByteStringObject::create($signatureBytes)
-);
+    $payload,
+    $signature,
+]));
 
 // Encode to CBOR
 $encoded = (string) $coseSign1;
 ```
 
+> [!NOTE]
+> `CoseSign1Tag::createFromComponents($protectedHeader, $unprotectedHeader, $payload, $signature)` takes the protected
+> header as a **map** and encodes it itself, which is shorter but re-encodes what you already signed. Use it when the
+> signature is computed after the message, and `create()` — as above — when the bytes have to travel verbatim.
+> [`examples/01-sign1.php`](examples/01-sign1.php) is the whole round trip, key generation included, and runs as it
+> stands.
+
 ## Documentation
 
+- **[Examples](examples/)** - A runnable program per topic; `php examples/01-sign1.php` to start
 - **[Usage Guide](doc/Usage.md)** - Complete documentation with examples
 - **[RFC 9052](https://datatracker.ietf.org/doc/html/rfc9052)** - COSE Structures
 - **[RFC 9053](https://datatracker.ietf.org/doc/html/rfc9053)** - COSE Algorithms

--- a/doc/Usage.md
+++ b/doc/Usage.md
@@ -10,6 +10,8 @@ Content encryption itself is not implemented: the encryption tags carry a cipher
 
 - [Installation](#installation)
 - [COSE Tags](#cose-tags)
+- [Cryptographic Structures](#cryptographic-structures)
+- [Reading Headers](#reading-headers)
 - [Signature Operations](#signature-operations)
   - [COSE_Sign1 (Single Signer)](#cose_sign1-single-signer)
   - [COSE_Sign (Multiple Signers)](#cose_sign-multiple-signers)
@@ -19,8 +21,9 @@ Content encryption itself is not implemented: the encryption tags carry a cipher
 - [MAC Operations](#mac-operations)
   - [COSE_Mac0 (Without Recipients)](#cose_mac0-without-recipients)
   - [COSE_Mac (With Recipients)](#cose_mac-with-recipients)
-  - [Detached Content](#detached-content)
-  - [External Additional Authenticated Data](#external-additional-authenticated-data)
+- [CBOR Web Tokens (CWT)](#cbor-web-tokens-cwt)
+- [Detached Content](#detached-content)
+- [External Additional Authenticated Data](#external-additional-authenticated-data)
 - [Upgrading from the Cose\...Tag classes](#upgrading-from-the-cosetag-classes)
 - [Supported Algorithms](#supported-algorithms)
   - [Fully-Specified Algorithms](#fully-specified-algorithms)
@@ -71,6 +74,97 @@ COSE defines six main tags for different cryptographic operations:
 All seven are registered in the default decoder, so `Decoder::create()` resolves them without any `TagManager`
 configuration.
 
+## Cryptographic Structures
+
+A COSE signature or MAC never covers the payload on its own. It covers a **structure** that also binds the protected
+header and the message type, so a tag computed for a `COSE_Mac0` cannot be replayed on a `COSE_Mac`, and a signature
+made for one signer of a `COSE_Sign` cannot be lifted into a `COSE_Sign1`. These structures are what this library
+builds; casting one to string yields the CBOR bytes to hand to the algorithm.
+
+| RFC 9052 | Class | Context | Fields after the context |
+|---|---|---|---|
+| §4.4 `Sig_structure` | `Cose\Signature\Signature1` | `"Signature1"` | body_protected, external_aad, payload |
+| §4.4 `Sig_structure` | `Cose\Signature\Signature` | `"Signature"` | body_protected, **sign_protected**, external_aad, payload |
+| §6.3 `MAC_structure` | `Cose\Mac\Mac0Structure` | `"MAC0"` | protected, external_aad, payload |
+| §6.3 `MAC_structure` | `Cose\Mac\MacStructure` | `"MAC"` | protected, external_aad, payload |
+| §5.3 `Enc_structure` | `Cose\Encryption\Encrypt0Structure` | `"Encrypt0"` | protected, external_aad |
+| §5.3 `Enc_structure` | `Cose\Encryption\EncryptStructure` | `"Encrypt"` | protected, external_aad |
+| §5.3 `Enc_structure` | `RecipientStructure::forEncryptRecipient()` | `"Enc_Recipient"` | protected, external_aad |
+| §5.3 `Enc_structure` | `RecipientStructure::forMacRecipient()` | `"Mac_Recipient"` | protected, external_aad |
+| §5.3 `Enc_structure` | `RecipientStructure::forNestedRecipient()` | `"Rec_Recipient"` | protected, external_aad |
+
+```php
+use Cose\Mac\Mac0Structure;
+use Cose\Signature\Signature1;
+
+// Signing and verifying a COSE_Sign1
+$toBeSigned = Signature1::create($protectedHeaderAsBytes, $payload);
+$signature = $algorithm->sign((string) $toBeSigned, $privateKey);
+$isValid = $algorithm->verify((string) $toBeSigned, $publicKey, $signature);
+
+// Authenticating a COSE_Mac0 — the same shape, a different context string
+$toBeMaced = Mac0Structure::create($protectedHeaderAsBytes, $payload);
+$macTag = $macAlgorithm->hash((string) $toBeMaced, $symmetricKey);
+```
+
+> [!WARNING]
+> `Cose\Algorithm\Mac\Mac::hash()` and `verify()` authenticate exactly the bytes they are given. Passing
+> `getPayload()->getValue()` straight to them produces a tag bound to no header, no algorithm and no message type,
+> which no other implementation will accept.
+
+The protected header is passed as the **byte string the message carries**, not as a map: the structure has to embed
+it verbatim, or the signature no longer verifies. `HeaderMapHelper::encodeProtected()` produces those bytes from a
+map, applying the RFC 9052 §3 rules on the way out.
+
+Every structure takes the optional `external_aad` of §4.4 as its last argument, defaulting to the zero-length byte
+string the RFC prescribes:
+
+```php
+$toBeSigned = Signature1::create(
+    $protectedHeaderAsBytes,
+    $payload,
+    ByteStringObject::create($applicationSuppliedData),
+);
+```
+
+## Reading Headers
+
+cbor-php carries the two header buckets; RFC 9052 decides what they mean. `Cose\Structure\CoseHeaders` applies the
+second part to any COSE message:
+
+```php
+use Cose\Structure\CoseHeaders;
+
+$headers = CoseHeaders::fromMessage($coseSign1);   // any CBOR\Tag\Cose*Tag
+
+$headers->getProtectedHeaderParameter(1);          // ?CBORObject — protected bucket only
+$headers->getUnprotectedHeaderParameter(4);        // ?CBORObject — unprotected bucket only
+$headers->getHeaderParameter(1);                   // ?CBORObject — protected first, then unprotected
+$headers->getProtectedHeaderAsMap();               // MapObject, decoded and checked
+```
+
+What it enforces, and why the raw `MapObject` accessors are not enough:
+
+- **A label is an integer *or* a text string** ([§1.5](https://datatracker.ietf.org/doc/html/rfc9052#section-1.5)),
+  and the two are different labels. cbor-php normalizes the integer `1`, the text string `"1"` and the byte string
+  `h'31'` to the same map offset, so `$map->has(1)` answers `true` for all three. `getProtectedHeaderParameter(1)`
+  matches the type as well, and only the integer `1` is the algorithm parameter.
+- **A byte-string key is not a label at all** and makes the header malformed.
+- **The zero-length protected header is accepted** ([§3](https://datatracker.ietf.org/doc/html/rfc9052#section-3):
+  "Recipients MUST accept both a zero-length byte string and a zero-length map encoded in a byte string"), and
+  **trailing bytes inside the protected bucket are not** — the CDDL `bstr .cbor header_map` holds exactly one item.
+- **The protected bucket wins a combined lookup**, because that is the value the signature or the MAC commits to.
+
+For a per-signer or per-recipient bucket, `CoseSignature` and `CoseRecipient` expose the same lookups; for a header
+map you assembled yourself, use `CoseHeaders::of($protectedBytes, $unprotectedMap)`.
+
+The protected header is decoded with a decoder bounded to `CoseHeaders::DEFAULT_PROTECTED_HEADER_MAX_DEPTH` (32)
+levels of nesting. Pass your own `Decoder` when a header carries custom CBOR tags, or a different `$maxDepth`:
+
+```php
+$headers = CoseHeaders::fromMessage($coseSign1, $customDecoder);
+```
+
 ## Signature Operations
 
 ### COSE_Sign1 (Single Signer)
@@ -81,67 +175,60 @@ The `COSE_Sign1` structure is used when a message has a single signer.
 
 ```php
 use CBOR\ByteStringObject;
+use CBOR\ListObject;
 use CBOR\MapItem;
 use CBOR\MapObject;
 use CBOR\NegativeIntegerObject;
 use CBOR\Tag\CoseSign1Tag;
 use CBOR\UnsignedIntegerObject;
+use Cose\Algorithm\Signature\ECDSA\ES256;
+use Cose\Key\Ec2Key;
+use Cose\Signature\Signature1;
+use Cose\Structure\HeaderMapHelper;
 
-// Create headers
+$algorithm = ES256::create();
+$key = Ec2Key::create($yourPrivateCoseKey);
+
+// Define headers
 $protectedHeader = MapObject::create([
     MapItem::create(
-        UnsignedIntegerObject::create(1), // alg label
-        NegativeIntegerObject::create(-7) // ES256 algorithm
+        UnsignedIntegerObject::create(1),                  // alg
+        NegativeIntegerObject::create(ES256::identifier()) // ES256 (-7)
     ),
 ]);
-
 $unprotectedHeader = MapObject::create([
     MapItem::create(
-        UnsignedIntegerObject::create(4), // kid label
-        ByteStringObject::create('my-key-id') // key identifier
+        UnsignedIntegerObject::create(4),                  // kid
+        ByteStringObject::create('my-key-id')
     ),
 ]);
-
-// Payload
 $payload = ByteStringObject::create('Message to sign');
 
-// Create signature (you would typically use a cryptographic library here)
-$signature = ByteStringObject::create($yourSignatureBytes);
+// The signature covers the Sig_structure, never the payload on its own. Encode the protected bucket once, so the
+// bytes that are signed are the bytes the message carries. HeaderMapHelper applies RFC 9052 §3 on the way out: an
+// empty map becomes h'' rather than h'a0', and the labels are checked (§1.5, §9).
+$protectedHeaderAsBytes = HeaderMapHelper::encodeProtected($protectedHeader);
+$toBeSigned = Signature1::create($protectedHeaderAsBytes, $payload);
+$signature = ByteStringObject::create($algorithm->sign((string) $toBeSigned, $key));
 
-// Create the COSE_Sign1 tag
-$coseSign1 = CoseSign1Tag::createFromComponents(
-    $protectedHeader,
+// Assemble the message around those exact bytes
+$coseSign1 = CoseSign1Tag::create(ListObject::create([
+    $protectedHeaderAsBytes,
     $unprotectedHeader,
     $payload,
-    $signature
-);
+    $signature,
+]));
 
 // Encode to CBOR
 $encoded = (string) $coseSign1;
 ```
 
-> [!IMPORTANT]
-> `createFromComponents()` encodes the protected map itself. A signer computes its `Sig_structure` over the *bytes* of
-> that bucket, so build them once and pass them to both, using `create()` when the bytes have to travel verbatim:
->
-> ```php
-> use CBOR\ListObject;
-> use Cose\Structure\HeaderMapHelper;
->
-> // HeaderMapHelper applies RFC 9052 §3 on the way out: an empty map becomes h'' rather than h'a0', and the labels
-> // are checked (§1.5, §9).
-> $protectedHeaderAsBytes = HeaderMapHelper::encodeProtected($protectedHeader);
->
-> $toBeSigned = Signature1::create($protectedHeaderAsBytes, $payload);
-> $signature = ByteStringObject::create($algorithm->sign((string) $toBeSigned, $key));
->
-> $coseSign1 = CoseSign1Tag::create(ListObject::create([
->     $protectedHeaderAsBytes,
->     $unprotectedHeader,
->     $payload,
->     $signature,
-> ]));
-> ```
+> [!NOTE]
+> `CoseSign1Tag::createFromComponents($protectedHeader, $unprotectedHeader, $payload, $signature)` takes the protected
+> header as a **map** and encodes it itself, which is shorter but re-encodes what you already signed. Use it when the
+> signature is computed after the message, and `create()` — as above — when the bytes have to travel verbatim.
+> [`examples/01-sign1.php`](examples/01-sign1.php) is the whole round trip, key generation included, and runs as it
+> stands.
 
 #### Decoding and Verifying a COSE_Sign1 Message
 
@@ -424,7 +511,50 @@ $coseMac = CoseMacTag::createFromComponents(
 > `getPayload()->getValue()` straight to them produces a tag bound to nothing and interoperable with no other
 > implementation.
 
-### Detached Content
+## CBOR Web Tokens (CWT)
+
+A CWT ([RFC 8392](https://datatracker.ietf.org/doc/html/rfc8392)) is a claims map carried as the payload of a COSE
+message — most often a `COSE_Sign1`. cbor-php 3.4.0 also ships `CBOR\Tag\CwtTag` for the optional tag 61 that marks
+the whole thing as a CWT.
+
+Nothing about the verification changes: the payload is opaque bytes to COSE, and the claims are decoded once the
+signature checks out.
+
+```php
+use CBOR\Decoder;
+use CBOR\StringStream;
+use CBOR\Tag\CoseSign1Tag;
+use CBOR\Tag\CwtTag;
+use Cose\Signature\Signature1;
+use Cose\Structure\CoseHeaders;
+
+$decoded = Decoder::create()->decode(StringStream::create($encoded));
+
+// Tag 61 is optional; the message underneath is the COSE structure
+$message = $decoded instanceof CwtTag ? $decoded->getValue() : $decoded;
+assert($message instanceof CoseSign1Tag);
+
+// Verify first
+$toBeVerified = Signature1::create($message->getProtectedHeader(), $message->getPayload());
+if (! $algorithm->verify((string) $toBeVerified, $key, $message->getSignature()->getValue())) {
+    throw new RuntimeException('Invalid signature');
+}
+
+// Then read the claims (RFC 8392 §3.1: 1 = iss, 2 = sub, 3 = aud, 4 = exp, 5 = nbf, 6 = iat, 7 = cti)
+$claims = Decoder::create()
+    ->decode(StringStream::create($message->getPayload()->getValue()))
+    ->normalize();
+
+// ['1' => 'coap://as.example.com', '6' => '1443944944'] — cbor-php normalizes CBOR integers to numeric strings,
+// so cast the timestamps before comparing them.
+$expiresAt = isset($claims[4]) ? (int) $claims[4] : null;
+```
+
+> [!IMPORTANT]
+> Verify before you read. A claims map decoded from an unverified payload is attacker-controlled input, and `exp` or
+> `iss` read from it means nothing.
+
+## Detached Content
 
 [RFC 9052 §4.1](https://datatracker.ietf.org/doc/html/rfc9052#section-4.1) lets the payload — or the ciphertext of an
 encrypted message — travel outside the message, as a `nil` in its place:
@@ -449,7 +579,7 @@ if ($payload instanceof NullObject) {
 $toBeSigned = Signature1::create($coseSign1->getProtectedHeader(), $payload);
 ```
 
-### External Additional Authenticated Data
+## External Additional Authenticated Data
 
 Every structure takes the optional `external_aad` of
 [RFC 9052 §4.4](https://datatracker.ietf.org/doc/html/rfc9052#section-4.4) as its last argument. It defaults to the
@@ -1025,12 +1155,37 @@ The following header parameters are commonly used in COSE structures:
 
 ## Examples
 
-Complete examples can be found in the `tests/` directory:
+The [`examples/`](../examples) directory holds a runnable program per topic. Each prints what it does and fails
+loudly if a check does not hold, and `tests/ExamplesTest.php` runs all of them on each build:
 
-- `tests/Signature/CoseSign1CreateAndVerifyTest.php` - COVID certificate verification
-- `tests/Signature/CoseSignTagTest.php` - Multiple signatures
-- `tests/Encryption/CoseEncrypt0TagTest.php` - Single recipient encryption
-- `tests/Mac/CoseMac0TagTest.php` - MAC without recipients
+```bash
+composer install
+php examples/01-sign1.php
+```
+
+| File | Topic |
+|---|---|
+| `examples/01-sign1.php` | COSE_Sign1: sign, encode, decode, verify |
+| `examples/02-sign-multiple-signers.php` | COSE_Sign, and why `Signature` carries `sign_protected` |
+| `examples/03-mac0.php` | COSE_Mac0 over the MAC_structure |
+| `examples/04-encrypt0.php` | COSE_Encrypt0 with `Enc_structure` as the AEAD's AAD |
+| `examples/05-encrypt-recipients.php` | COSE_Encrypt: key wrapping, nested recipients, detached ciphertext |
+| `examples/06-headers.php` | The header rules, against what the raw CBOR map answers |
+| `examples/07-detached-and-external-aad.php` | Detached content and `external_aad` |
+| `examples/08-cwt.php` | CBOR Web Tokens |
+| `examples/09-migration.php` | Moving off the deprecated `Cose\...Tag` classes |
+
+The test suite is the rest of the examples, and every one of them is executed on each build:
+
+| File | Shows |
+|---|---|
+| `tests/Signature/DocumentedVerifierTest.php` | The verifier documented above, run exactly as written |
+| `tests/Structure/CoseStructureTest.php` | The structures against the RFC 9052 Appendix C vectors |
+| `tests/Structure/CoseHeadersTest.php` | The header rules, on all six message types |
+| `tests/Structure/CoseSignatureTest.php` | Per-signer views of a `COSE_Sign` |
+| `tests/Structure/CoseRecipientTest.php` | Per-recipient views, nested recipients and detached ciphertext |
+| `tests/Signature/CoseSign1CreateAndVerifyTest.php` | EU digital COVID certificate verification |
+| `tests/Structure/DeprecatedTagClassesTest.php` | The deprecation and the upstream replacements |
 
 ## References
 

--- a/examples/01-sign1.php
+++ b/examples/01-sign1.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * COSE_Sign1 (RFC 9052 section 4.2): one signer, the shape WebAuthn and CWT use most.
+ *
+ * The point to take away: the signature covers the Sig_structure, never the payload on its own. That structure binds
+ * the protected header and the message type, which is what stops a signature from being lifted onto another message.
+ */
+
+use CBOR\ByteStringObject;
+use CBOR\Decoder;
+use CBOR\ListObject;
+use CBOR\MapItem;
+use CBOR\MapObject;
+use CBOR\NegativeIntegerObject;
+use CBOR\OtherObject\NullObject;
+use CBOR\StringStream;
+use CBOR\Tag\CoseSign1Tag;
+use CBOR\UnsignedIntegerObject;
+use Cose\Algorithm\Signature\ECDSA\ES256;
+use Cose\Signature\Signature1;
+use Cose\Structure\CoseHeaders;
+use Cose\Structure\HeaderMapHelper;
+
+require_once __DIR__ . '/_bootstrap.php';
+
+example_title('COSE_Sign1: sign and verify');
+
+$privateKey = example_ec_key();
+$publicKey = $privateKey->toPublic();
+$algorithm = ES256::create();
+
+// --- signing ---------------------------------------------------------------
+
+// The protected bucket is authenticated; the unprotected one is not. "alg" belongs in the protected one
+// (RFC 9052 section 3.1), "kid" is only a hint and can sit outside.
+$protectedHeader = MapObject::create([
+    MapItem::create(UnsignedIntegerObject::create(1), NegativeIntegerObject::create(ES256::identifier())),
+]);
+$unprotectedHeader = MapObject::create([
+    MapItem::create(UnsignedIntegerObject::create(4), ByteStringObject::create('my-key-id')),
+]);
+$payload = ByteStringObject::create('Message to sign');
+
+// Encode the protected bucket once. The Sig_structure embeds these bytes verbatim, so the message has to carry the
+// very same ones -- re-encoding the map afterwards is how signatures silently stop verifying.
+$protectedHeaderAsBytes = HeaderMapHelper::encodeProtected($protectedHeader);
+
+$toBeSigned = Signature1::create($protectedHeaderAsBytes, $payload);
+$signature = ByteStringObject::create($algorithm->sign((string) $toBeSigned, $privateKey));
+
+$message = CoseSign1Tag::create(ListObject::create([
+    $protectedHeaderAsBytes,
+    $unprotectedHeader,
+    $payload,
+    $signature,
+]));
+
+$encoded = (string) $message;
+example_line('Sig_structure', bin2hex((string) $toBeSigned));
+example_line('COSE_Sign1', bin2hex($encoded));
+echo PHP_EOL;
+
+// --- verifying -------------------------------------------------------------
+
+// cbor-php 3.4.0 registers the six COSE tags in the default decoder, so tag 18 resolves without any setup.
+$decoded = Decoder::create()->decode(StringStream::create($encoded));
+example_assert($decoded instanceof CoseSign1Tag, 'decoded as a COSE_Sign1');
+
+$headers = CoseHeaders::fromMessage($decoded);
+
+// RFC 9052 section 3.1: the algorithm the protected header declares has to be the one you accept for that key. A
+// verifier that hard-codes its algorithm and ignores the header accepts a message announcing another one.
+$alg = $headers->getProtectedHeaderParameter(1);
+example_assert(
+    $alg !== null && (int) $alg->normalize() === ES256::identifier(),
+    'the protected header declares ES256'
+);
+example_line('kid', (string) $headers->getHeaderParameter(4)?->getValue());
+
+$decodedPayload = $decoded->getPayload();
+example_assert(! $decodedPayload instanceof NullObject, 'the payload is attached');
+
+$toBeVerified = Signature1::create($decoded->getProtectedHeader(), $decodedPayload);
+example_assert(
+    $algorithm->verify((string) $toBeVerified, $publicKey, $decoded->getSignature()->getValue()),
+    'the signature verifies'
+);
+
+// --- what tampering looks like ---------------------------------------------
+
+$tampered = (string) CoseSign1Tag::create(ListObject::create([
+    $decoded->getProtectedHeader(),
+    $decoded->getUnprotectedHeader(),
+    ByteStringObject::create('Another message'),
+    $decoded->getSignature(),
+]));
+$tamperedMessage = Decoder::create()->decode(StringStream::create($tampered));
+$toBeVerified = Signature1::create($tamperedMessage->getProtectedHeader(), $tamperedMessage->getPayload());
+example_assert(
+    ! $algorithm->verify((string) $toBeVerified, $publicKey, $tamperedMessage->getSignature()->getValue()),
+    'a swapped payload no longer verifies'
+);

--- a/examples/02-sign-multiple-signers.php
+++ b/examples/02-sign-multiple-signers.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * COSE_Sign (RFC 9052 section 4.1): several signers over one payload.
+ *
+ * The point to take away: a signer of a COSE_Sign commits to two protected buckets -- the message's and its own --
+ * through the "Signature" structure. Signing with "Signature1" instead would produce a signature that is also valid
+ * as a COSE_Sign1, which is not what a multi-signer message means.
+ */
+
+use CBOR\ByteStringObject;
+use CBOR\Decoder;
+use CBOR\ListObject;
+use CBOR\MapItem;
+use CBOR\MapObject;
+use CBOR\NegativeIntegerObject;
+use CBOR\StringStream;
+use CBOR\Tag\CoseSignTag;
+use CBOR\UnsignedIntegerObject;
+use Cose\Algorithm\Signature\ECDSA\ES256;
+use Cose\Signature\CoseSignature;
+use Cose\Signature\Signature;
+use Cose\Signature\Signature1;
+use Cose\Structure\HeaderMapHelper;
+
+require_once __DIR__ . '/_bootstrap.php';
+
+example_title('COSE_Sign: two signers over one payload');
+
+$algorithm = ES256::create();
+$signers = [
+    'signer-1' => example_ec_key(),
+    'signer-2' => example_ec_key(),
+];
+
+// The body protected bucket is empty here: each signer declares its own algorithm, so there is nothing the message
+// as a whole has to say. RFC 9052 section 3 asks senders to encode an empty map as h'', which encodeProtected() does.
+$bodyProtectedHeader = HeaderMapHelper::encodeProtected(MapObject::create());
+$payload = ByteStringObject::create('Document to be signed by several parties');
+example_line('body protected', "h'" . bin2hex($bodyProtectedHeader->getValue()) . "'");
+
+// --- signing ---------------------------------------------------------------
+
+$entries = [];
+foreach ($signers as $kid => $key) {
+    // Each signer's own protected bucket, carrying its algorithm.
+    $signProtectedHeader = HeaderMapHelper::encodeProtected(MapObject::create([
+        MapItem::create(UnsignedIntegerObject::create(1), NegativeIntegerObject::create(ES256::identifier())),
+    ]));
+
+    $toBeSigned = Signature::create($bodyProtectedHeader, $signProtectedHeader, $payload);
+    $signature = ByteStringObject::create($algorithm->sign((string) $toBeSigned, $key));
+
+    // COSE_Signature = [ protected, unprotected, signature ]
+    $entries[] = ListObject::create([
+        $signProtectedHeader,
+        MapObject::create([
+            MapItem::create(UnsignedIntegerObject::create(4), ByteStringObject::create($kid)),
+        ]),
+        $signature,
+    ]);
+}
+
+$message = CoseSignTag::create(ListObject::create([
+    $bodyProtectedHeader,
+    MapObject::create(),
+    $payload,
+    ListObject::create($entries),
+]));
+
+$encoded = (string) $message;
+example_line('COSE_Sign', bin2hex($encoded));
+echo PHP_EOL;
+
+// --- verifying -------------------------------------------------------------
+
+$decoded = Decoder::create()->decode(StringStream::create($encoded));
+example_assert($decoded instanceof CoseSignTag, 'decoded as a COSE_Sign');
+
+// getSignatures() hands back the raw list, which the CBOR layer only checked is a list. CoseSignature::all() applies
+// RFC 9052 section 4.1: at least one entry, each a [bstr, map, bstr].
+$entries = CoseSignature::all($decoded->getSignatures());
+example_assert(count($entries) === 2, 'the message carries two well-formed signatures');
+
+foreach ($entries as $entry) {
+    $kid = (string) $entry->getUnprotectedHeaderParameter(4)?->getValue();
+    $key = $signers[$kid]->toPublic();
+
+    $toBeVerified = Signature::create(
+        $decoded->getProtectedHeader(),   // body_protected
+        $entry->getProtectedHeader(),     // sign_protected
+        $decoded->getPayload()
+    );
+    example_assert(
+        $algorithm->verify((string) $toBeVerified, $key, $entry->getSignature()->getValue()),
+        sprintf('the signature of %s verifies', $kid)
+    );
+}
+
+// --- why the context string matters ----------------------------------------
+
+$first = $entries[0];
+$asSign1 = Signature1::create($first->getProtectedHeader(), $decoded->getPayload());
+example_assert(
+    ! $algorithm->verify(
+        (string) $asSign1,
+        $signers['signer-1']->toPublic(),
+        $first->getSignature()->getValue()
+    ),
+    'the same signature is not valid as a COSE_Sign1'
+);
+
+// --- what the CBOR layer would have let through ------------------------------
+
+try {
+    CoseSignature::all(ListObject::create([]));
+    example_assert(false, 'unreachable');
+} catch (InvalidArgumentException $exception) {
+    // RFC 9052 writes the list as "[+ COSE_Signature]": one or more. A "reject if any signature fails" loop over an
+    // empty list passes vacuously, which is the bug this turns into an exception.
+    example_line('empty list', $exception->getMessage());
+}

--- a/examples/03-mac0.php
+++ b/examples/03-mac0.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * COSE_Mac0 (RFC 9052 section 6.2): a MAC with no recipient structure.
+ *
+ * The point to take away: Mac::hash() authenticates exactly the bytes it is given. Handing it the payload produces a
+ * tag bound to no header, no algorithm and no message type -- and interoperable with nothing. The MAC_structure is
+ * what binds them, and its context string is the only difference between a COSE_Mac0 and a COSE_Mac tag.
+ */
+
+use CBOR\ByteStringObject;
+use CBOR\Decoder;
+use CBOR\ListObject;
+use CBOR\MapItem;
+use CBOR\MapObject;
+use CBOR\StringStream;
+use CBOR\Tag\CoseMac0Tag;
+use CBOR\UnsignedIntegerObject;
+use Cose\Algorithm\Mac\HS256;
+use Cose\Mac\Mac0Structure;
+use Cose\Mac\MacStructure;
+use Cose\Structure\CoseHeaders;
+use Cose\Structure\HeaderMapHelper;
+
+require_once __DIR__ . '/_bootstrap.php';
+
+example_title('COSE_Mac0: authenticate and verify');
+
+$key = example_symmetric_key();
+$algorithm = HS256::create();
+
+// --- authenticating ---------------------------------------------------------
+
+// HMAC 256/256 is algorithm 5 in the IANA COSE Algorithms registry.
+$protectedHeader = HeaderMapHelper::encodeProtected(MapObject::create([
+    MapItem::create(UnsignedIntegerObject::create(1), UnsignedIntegerObject::create(HS256::identifier())),
+]));
+$payload = ByteStringObject::create('Data to authenticate');
+
+$toBeMaced = Mac0Structure::create($protectedHeader, $payload);
+$tag = ByteStringObject::create($algorithm->hash((string) $toBeMaced, $key));
+
+$message = CoseMac0Tag::create(ListObject::create([
+    $protectedHeader,
+    MapObject::create(),
+    $payload,
+    $tag,
+]));
+
+$encoded = (string) $message;
+example_line('MAC_structure', bin2hex((string) $toBeMaced));
+example_line('COSE_Mac0', bin2hex($encoded));
+echo PHP_EOL;
+
+// --- verifying ---------------------------------------------------------------
+
+$decoded = Decoder::create()->decode(StringStream::create($encoded));
+example_assert($decoded instanceof CoseMac0Tag, 'decoded as a COSE_Mac0');
+
+$headers = CoseHeaders::fromMessage($decoded);
+$alg = $headers->getProtectedHeaderParameter(1);
+example_assert(
+    $alg !== null && (int) $alg->normalize() === HS256::identifier(),
+    'the protected header declares HMAC 256/256'
+);
+
+$toBeVerified = Mac0Structure::create($decoded->getProtectedHeader(), $decoded->getPayload());
+example_assert(
+    $algorithm->verify((string) $toBeVerified, $key, $decoded->getTag()->getValue()),
+    'the tag verifies over the MAC_structure'
+);
+
+// --- the two mistakes the structure prevents ---------------------------------
+
+example_assert(
+    ! $algorithm->verify($decoded->getPayload()->getValue(), $key, $decoded->getTag()->getValue()),
+    'the tag does not verify over the bare payload'
+);
+
+// The same header and payload under the "MAC" context -- a COSE_Mac -- give a different tag, so a tag cannot be
+// moved between the two message types.
+$asMac = MacStructure::create($decoded->getProtectedHeader(), $decoded->getPayload());
+example_assert(
+    ! $algorithm->verify((string) $asMac, $key, $decoded->getTag()->getValue()),
+    'the tag is not valid under the "MAC" context'
+);
+example_line('MAC0 context', substr(bin2hex((string) $toBeVerified), 0, 12));
+example_line('MAC context', substr(bin2hex((string) $asMac), 0, 12));

--- a/examples/04-encrypt0.php
+++ b/examples/04-encrypt0.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * COSE_Encrypt0 (RFC 9052 section 5.2): content encrypted for a single recipient.
+ *
+ * This library does not implement content encryption -- that is what your AEAD is for. What it gives you is the
+ * Enc_structure of RFC 9052 section 5.3, the additional authenticated data the AEAD has to cover so that the
+ * ciphertext is bound to the header it travels with. Here the AEAD is AES-128-GCM through OpenSSL.
+ *
+ * Note that Enc_structure carries no payload: the content is what the AEAD encrypts, and the structure is what it
+ * authenticates alongside it.
+ */
+
+use CBOR\ByteStringObject;
+use CBOR\Decoder;
+use CBOR\ListObject;
+use CBOR\MapItem;
+use CBOR\MapObject;
+use CBOR\StringStream;
+use CBOR\Tag\CoseEncrypt0Tag;
+use CBOR\UnsignedIntegerObject;
+use Cose\Encryption\Encrypt0Structure;
+use Cose\Structure\CoseHeaders;
+use Cose\Structure\HeaderMapHelper;
+
+require_once __DIR__ . '/_bootstrap.php';
+
+example_title('COSE_Encrypt0: encrypt and decrypt');
+
+$contentEncryptionKey = random_bytes(16);
+$iv = random_bytes(12);
+$plaintext = 'Secret content';
+
+// --- encrypting -------------------------------------------------------------
+
+// A128GCM is algorithm 1 in the IANA COSE Algorithms registry. The IV (label 5) is not secret and rides in the
+// unprotected bucket, as RFC 9053 section 4.1 allows.
+$protectedHeader = HeaderMapHelper::encodeProtected(MapObject::create([
+    MapItem::create(UnsignedIntegerObject::create(1), UnsignedIntegerObject::create(1)),
+]));
+$unprotectedHeader = MapObject::create([
+    MapItem::create(UnsignedIntegerObject::create(5), ByteStringObject::create($iv)),
+]);
+
+// The additional authenticated data: ["Encrypt0", protected, external_aad]
+$aad = (string) Encrypt0Structure::create($protectedHeader);
+example_line('Enc_structure', bin2hex($aad));
+
+$ciphertext = openssl_encrypt(
+    $plaintext,
+    'aes-128-gcm',
+    $contentEncryptionKey,
+    OPENSSL_RAW_DATA,
+    $iv,
+    $authTag,
+    $aad,
+    16
+);
+example_assert($ciphertext !== false, 'the content was encrypted');
+
+// RFC 9053 section 4.1: the authentication tag is appended to the ciphertext.
+$message = CoseEncrypt0Tag::create(ListObject::create([
+    $protectedHeader,
+    $unprotectedHeader,
+    ByteStringObject::create($ciphertext . $authTag),
+]));
+
+$encoded = (string) $message;
+example_line('COSE_Encrypt0', bin2hex($encoded));
+echo PHP_EOL;
+
+// --- decrypting -------------------------------------------------------------
+
+$decoded = Decoder::create()->decode(StringStream::create($encoded));
+example_assert($decoded instanceof CoseEncrypt0Tag, 'decoded as a COSE_Encrypt0');
+
+$headers = CoseHeaders::fromMessage($decoded);
+$alg = $headers->getProtectedHeaderParameter(1);
+example_assert($alg !== null && (int) $alg->normalize() === 1, 'the protected header declares A128GCM');
+
+$decodedIv = $headers->getUnprotectedHeaderParameter(5)?->getValue();
+example_assert($decodedIv !== null, 'the IV is present');
+
+// The AAD is rebuilt from the bytes the message carries, not from a re-encoded map.
+$aad = (string) Encrypt0Structure::create($decoded->getProtectedHeader());
+
+$carried = $decoded->getCiphertext()->getValue();
+$recovered = openssl_decrypt(
+    substr($carried, 0, -16),
+    'aes-128-gcm',
+    $contentEncryptionKey,
+    OPENSSL_RAW_DATA,
+    (string) $decodedIv,
+    substr($carried, -16),
+    $aad
+);
+example_assert($recovered === $plaintext, 'the content was recovered');
+
+// --- what the AAD buys you ----------------------------------------------------
+
+// Flip the declared algorithm in the AAD and the AEAD refuses: the ciphertext is bound to the header it shipped with.
+$tamperedAad = (string) Encrypt0Structure::create(
+    HeaderMapHelper::encodeProtected(MapObject::create([
+        MapItem::create(UnsignedIntegerObject::create(1), UnsignedIntegerObject::create(3)),
+    ]))
+);
+$shouldFail = openssl_decrypt(
+    substr($carried, 0, -16),
+    'aes-128-gcm',
+    $contentEncryptionKey,
+    OPENSSL_RAW_DATA,
+    (string) $decodedIv,
+    substr($carried, -16),
+    $tamperedAad
+);
+example_assert($shouldFail === false, 'a rewritten protected header breaks decryption');

--- a/examples/05-encrypt-recipients.php
+++ b/examples/05-encrypt-recipients.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * COSE_Encrypt (RFC 9052 section 5.1): one ciphertext, several recipients.
+ *
+ * Each recipient carries the content encryption key wrapped for itself, and may carry recipients of its own -- which
+ * is how RFC 9052 expresses key layering. CoseRecipient is the checked view over that list: the CBOR layer only
+ * verifies the item is a list, so an empty list or a list of integers decodes without complaint.
+ */
+
+use CBOR\ByteStringObject;
+use CBOR\Decoder;
+use CBOR\ListObject;
+use CBOR\MapItem;
+use CBOR\MapObject;
+use CBOR\NegativeIntegerObject;
+use CBOR\OtherObject\NullObject;
+use CBOR\StringStream;
+use CBOR\Tag\CoseEncryptTag;
+use CBOR\UnsignedIntegerObject;
+use Cose\Encryption\EncryptStructure;
+use Cose\Encryption\RecipientStructure;
+use Cose\Structure\CoseRecipient;
+use Cose\Structure\HeaderMapHelper;
+
+require_once __DIR__ . '/_bootstrap.php';
+
+example_title('COSE_Encrypt: several recipients');
+
+$contentEncryptionKey = random_bytes(16);
+$iv = random_bytes(12);
+$plaintext = 'Secret shared with two parties';
+
+// Each recipient has a key-encryption key it already shares with the sender.
+$keyEncryptionKeys = [
+    'alice' => random_bytes(16),
+    'bob' => random_bytes(16),
+];
+
+// --- encrypting the content ---------------------------------------------------
+
+$protectedHeader = HeaderMapHelper::encodeProtected(MapObject::create([
+    MapItem::create(UnsignedIntegerObject::create(1), UnsignedIntegerObject::create(1)), // A128GCM
+]));
+$aad = (string) EncryptStructure::create($protectedHeader);
+$ciphertext = openssl_encrypt(
+    $plaintext,
+    'aes-128-gcm',
+    $contentEncryptionKey,
+    OPENSSL_RAW_DATA,
+    $iv,
+    $authTag,
+    $aad,
+    16
+);
+example_assert($ciphertext !== false, 'the content was encrypted');
+example_line('Enc_structure', bin2hex($aad));
+
+// --- wrapping the key for each recipient ---------------------------------------
+
+$recipients = [];
+foreach ($keyEncryptionKeys as $kid => $kek) {
+    // A128KW is algorithm -3. Its Enc_structure uses the "Enc_Recipient" context, which is what stops a wrapped key
+    // from being replayed at another level of the same message.
+    $recipientProtectedHeader = HeaderMapHelper::encodeProtected(MapObject::create([
+        MapItem::create(UnsignedIntegerObject::create(1), NegativeIntegerObject::create(-3)),
+    ]));
+    $recipientAad = (string) RecipientStructure::forEncryptRecipient($recipientProtectedHeader);
+
+    $wrapIv = random_bytes(12);
+    $wrapped = openssl_encrypt(
+        $contentEncryptionKey,
+        'aes-128-gcm',
+        $kek,
+        OPENSSL_RAW_DATA,
+        $wrapIv,
+        $wrapTag,
+        $recipientAad,
+        16
+    );
+
+    // COSE_recipient = [ protected, unprotected, ciphertext / nil, ? recipients ]
+    $recipients[] = ListObject::create([
+        $recipientProtectedHeader,
+        MapObject::create([
+            MapItem::create(UnsignedIntegerObject::create(4), ByteStringObject::create($kid)),
+            MapItem::create(UnsignedIntegerObject::create(5), ByteStringObject::create($wrapIv)),
+        ]),
+        ByteStringObject::create($wrapped . $wrapTag),
+    ]);
+}
+
+$message = CoseEncryptTag::create(ListObject::create([
+    $protectedHeader,
+    MapObject::create([
+        MapItem::create(UnsignedIntegerObject::create(5), ByteStringObject::create($iv)),
+    ]),
+    ByteStringObject::create($ciphertext . $authTag),
+    ListObject::create($recipients),
+]));
+
+$encoded = (string) $message;
+example_line('COSE_Encrypt', substr(bin2hex($encoded), 0, 96) . '...');
+echo PHP_EOL;
+
+// --- a recipient opens the message ---------------------------------------------
+
+$decoded = Decoder::create()->decode(StringStream::create($encoded));
+example_assert($decoded instanceof CoseEncryptTag, 'decoded as a COSE_Encrypt');
+
+$entries = CoseRecipient::all($decoded->getRecipients());
+example_assert(count($entries) === 2, 'the message carries two well-formed recipients');
+
+foreach ($entries as $entry) {
+    $kid = (string) $entry->getUnprotectedHeaderParameter(4)?->getValue();
+    $kek = $keyEncryptionKeys[$kid];
+
+    example_assert(! $entry->hasDetachedCiphertext(), sprintf('%s carries a wrapped key', $kid));
+    $wrapped = $entry->getCiphertext()->getValue();
+    $wrapIv = (string) $entry->getUnprotectedHeaderParameter(5)?->getValue();
+    $recipientAad = (string) RecipientStructure::forEncryptRecipient($entry->getProtectedHeader());
+
+    $cek = openssl_decrypt(
+        substr($wrapped, 0, -16),
+        'aes-128-gcm',
+        $kek,
+        OPENSSL_RAW_DATA,
+        $wrapIv,
+        substr($wrapped, -16),
+        $recipientAad
+    );
+    example_assert($cek === $contentEncryptionKey, sprintf('%s unwrapped the content key', $kid));
+
+    // With the content key in hand, the content itself
+    $carried = $decoded->getCiphertext()->getValue();
+    $recovered = openssl_decrypt(
+        substr($carried, 0, -16),
+        'aes-128-gcm',
+        (string) $cek,
+        OPENSSL_RAW_DATA,
+        (string) HeaderMapHelper::findLabel($decoded->getUnprotectedHeader(), 5)?->getValue(),
+        substr($carried, -16),
+        (string) EncryptStructure::create($decoded->getProtectedHeader())
+    );
+    example_assert($recovered === $plaintext, sprintf('%s read the content', $kid));
+}
+
+// --- nested recipients and detached ciphertext ---------------------------------
+
+// The CDDL allows a fourth item -- recipients of the recipient -- and a nil ciphertext.
+$layered = CoseRecipient::create(ListObject::create([
+    ByteStringObject::create(''),
+    MapObject::create([MapItem::create(UnsignedIntegerObject::create(4), ByteStringObject::create('outer'))]),
+    NullObject::create(),
+    ListObject::create([
+        ListObject::create([
+            ByteStringObject::create(''),
+            MapObject::create([MapItem::create(UnsignedIntegerObject::create(4), ByteStringObject::create('inner'))]),
+            ByteStringObject::create('wrapped'),
+        ]),
+    ]),
+]));
+example_assert($layered->hasDetachedCiphertext(), 'the outer recipient has a detached ciphertext');
+example_assert(count($layered->getRecipients()) === 1, 'it carries one nested recipient');
+example_line(
+    'nested kid',
+    (string) $layered->getRecipients()[0]->getUnprotectedHeaderParameter(4)?->getValue()
+);

--- a/examples/06-headers.php
+++ b/examples/06-headers.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Reading headers the way RFC 9052 defines them.
+ *
+ * cbor-php carries the two buckets; it does not decide what they mean. CoseHeaders does, and each rule below exists
+ * because the raw MapObject accessors answer differently -- in a way a conformant peer would not.
+ */
+
+use CBOR\ByteStringObject;
+use CBOR\ListObject;
+use CBOR\MapItem;
+use CBOR\MapObject;
+use CBOR\NegativeIntegerObject;
+use CBOR\Tag\CoseSign1Tag;
+use CBOR\TextStringObject;
+use CBOR\UnsignedIntegerObject;
+use Cose\Structure\CoseHeaders;
+use Cose\Structure\HeaderMapHelper;
+
+require_once __DIR__ . '/_bootstrap.php';
+
+example_title('Header rules');
+
+/**
+ * A COSE_Sign1 around the given protected bucket, so each rule is shown on a real message.
+ */
+$messageWith = static fn (string $protectedHeaderBytes, ?MapObject $unprotected = null): CoseSign1Tag
+    => CoseSign1Tag::create(ListObject::create([
+        ByteStringObject::create($protectedHeaderBytes),
+        $unprotected ?? MapObject::create(),
+        ByteStringObject::create('content'),
+        ByteStringObject::create('signature'),
+    ]));
+
+// --- 1. a label is an int OR a tstr, and the two are different -----------------
+
+// {"1": -7} -- a text-string label, not the algorithm parameter.
+$textLabel = MapObject::create([
+    MapItem::create(TextStringObject::create('1'), NegativeIntegerObject::create(-7)),
+]);
+$headers = CoseHeaders::fromMessage($messageWith((string) $textLabel));
+
+// cbor-php keys its map by the normalized key, and PHP turns the offset "1" into 1, so both land on one slot:
+example_assert($headers->getProtectedHeaderAsMap()->has(1), 'the raw map answers has(1) for a text-string key');
+example_assert($headers->getProtectedHeaderParameter(1) === null, 'but the integer label 1 is absent');
+example_assert(
+    $headers->getProtectedHeaderParameter('1')?->normalize() === '-7',
+    'and the text-string label "1" is what carries the value'
+);
+echo PHP_EOL;
+
+// --- 2. a byte-string key is not a label at all --------------------------------
+
+// {h'31': -7} normalizes to the string "1" as well, so without a type check it would answer for "alg".
+$byteLabel = MapObject::create([
+    MapItem::create(ByteStringObject::create('1'), NegativeIntegerObject::create(-7)),
+]);
+try {
+    CoseHeaders::fromMessage($messageWith((string) $byteLabel))->getProtectedHeaderAsMap();
+    example_assert(false, 'unreachable');
+} catch (InvalidArgumentException $exception) {
+    example_line('byte-string key', $exception->getMessage());
+}
+echo PHP_EOL;
+
+// --- 3. the empty protected bucket, both spellings -----------------------------
+
+// RFC 9052 section 3: "Recipients MUST accept both a zero-length byte string and a zero-length map encoded in a byte
+// string." The first is the form senders are told to prefer.
+foreach (['' => "h''", "\xa0" => "h'a0'"] as $bytes => $description) {
+    $headers = CoseHeaders::fromMessage($messageWith($bytes));
+    example_assert(count($headers->getProtectedHeaderAsMap()) === 0, $description . ' is an empty header');
+}
+example_line('encodeProtected([])', "h'" . bin2hex(HeaderMapHelper::encodeProtected(MapObject::create())->getValue()) . "'");
+echo PHP_EOL;
+
+// --- 4. the protected bucket holds exactly one CBOR item -----------------------
+
+// The CDDL is "bstr .cbor header_map". Trailing bytes make the bucket malformed, and a decoder that ignores them
+// disagrees with a strict one about what the message says.
+try {
+    CoseHeaders::fromMessage($messageWith("\xa1\x01\x26\xff\xff"))->getProtectedHeaderAsMap();
+    example_assert(false, 'unreachable');
+} catch (InvalidArgumentException $exception) {
+    example_line('trailing bytes', $exception->getMessage());
+}
+echo PHP_EOL;
+
+// --- 5. the protected bucket wins a combined lookup ----------------------------
+
+// A message carrying a label in both buckets is malformed anyway; preferring the protected value keeps the answer on
+// the side the signature covers.
+$protectedHeader = MapObject::create([
+    MapItem::create(UnsignedIntegerObject::create(1), NegativeIntegerObject::create(-7)),
+]);
+$unprotectedHeader = MapObject::create([
+    MapItem::create(UnsignedIntegerObject::create(1), NegativeIntegerObject::create(-35)),
+    MapItem::create(UnsignedIntegerObject::create(4), ByteStringObject::create('key-1')),
+]);
+$headers = CoseHeaders::fromMessage($messageWith((string) $protectedHeader, $unprotectedHeader));
+
+example_assert($headers->getHeaderParameter(1)?->normalize() === '-7', 'getHeaderParameter reads the protected -7');
+example_assert(
+    $headers->getUnprotectedHeaderParameter(1)?->normalize() === '-35',
+    'the unprotected -35 is still reachable explicitly'
+);
+example_assert($headers->getHeaderParameter(4)?->getValue() === 'key-1', 'kid falls through to the unprotected bucket');
+example_assert($headers->getHeaderParameter(42) === null, 'an absent label is null, not an exception');
+echo PHP_EOL;
+
+// --- 6. duplicate labels ---------------------------------------------------------
+
+// RFC 9052 section 9: "Applications MUST NOT generate messages with the same label used twice as a key in a single
+// map." Building one is refused before it can be sent.
+try {
+    HeaderMapHelper::encodeProtected(MapObject::create([
+        MapItem::create(UnsignedIntegerObject::create(1), NegativeIntegerObject::create(-7)),
+        MapItem::create(UnsignedIntegerObject::create(1), NegativeIntegerObject::create(-35)),
+    ]));
+    example_assert(false, 'unreachable');
+} catch (InvalidArgumentException $exception) {
+    example_line('duplicate label', $exception->getMessage());
+}

--- a/examples/07-detached-and-external-aad.php
+++ b/examples/07-detached-and-external-aad.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Detached content (RFC 9052 section 4.1) and external_aad (section 4.4).
+ *
+ * Two things an application supplies from outside the message: the payload, when it travels separately, and any
+ * context the signature should cover without being carried on the wire.
+ */
+
+use CBOR\ByteStringObject;
+use CBOR\Decoder;
+use CBOR\ListObject;
+use CBOR\MapItem;
+use CBOR\MapObject;
+use CBOR\NegativeIntegerObject;
+use CBOR\OtherObject\NullObject;
+use CBOR\StringStream;
+use CBOR\Tag\CoseSign1Tag;
+use CBOR\UnsignedIntegerObject;
+use Cose\Algorithm\Signature\ECDSA\ES256;
+use Cose\Signature\Signature1;
+use Cose\Structure\HeaderMapHelper;
+
+require_once __DIR__ . '/_bootstrap.php';
+
+example_title('Detached content and external_aad');
+
+$privateKey = example_ec_key();
+$publicKey = $privateKey->toPublic();
+$algorithm = ES256::create();
+
+$protectedHeader = HeaderMapHelper::encodeProtected(MapObject::create([
+    MapItem::create(UnsignedIntegerObject::create(1), NegativeIntegerObject::create(ES256::identifier())),
+]));
+
+// --- detached content ---------------------------------------------------------
+
+// The content travels out of band -- a large file, a body already on disk -- and a nil sits in its place.
+$content = ByteStringObject::create('A payload carried outside the message');
+
+$toBeSigned = Signature1::create($protectedHeader, $content);
+$signature = ByteStringObject::create($algorithm->sign((string) $toBeSigned, $privateKey));
+
+$detached = CoseSign1Tag::create(ListObject::create([
+    $protectedHeader,
+    MapObject::create(),
+    NullObject::create(),
+    $signature,
+]));
+
+$encoded = (string) $detached;
+example_line('COSE_Sign1', bin2hex($encoded));
+example_line('size', sprintf('%d bytes, payload not included', strlen($encoded)));
+
+$decoded = Decoder::create()->decode(StringStream::create($encoded));
+example_assert($decoded instanceof CoseSign1Tag, 'decoded as a COSE_Sign1');
+example_assert($decoded->getPayload() instanceof NullObject, 'the payload is detached');
+
+// The application puts the content back before verifying. Everything else is unchanged.
+$toBeVerified = Signature1::create($decoded->getProtectedHeader(), $content);
+example_assert(
+    $algorithm->verify((string) $toBeVerified, $publicKey, $decoded->getSignature()->getValue()),
+    'the signature verifies once the content is supplied'
+);
+
+// Supplying the wrong content fails, which is the whole point of signing it.
+$wrong = Signature1::create($decoded->getProtectedHeader(), ByteStringObject::create('Something else'));
+example_assert(
+    ! $algorithm->verify((string) $wrong, $publicKey, $decoded->getSignature()->getValue()),
+    'the wrong content does not verify'
+);
+echo PHP_EOL;
+
+// --- external_aad --------------------------------------------------------------
+
+// Context the two parties already share -- a session identifier, a transaction id -- that the signature should cover
+// without being transmitted. RFC 9052 section 4.4: absent, it defaults to a zero-length byte string.
+$sessionContext = ByteStringObject::create('session-42');
+$payload = ByteStringObject::create('Bound to a session');
+
+$toBeSigned = Signature1::create($protectedHeader, $payload, $sessionContext);
+$signature = ByteStringObject::create($algorithm->sign((string) $toBeSigned, $privateKey));
+
+example_line('with external_aad', bin2hex((string) $toBeSigned));
+example_line('without', bin2hex((string) Signature1::create($protectedHeader, $payload)));
+
+$message = CoseSign1Tag::create(ListObject::create([
+    $protectedHeader,
+    MapObject::create(),
+    $payload,
+    $signature,
+]));
+$decoded = Decoder::create()->decode(StringStream::create((string) $message));
+
+// A verifier that knows the context accepts it...
+$toBeVerified = Signature1::create($decoded->getProtectedHeader(), $decoded->getPayload(), $sessionContext);
+example_assert(
+    $algorithm->verify((string) $toBeVerified, $publicKey, $decoded->getSignature()->getValue()),
+    'the signature verifies with the right external_aad'
+);
+
+// ...and one that does not, or that has the wrong context, does not. The message on the wire is identical.
+$toBeVerified = Signature1::create($decoded->getProtectedHeader(), $decoded->getPayload());
+example_assert(
+    ! $algorithm->verify((string) $toBeVerified, $publicKey, $decoded->getSignature()->getValue()),
+    'and not without it'
+);
+$toBeVerified = Signature1::create(
+    $decoded->getProtectedHeader(),
+    $decoded->getPayload(),
+    ByteStringObject::create('session-43')
+);
+example_assert(
+    ! $algorithm->verify((string) $toBeVerified, $publicKey, $decoded->getSignature()->getValue()),
+    'nor with a different one'
+);

--- a/examples/08-cwt.php
+++ b/examples/08-cwt.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * CBOR Web Token (RFC 8392): a claims set carried as the payload of a COSE message.
+ *
+ * A CWT is not a separate format -- it is what a COSE_Sign1 most often contains. cbor-php 3.4.0 also ships CwtTag for
+ * the optional tag 61 that marks the whole thing as a CWT.
+ *
+ * The point to take away: verify, then read. A claims map decoded from an unverified payload is attacker-controlled
+ * input, and an "exp" read from it means nothing.
+ */
+
+use CBOR\ByteStringObject;
+use CBOR\Decoder;
+use CBOR\ListObject;
+use CBOR\MapItem;
+use CBOR\MapObject;
+use CBOR\NegativeIntegerObject;
+use CBOR\StringStream;
+use CBOR\Tag\CoseSign1Tag;
+use CBOR\Tag\CwtTag;
+use CBOR\TextStringObject;
+use CBOR\UnsignedIntegerObject;
+use Cose\Algorithm\Signature\ECDSA\ES256;
+use Cose\Signature\Signature1;
+use Cose\Structure\CoseHeaders;
+use Cose\Structure\HeaderMapHelper;
+
+require_once __DIR__ . '/_bootstrap.php';
+
+example_title('CWT: a signed claims set');
+
+$privateKey = example_ec_key();
+$publicKey = $privateKey->toPublic();
+$algorithm = ES256::create();
+
+$issuedAt = 1443944944;
+$expiresAt = $issuedAt + 3600;
+
+// --- issuing ------------------------------------------------------------------
+
+// RFC 8392 section 3.1: 1 = iss, 2 = sub, 3 = aud, 4 = exp, 5 = nbf, 6 = iat, 7 = cti
+$claims = MapObject::create([
+    MapItem::create(UnsignedIntegerObject::create(1), TextStringObject::create('coap://as.example.com')),
+    MapItem::create(UnsignedIntegerObject::create(2), TextStringObject::create('erikw')),
+    MapItem::create(UnsignedIntegerObject::create(4), UnsignedIntegerObject::create($expiresAt)),
+    MapItem::create(UnsignedIntegerObject::create(6), UnsignedIntegerObject::create($issuedAt)),
+]);
+
+$protectedHeader = HeaderMapHelper::encodeProtected(MapObject::create([
+    MapItem::create(UnsignedIntegerObject::create(1), NegativeIntegerObject::create(ES256::identifier())),
+]));
+
+// The claims set is the payload: opaque bytes as far as COSE is concerned.
+$payload = ByteStringObject::create((string) $claims);
+
+$toBeSigned = Signature1::create($protectedHeader, $payload);
+$signature = ByteStringObject::create($algorithm->sign((string) $toBeSigned, $privateKey));
+
+$message = CoseSign1Tag::create(ListObject::create([
+    $protectedHeader,
+    MapObject::create([
+        MapItem::create(UnsignedIntegerObject::create(4), ByteStringObject::create('AsymmetricECDSA256')),
+    ]),
+    $payload,
+    $signature,
+]));
+
+// Tag 61 is optional; it says "what follows is a CWT".
+$encoded = (string) CwtTag::create($message);
+example_line('CWT', bin2hex($encoded));
+example_assert(str_starts_with(bin2hex($encoded), 'd83d'), 'the outer head is tag 61');
+echo PHP_EOL;
+
+// --- consuming -----------------------------------------------------------------
+
+$decoded = Decoder::create()->decode(StringStream::create($encoded));
+
+// Accept both the tagged and the untagged form.
+$token = $decoded instanceof CwtTag ? $decoded->getValue() : $decoded;
+example_assert($token instanceof CoseSign1Tag, 'the token is a COSE_Sign1');
+
+// 1. Bind the algorithm before anything else.
+$headers = CoseHeaders::fromMessage($token);
+$alg = $headers->getProtectedHeaderParameter(1);
+example_assert(
+    $alg !== null && (int) $alg->normalize() === ES256::identifier(),
+    'the protected header declares the expected algorithm'
+);
+example_line('kid', (string) $headers->getHeaderParameter(4)?->getValue());
+
+// 2. Verify.
+$toBeVerified = Signature1::create($token->getProtectedHeader(), $token->getPayload());
+example_assert(
+    $algorithm->verify((string) $toBeVerified, $publicKey, $token->getSignature()->getValue()),
+    'the signature verifies'
+);
+
+// 3. Only now, read the claims.
+$decodedClaims = Decoder::create()
+    ->decode(StringStream::create($token->getPayload()->getValue()))
+    ->normalize();
+
+example_line('iss', (string) $decodedClaims[1]);
+example_line('sub', (string) $decodedClaims[2]);
+
+// cbor-php normalizes CBOR integers to numeric strings, so cast before comparing timestamps.
+example_assert(is_string($decodedClaims[4]), 'the timestamps come back as numeric strings');
+$expiry = (int) $decodedClaims[4];
+example_line('exp', sprintf('%d (%s)', $expiry, gmdate('Y-m-d H:i:s\Z', $expiry)));
+example_assert($expiry === $expiresAt, 'the expiry round-trips once cast');

--- a/examples/09-migration.php
+++ b/examples/09-migration.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Migrating off the deprecated Cose\...Tag classes (issue #176).
+ *
+ * The six COSE message classes moved to spomky-labs/cbor-php 3.4.0. The ones this library shipped are deprecated
+ * since 4.8.0 and removed in 5.0.0. The wire format is identical, so the two sides interoperate and an application
+ * can migrate one at a time.
+ *
+ * Run with `php -d error_reporting=E_ALL examples/09-migration.php` to see the deprecation notices.
+ */
+
+use CBOR\ByteStringObject;
+use CBOR\Decoder;
+use CBOR\ListObject;
+use CBOR\MapItem;
+use CBOR\MapObject;
+use CBOR\NegativeIntegerObject;
+use CBOR\StringStream;
+use CBOR\Tag\CoseSign1Tag;
+use CBOR\UnsignedIntegerObject;
+use Cose\Signature\CoseSign1Tag as DeprecatedCoseSign1Tag;
+use Cose\Structure\CoseHeaders;
+use Cose\Structure\HeaderMapHelper;
+
+require_once __DIR__ . '/_bootstrap.php';
+
+example_title('Migrating to the cbor-php COSE classes');
+
+$protectedHeader = MapObject::create([
+    MapItem::create(UnsignedIntegerObject::create(1), NegativeIntegerObject::create(-7)),
+]);
+$unprotectedHeader = MapObject::create([
+    MapItem::create(UnsignedIntegerObject::create(4), ByteStringObject::create('my-key-id')),
+]);
+$payload = ByteStringObject::create('Message');
+$signature = ByteStringObject::create('signature');
+
+// --- before --------------------------------------------------------------------
+
+// The deprecated four-argument factory. The notice is silenced here only so the example reads cleanly.
+$before = @DeprecatedCoseSign1Tag::create($protectedHeader, $unprotectedHeader, $payload, $signature);
+example_line('before', bin2hex((string) $before));
+
+// --- after ---------------------------------------------------------------------
+
+// create() upstream takes the whole list, so the four-argument form is createFromComponents(). This is the one point
+// where renaming the class is not enough -- a leftover create($a, $b, $c, $d) raises an ArgumentCountError rather
+// than misbehaving quietly.
+$after = CoseSign1Tag::createFromComponents($protectedHeader, $unprotectedHeader, $payload, $signature);
+example_line('after', bin2hex((string) $after));
+
+example_assert((string) $before === (string) $after, 'both produce the same bytes');
+echo PHP_EOL;
+
+// --- the two sides interoperate --------------------------------------------------
+
+// A message written by the deprecated class decodes as the replacement. Since cbor-php 3.4.0 the COSE tags are in
+// the default decoder, so TagManager::create()->add(...) is no longer needed either.
+$decoded = Decoder::create()->decode(StringStream::create((string) $before));
+example_assert($decoded instanceof CoseSign1Tag, 'the old bytes decode as the new class');
+example_assert((string) $decoded === (string) $before, 're-encoding is byte-identical');
+echo PHP_EOL;
+
+// --- what changed in the accessors -------------------------------------------------
+
+// getPayload() can now return NullObject: detached content is representable, where the deprecated class rejected it.
+example_line('getPayload()', $decoded->getPayload()::class);
+
+// The header accessors move to CoseHeaders. getProtectedHeaderAsMap() exists upstream but applies only the CBOR
+// rules; the RFC 9052 ones -- label typing, trailing data, the protected-first lookup -- live here.
+$headers = CoseHeaders::fromMessage($decoded);
+example_line('alg', (string) $headers->getProtectedHeaderParameter(1)?->normalize());
+example_line('kid', (string) $headers->getHeaderParameter(4)?->getValue());
+echo PHP_EOL;
+
+// --- one behaviour worth knowing ----------------------------------------------------
+
+// createFromComponents() encodes an empty protected map as h'a0'. RFC 9052 section 3 asks senders to prefer h'',
+// which encodeProtected() emits -- pass the bytes to create() when that matters.
+$viaComponents = CoseSign1Tag::createFromComponents(
+    MapObject::create(),
+    MapObject::create(),
+    $payload,
+    $signature
+);
+example_line('empty, components', "h'" . bin2hex($viaComponents->getProtectedHeader()->getValue()) . "'");
+
+$viaBytes = CoseSign1Tag::create(ListObject::create([
+    HeaderMapHelper::encodeProtected(MapObject::create()),
+    MapObject::create(),
+    $payload,
+    $signature,
+]));
+example_line('empty, encodeProtected', "h'" . bin2hex($viaBytes->getProtectedHeader()->getValue()) . "'");

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,39 @@
+# Examples
+
+Runnable programs, one per topic. Each prints what it does and fails loudly if a check does not hold, so a broken
+example is a broken build rather than a puzzle for the reader.
+
+```bash
+composer install
+php examples/01-sign1.php
+```
+
+`tests/ExamplesTest.php` runs every one of them on each build.
+
+| File | Topic |
+|---|---|
+| [`01-sign1.php`](01-sign1.php) | COSE_Sign1: sign, encode, decode, verify — and what a swapped payload does |
+| [`02-sign-multiple-signers.php`](02-sign-multiple-signers.php) | COSE_Sign: several signers, and why `Signature` carries `sign_protected` |
+| [`03-mac0.php`](03-mac0.php) | COSE_Mac0: the tag covers the MAC_structure, never the bare payload |
+| [`04-encrypt0.php`](04-encrypt0.php) | COSE_Encrypt0: `Enc_structure` as the AEAD's additional authenticated data |
+| [`05-encrypt-recipients.php`](05-encrypt-recipients.php) | COSE_Encrypt: key wrapping per recipient, nested recipients, detached ciphertext |
+| [`06-headers.php`](06-headers.php) | The RFC 9052 header rules, each shown against what the raw CBOR map answers |
+| [`07-detached-and-external-aad.php`](07-detached-and-external-aad.php) | Detached content, and binding context that never travels |
+| [`08-cwt.php`](08-cwt.php) | CBOR Web Tokens: verify first, then read the claims |
+| [`09-migration.php`](09-migration.php) | Moving off the deprecated `Cose\...Tag` classes |
+
+## What the library does and does not do
+
+The COSE **message types** come from [spomky-labs/cbor-php](https://github.com/Spomky-Labs/cbor-php) 3.4.0 —
+`CBOR\Tag\CoseSign1Tag` and its siblings, registered in the default decoder. This library owns what RFC 9052 reads
+into them: the header rules, the checked views over the signature and recipient lists, and the cryptographic
+structures a signature or a MAC is actually computed over.
+
+**Content encryption is not implemented.** Examples 04 and 05 use AES-GCM through OpenSSL and take the
+`Enc_structure` from here as the additional authenticated data, which is the intended split.
+
+## A note on the keys
+
+`_bootstrap.php` generates a fresh key on every run, so the byte strings printed differ each time. It also pads the
+EC coordinates back to a fixed 32 bytes: OpenSSL strips leading zeros and COSE requires them, a mismatch that
+otherwise shows up roughly one run in 256.

--- a/examples/_bootstrap.php
+++ b/examples/_bootstrap.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Shared plumbing for the examples: the autoloader, key generation and a little output formatting.
+ *
+ * Nothing here is part of the library's API. It exists so that each example can open on the COSE code it is about
+ * rather than on twenty lines of setup.
+ */
+
+use Cose\Key\Ec2Key;
+use Cose\Key\SymmetricKey;
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+/**
+ * A freshly generated P-256 key pair, private part included.
+ *
+ * OpenSSL strips the leading zero bytes of the coordinates; COSE requires them to be a fixed size, so they are
+ * padded back. Getting this wrong produces a key that fails roughly one time in 256.
+ */
+function example_ec_key(): Ec2Key
+{
+    $key = openssl_pkey_new([
+        'private_key_type' => OPENSSL_KEYTYPE_EC,
+        'curve_name' => 'prime256v1',
+    ]);
+    if ($key === false) {
+        throw new RuntimeException('Unable to generate an EC key: ' . openssl_error_string());
+    }
+    $details = openssl_pkey_get_details($key)['ec'];
+    $pad = static fn (string $value): string => str_pad($value, 32, "\x00", STR_PAD_LEFT);
+
+    return Ec2Key::create([
+        Ec2Key::TYPE => Ec2Key::TYPE_EC2,
+        Ec2Key::DATA_CURVE => Ec2Key::CURVE_P256,
+        Ec2Key::DATA_X => $pad($details['x']),
+        Ec2Key::DATA_Y => $pad($details['y']),
+        Ec2Key::DATA_D => $pad($details['d']),
+    ]);
+}
+
+/**
+ * A 256-bit symmetric COSE key.
+ */
+function example_symmetric_key(): SymmetricKey
+{
+    return SymmetricKey::create([
+        SymmetricKey::TYPE => SymmetricKey::TYPE_OCT,
+        SymmetricKey::DATA_K => random_bytes(32),
+    ]);
+}
+
+function example_title(string $title): void
+{
+    echo $title, PHP_EOL, str_repeat('=', strlen($title)), PHP_EOL, PHP_EOL;
+}
+
+function example_line(string $label, string $value): void
+{
+    printf("%-22s %s\n", $label . ':', $value);
+}
+
+/**
+ * Fails the example loudly rather than printing a wrong result quietly.
+ */
+function example_assert(bool $condition, string $message): void
+{
+    if (! $condition) {
+        throw new RuntimeException('FAILED: ' . $message);
+    }
+    example_line('ok', $message);
+}

--- a/tests/ExamplesTest.php
+++ b/tests/ExamplesTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cose\Tests;
+
+use function dirname;
+use const E_ALL;
+use function escapeshellarg;
+use function glob;
+use const PHP_BINARY;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use function sprintf;
+
+/**
+ * The examples under examples/ are run, not just linted.
+ *
+ * A documented snippet that no longer works is worse than none: the previous one ended on an undefined
+ * $signatureBytes and had been published that way. Each example asserts its own outcome through example_assert() and
+ * exits non-zero when something does not hold, so running it is the whole check.
+ *
+ * They are executed in a separate process because they are scripts, not classes: they run at include time, several
+ * of them define the same helper names, and one of them deliberately builds a deprecated class.
+ *
+ * @see \Cose\Tests\Signature\DocumentedSignerTest for the same idea applied to the README snippet
+ */
+final class ExamplesTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function getExamples(): iterable
+    {
+        $directory = dirname(__DIR__) . '/examples';
+        $files = glob($directory . '/*.php');
+        static::assertNotFalse($files, 'The examples directory is unreadable');
+
+        foreach ($files as $file) {
+            $name = basename($file);
+            // _bootstrap.php is the shared setup, included by the others rather than run on its own.
+            if (str_starts_with($name, '_')) {
+                continue;
+            }
+            yield $name => [$file];
+        }
+    }
+
+    /**
+     * Every example runs to completion, with every diagnostic turned into a failure.
+     */
+    #[Test]
+    #[DataProvider('getExamples')]
+    public function theExampleRunsCleanly(string $file): void
+    {
+        // Given: E_ALL, so an undefined variable or a deprecated call inside an example fails here
+        $command = sprintf(
+            '%s -d error_reporting=%d -d display_errors=1 %s 2>&1',
+            escapeshellarg(PHP_BINARY),
+            E_ALL,
+            escapeshellarg($file)
+        );
+
+        // When
+        $output = [];
+        $status = 0;
+        exec($command, $output, $status);
+        $printed = implode("\n", $output);
+
+        // Then
+        static::assertSame(0, $status, sprintf("%s exited with %d:\n%s", basename($file), $status, $printed));
+        static::assertStringNotContainsString('FAILED:', $printed, $printed);
+        static::assertStringNotContainsString('Warning:', $printed, $printed);
+        static::assertStringNotContainsString('Fatal error:', $printed, $printed);
+        static::assertNotSame('', trim($printed), 'The example printed nothing');
+    }
+
+    /**
+     * The index lists every example, so a new one cannot be added without a line explaining what it shows.
+     */
+    #[Test]
+    public function theIndexListsEveryExample(): void
+    {
+        // Given
+        $index = (string) file_get_contents(dirname(__DIR__) . '/examples/README.md');
+        static::assertNotSame('', $index);
+
+        // Then
+        foreach (self::getExamples() as $name => $ignored) {
+            static::assertStringContainsString($name, $index, $name . ' is missing from examples/README.md');
+        }
+    }
+}

--- a/tests/Signature/DocumentedSignerTest.php
+++ b/tests/Signature/DocumentedSignerTest.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cose\Tests\Signature;
+
+use CBOR\ByteStringObject;
+use CBOR\Decoder;
+use CBOR\ListObject;
+use CBOR\MapItem;
+use CBOR\MapObject;
+use CBOR\NegativeIntegerObject;
+use CBOR\OtherObject\NullObject;
+use CBOR\StringStream;
+use CBOR\Tag\CoseSign1Tag;
+use CBOR\UnsignedIntegerObject;
+use Cose\Algorithm\Signature\ECDSA\ES256;
+use Cose\Key\Ec2Key;
+use Cose\Signature\Signature1;
+use Cose\Structure\CoseHeaders;
+use Cose\Structure\HeaderMapHelper;
+use const OPENSSL_KEYTYPE_EC;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use function str_pad;
+use const STR_PAD_LEFT;
+
+/**
+ * The COSE_Sign1 signer documented in README.md and doc/Usage.md, run as it is written there.
+ *
+ * The documented creation snippet used to end at `ByteStringObject::create($yourSignatureBytes)` -- a placeholder
+ * that made the example impossible to run, and left the one thing worth showing (that the signature covers the
+ * Sig_structure and not the payload) implicit. This test is what keeps the published round trip executable.
+ *
+ * @see \Cose\Tests\Signature\DocumentedVerifierTest for the reading half
+ */
+final class DocumentedSignerTest extends TestCase
+{
+    private const PAYLOAD = 'Message to sign';
+
+    private const KID = 'my-key-id';
+
+    /**
+     * The round trip of examples/01-sign1.php: sign, encode, decode, verify.
+     */
+    #[Test]
+    public function theDocumentedRoundTripProducesAVerifiableMessage(): void
+    {
+        // Given
+        $key = self::signingKey();
+
+        // When
+        $encoded = self::documentedSigner($key);
+        $isValid = self::verify($encoded, $key->toPublic());
+
+        // Then
+        static::assertTrue($isValid);
+    }
+
+    /**
+     * The protected bucket is signed verbatim, so the message has to carry the very bytes the Sig_structure covered.
+     * Re-encoding the map instead of reusing them is the mistake the documentation now steers away from.
+     */
+    #[Test]
+    public function theMessageCarriesTheBytesThatWereSigned(): void
+    {
+        // Given
+        $key = self::signingKey();
+        $encoded = self::documentedSigner($key);
+
+        // When
+        $message = Decoder::create()
+            ->decode(StringStream::create($encoded));
+        static::assertInstanceOf(CoseSign1Tag::class, $message);
+
+        // Then: {1: -7} and nothing else
+        static::assertSame("\xa1\x01\x26", $message->getProtectedHeader()->getValue());
+    }
+
+    /**
+     * The header the documented signer writes is the one the documented reader finds.
+     */
+    #[Test]
+    public function theDocumentedHeadersAreReadBack(): void
+    {
+        // Given
+        $encoded = self::documentedSigner(self::signingKey());
+        $message = Decoder::create()
+            ->decode(StringStream::create($encoded));
+        static::assertInstanceOf(CoseSign1Tag::class, $message);
+
+        // When
+        $headers = CoseHeaders::fromMessage($message);
+
+        // Then
+        static::assertSame((string) ES256::identifier(), $headers->getProtectedHeaderParameter(1)?->normalize());
+        static::assertSame(self::KID, $headers->getHeaderParameter(4)?->getValue());
+        static::assertNull($headers->getProtectedHeaderParameter(4));
+    }
+
+    /**
+     * A message signed over one payload does not verify against another.
+     */
+    #[Test]
+    public function aTamperedPayloadIsRejected(): void
+    {
+        // Given
+        $key = self::signingKey();
+        $message = Decoder::create()
+            ->decode(StringStream::create(self::documentedSigner($key)));
+        static::assertInstanceOf(CoseSign1Tag::class, $message);
+
+        // When: the payload is swapped, the protected bucket left as it was
+        $tampered = (string) CoseSign1Tag::create(ListObject::create([
+            $message->getProtectedHeader(),
+            $message->getUnprotectedHeader(),
+            ByteStringObject::create('Another message'),
+            $message->getSignature(),
+        ]));
+
+        // Then
+        static::assertFalse(self::verify($tampered, $key->toPublic()));
+    }
+
+    /**
+     * The signing half of the documented example, copied as it is documented.
+     */
+    private static function documentedSigner(Ec2Key $key): string
+    {
+        $algorithm = ES256::create();
+
+        $protectedHeader = MapObject::create([
+            MapItem::create(
+                UnsignedIntegerObject::create(1),
+                NegativeIntegerObject::create(ES256::identifier())
+            ),
+        ]);
+        $unprotectedHeader = MapObject::create([
+            MapItem::create(UnsignedIntegerObject::create(4), ByteStringObject::create(self::KID)),
+        ]);
+        $payload = ByteStringObject::create(self::PAYLOAD);
+
+        $protectedHeaderAsBytes = HeaderMapHelper::encodeProtected($protectedHeader);
+        $toBeSigned = Signature1::create($protectedHeaderAsBytes, $payload);
+        $signature = ByteStringObject::create($algorithm->sign((string) $toBeSigned, $key));
+
+        $coseSign1 = CoseSign1Tag::create(ListObject::create([
+            $protectedHeaderAsBytes,
+            $unprotectedHeader,
+            $payload,
+            $signature,
+        ]));
+
+        return (string) $coseSign1;
+    }
+
+    /**
+     * The verifying half.
+     */
+    private static function verify(string $encoded, Ec2Key $key): bool
+    {
+        $algorithm = ES256::create();
+
+        $decoded = Decoder::create()
+            ->decode(StringStream::create($encoded));
+        static::assertInstanceOf(CoseSign1Tag::class, $decoded);
+
+        $payload = $decoded->getPayload();
+        static::assertNotInstanceOf(NullObject::class, $payload);
+
+        $toBeVerified = Signature1::create($decoded->getProtectedHeader(), $payload);
+
+        return $algorithm->verify((string) $toBeVerified, $key, $decoded->getSignature()->getValue());
+    }
+
+    private static function signingKey(): Ec2Key
+    {
+        $details = openssl_pkey_get_details(openssl_pkey_new([
+            'private_key_type' => OPENSSL_KEYTYPE_EC,
+            'curve_name' => 'prime256v1',
+        ]))['ec'];
+        // OpenSSL strips the leading zero bytes of the coordinates; COSE requires them to be fixed size.
+        $pad = static fn (string $value): string => str_pad($value, 32, "\x00", STR_PAD_LEFT);
+
+        return Ec2Key::create([
+            Ec2Key::TYPE => Ec2Key::TYPE_EC2,
+            Ec2Key::DATA_CURVE => Ec2Key::CURVE_P256,
+            Ec2Key::DATA_X => $pad($details['x']),
+            Ec2Key::DATA_Y => $pad($details['y']),
+            Ec2Key::DATA_D => $pad($details['d']),
+        ]);
+    }
+}

--- a/tests/Structure/CwtTest.php
+++ b/tests/Structure/CwtTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cose\Tests\Structure;
+
+use CBOR\ByteStringObject;
+use CBOR\Decoder;
+use CBOR\ListObject;
+use CBOR\MapItem;
+use CBOR\MapObject;
+use CBOR\NegativeIntegerObject;
+use CBOR\StringStream;
+use CBOR\Tag\CoseSign1Tag;
+use CBOR\Tag\CwtTag;
+use CBOR\TextStringObject;
+use CBOR\UnsignedIntegerObject;
+use Cose\Algorithm\Signature\ECDSA\ES256;
+use Cose\Key\Ec2Key;
+use Cose\Signature\Signature1;
+use Cose\Structure\HeaderMapHelper;
+use const OPENSSL_KEYTYPE_EC;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use function str_pad;
+use const STR_PAD_LEFT;
+
+/**
+ * The CBOR Web Token flow documented in doc/Usage.md.
+ *
+ * A CWT (RFC 8392) is a claims map carried as the payload of a COSE message, optionally wrapped in tag 61. Nothing
+ * about the COSE verification changes -- the payload is opaque bytes until the signature checks out -- which is
+ * exactly what the documented order of operations is about.
+ *
+ * @see https://datatracker.ietf.org/doc/html/rfc8392#section-6
+ */
+final class CwtTest extends TestCase
+{
+    private const ISSUER = 'coap://as.example.com';
+
+    private const ISSUED_AT = 1443944944;
+
+    /**
+     * Tag 61 wraps the COSE structure; unwrapping it leaves the message to verify as usual.
+     */
+    #[Test]
+    public function aTaggedCwtIsUnwrappedAndVerified(): void
+    {
+        // Given
+        $key = self::signingKey();
+        $encoded = (string) CwtTag::create(self::signedToken($key));
+
+        // Then: tag 61 is the outer head
+        static::assertSame('d83d', substr(bin2hex($encoded), 0, 4));
+
+        // When
+        $decoded = Decoder::create()
+            ->decode(StringStream::create($encoded));
+        static::assertInstanceOf(CwtTag::class, $decoded);
+        $message = $decoded->getValue();
+
+        // Then
+        static::assertInstanceOf(CoseSign1Tag::class, $message);
+        static::assertTrue(self::verify($message, $key->toPublic()));
+    }
+
+    /**
+     * RFC 8392 §6 makes the tag optional, so the documented snippet accepts a bare COSE structure too.
+     */
+    #[Test]
+    public function anUntaggedCwtIsVerifiedTheSameWay(): void
+    {
+        // Given
+        $key = self::signingKey();
+        $encoded = (string) self::signedToken($key);
+
+        // When
+        $decoded = Decoder::create()
+            ->decode(StringStream::create($encoded));
+        $message = $decoded instanceof CwtTag ? $decoded->getValue() : $decoded;
+
+        // Then
+        static::assertInstanceOf(CoseSign1Tag::class, $message);
+        static::assertTrue(self::verify($message, $key->toPublic()));
+    }
+
+    /**
+     * The claims are read only once the signature holds, and cbor-php normalizes CBOR integers to numeric strings --
+     * which is what the documentation warns about for the timestamp claims.
+     */
+    #[Test]
+    public function theClaimsAreReadFromTheVerifiedPayload(): void
+    {
+        // Given
+        $key = self::signingKey();
+        $message = self::signedToken($key);
+        static::assertTrue(self::verify($message, $key->toPublic()));
+
+        // When
+        $claims = Decoder::create()
+            ->decode(StringStream::create($message->getPayload()->getValue()))
+            ->normalize();
+
+        // Then
+        static::assertSame(self::ISSUER, $claims[1]);
+        static::assertSame((string) self::ISSUED_AT, $claims[6]);
+        static::assertSame(self::ISSUED_AT, (int) $claims[6]);
+    }
+
+    /**
+     * A COSE_Sign1 carrying a CWT claims set as its payload.
+     */
+    private static function signedToken(Ec2Key $key): CoseSign1Tag
+    {
+        // RFC 8392 §3.1: 1 = iss, 6 = iat
+        $claims = MapObject::create([
+            MapItem::create(UnsignedIntegerObject::create(1), TextStringObject::create(self::ISSUER)),
+            MapItem::create(UnsignedIntegerObject::create(6), UnsignedIntegerObject::create(self::ISSUED_AT)),
+        ]);
+
+        $protectedHeader = MapObject::create([
+            MapItem::create(
+                UnsignedIntegerObject::create(1),
+                NegativeIntegerObject::create(ES256::identifier())
+            ),
+        ]);
+        $protectedHeaderAsBytes = HeaderMapHelper::encodeProtected($protectedHeader);
+        $payload = ByteStringObject::create((string) $claims);
+
+        $toBeSigned = Signature1::create($protectedHeaderAsBytes, $payload);
+        $signature = ByteStringObject::create(ES256::create()->sign((string) $toBeSigned, $key));
+
+        return CoseSign1Tag::create(ListObject::create([
+            $protectedHeaderAsBytes,
+            MapObject::create(),
+            $payload,
+            $signature,
+        ]));
+    }
+
+    private static function verify(CoseSign1Tag $message, Ec2Key $key): bool
+    {
+        $toBeVerified = Signature1::create($message->getProtectedHeader(), $message->getPayload());
+
+        return ES256::create()->verify((string) $toBeVerified, $key, $message->getSignature()->getValue());
+    }
+
+    private static function signingKey(): Ec2Key
+    {
+        $details = openssl_pkey_get_details(openssl_pkey_new([
+            'private_key_type' => OPENSSL_KEYTYPE_EC,
+            'curve_name' => 'prime256v1',
+        ]))['ec'];
+        $pad = static fn (string $value): string => str_pad($value, 32, "\x00", STR_PAD_LEFT);
+
+        return Ec2Key::create([
+            Ec2Key::TYPE => Ec2Key::TYPE_EC2,
+            Ec2Key::DATA_CURVE => Ec2Key::CURVE_P256,
+            Ec2Key::DATA_X => $pad($details['x']),
+            Ec2Key::DATA_Y => $pad($details['y']),
+            Ec2Key::DATA_D => $pad($details['d']),
+        ]);
+    }
+}


### PR DESCRIPTION
Follow-up to #190, whose documentation half was not part of the merge.

## Why

The published COSE_Sign1 creation snippet ended at `ByteStringObject::create($yourSignatureBytes)` — a placeholder that made it impossible to run, and that hid the one thing worth showing: **the signature covers the Sig_structure, not the payload.**

## `examples/`

Nine runnable programs, one per topic. Each prints what it does and exits non-zero if a check fails.

| File | Topic |
|---|---|
| `01-sign1.php` | COSE_Sign1: sign, encode, decode, verify — and what a swapped payload does |
| `02-sign-multiple-signers.php` | COSE_Sign, and why `Signature` carries `sign_protected` |
| `03-mac0.php` | The tag covers the MAC_structure, not the bare payload |
| `04-encrypt0.php` | `Enc_structure` as the AEAD's additional authenticated data |
| `05-encrypt-recipients.php` | Key wrapping per recipient, nested recipients, detached ciphertext |
| `06-headers.php` | Each header rule, against what the raw CBOR map answers instead |
| `07-detached-and-external-aad.php` | Content that travels separately, context that never travels |
| `08-cwt.php` | CBOR Web Tokens: verify, then read the claims |
| `09-migration.php` | Moving off the deprecated `Cose\...Tag` classes |

Several show the **failure** as well as the success — that is where the reason for the API is visible. 04 and 05 use AES-GCM through OpenSSL: this library does not implement content encryption, and the examples are the clearest place to say where the line falls.

## `doc/Usage.md`

Two reference sections for API #190 introduced that was only visible inside callouts: **Cryptographic Structures** (the nine context strings in one table, and why the protected header is passed as bytes) and **Reading Headers** (`CoseHeaders` and the four rules it applies). Detached content and `external_aad` move out of "MAC Operations", which they were never specific to; CWT gets a section of its own.

## Tests

`ExamplesTest` runs every example under `E_ALL` and fails on any diagnostic — so an example cannot rot the way the previous snippet had. `DocumentedSignerTest` runs the README round trip and asserts the message carries the bytes that were signed. `CwtTest` covers the tagged and untagged CWT paths.

1136 tests green on PHP 8.2 and 8.5. ECS, PHPStan, Rector, Deptrac, parallel-lint clean.
