### PR TITLE
feat(mac): AES-CBC-MAC algorithms 14, 15, 25, 26 (RFC 9053 §3.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This library implements:
 ✅ **Cryptographic Algorithms**
 - **Signatures**: ECDSA (ES256, ES384, ES512, ES256K), EdDSA (Ed25519, Ed448), RSA (RS256/384/512, PS256/384/512)
 - **Fully-specified identifiers** ([RFC 9864](https://www.rfc-editor.org/rfc/rfc9864.html)): ESP256/384/512, ESB256/320/384/512, Ed25519, Ed448
-- **MAC**: HMAC with SHA-256/384/512
+- **MAC**: HMAC with SHA-256/384/512, AES-CBC-MAC with 128/256-bit keys and 64/128-bit tags
 - Compatible with WebAuthn, FIDO2, and digital COVID certificates
 
 ✅ **Key Restrictions** ([RFC 9052](https://www.rfc-editor.org/rfc/rfc9052.html#section-7.1) §7.1)
@@ -310,6 +310,53 @@ the key. They live in the `Cose\Algorithm\Signature\FullySpecified` namespace.
 | HS384 | 6 | HMAC with SHA-384 |
 | HS512 | 7 | HMAC with SHA-512 |
 | HS256/64 | 4 | HMAC with SHA-256 truncated to 64 bits |
+| AES-MAC 128/64 | 14 | AES-CBC-MAC with a 128-bit key, 64-bit tag |
+| AES-MAC 256/64 | 15 | AES-CBC-MAC with a 256-bit key, 64-bit tag |
+| AES-MAC 128/128 | 25 | AES-CBC-MAC with a 128-bit key, 128-bit tag |
+| AES-MAC 256/128 | 26 | AES-CBC-MAC with a 256-bit key, 128-bit tag |
+
+The HMAC algorithms live in `Cose\Algorithm\Mac\HS256` and its siblings, the AES-CBC-MAC ones in
+`Cose\Algorithm\Mac\AESMAC128_64`, `AESMAC256_64`, `AESMAC128_128` and `AESMAC256_128`. All of them implement
+`Cose\Algorithm\Mac\Mac` and are used the same way:
+
+```php
+use Cose\Algorithm\Mac\AESMAC256_64;
+use Cose\Mac\Mac0Structure;
+
+$algorithm = AESMAC256_64::create();
+$toBeMaced = Mac0Structure::create($protectedHeaderAsBytes, $payload);
+
+$tag = $algorithm->hash((string) $toBeMaced, $symmetricKey);           // 8 bytes
+$isValid = $algorithm->verify((string) $toBeMaced, $symmetricKey, $tag); // compared with hash_equals()
+```
+
+> [!WARNING]
+> **AES-CBC-MAC is a MAC for structured messages, not for arbitrary bytes.**
+> [RFC 9053, section 3.2.1](https://www.rfc-editor.org/rfc/rfc9053#section-3.2.1) states two conditions the
+> algorithm classes cannot check for you:
+>
+> - *"A single key must only be used for messages of a fixed or known length."* Otherwise, given two message and
+>   tag pairs, an attacker forges a third. Computing the tag over a `Mac0Structure` or `MacStructure`, as above, is
+>   the mitigation: the `MAC_structure` of [RFC 9052 §6.3](https://www.rfc-editor.org/rfc/rfc9052#section-6.3) is
+>   CBOR, and CBOR encodes the length of every field it holds. A tag computed over `$payload->getValue()` directly
+>   has no such protection — on top of being interoperable with nothing.
+> - *"Cipher Block Chaining (CBC) encryption and CBC-MAC MUST use different keys."* A key that also encrypts
+>   anything in CBC mode turns the last ciphertext block into a valid tag.
+>
+> The construction is AES in CBC mode with an all-zero IV, padding method 1 of ISO/IEC 9797-1 (zero bytes up to
+> the block boundary, none when the message already is a multiple of 16 bytes — the padding the
+> [cose-wg/Examples](https://github.com/cose-wg/Examples/tree/master/cbc-mac-examples) vectors use), and the last
+> block truncated to the tag length. It is **not** AES-CMAC ([RFC 4493](https://www.rfc-editor.org/rfc/rfc4493)).
+>
+> The 64-bit tag variants are the ones constrained devices use; all four identifiers are marked *Recommended: Yes* at
+> IANA and none of them needs an acknowledgement.
+
+#### The AES-CBC-MAC Key
+
+The key must be symmetric, and its `k` must be a byte string of **exactly** the length of the identifier: 16 bytes
+for AES-MAC 128/64 and 128/128, 32 bytes for AES-MAC 256/64 and 256/128. A key of any other length is refused with
+an `InvalidArgumentException` before OpenSSL is reached — RFC 9053 §3.2 ties the key length to the identifier, so it
+is the wrong key rather than a weak one. `AesCbcMac::keyLength()` and `tagLength()` give the lengths in bytes.
 
 #### The HMAC Key
 
@@ -579,11 +626,11 @@ The library includes comprehensive tests including:
 - COVID-19 certificate verification examples
 - Test fixtures with actual certificates
 - The interoperability fixtures of the IETF COSE working group, [cose-wg/Examples](https://github.com/cose-wg/Examples),
-  vendored under [`tests/fixtures/cose-wg/`](tests/fixtures/cose-wg/README.md). Every ECDSA, EdDSA, HMAC and
-  RSASSA-PSS fixture is decoded, rebuilt into its `Sig_structure` or `MAC_structure`, compared with the bytes the
-  working group's generator signed, verified, and signed again; the fixtures the generator broke on purpose are
-  asserted to be rejected. Fixtures for algorithms the library does not implement yet are reported as skipped with
-  the identifier, so `phpunit --display-skipped` lists what is left.
+  vendored under [`tests/fixtures/cose-wg/`](tests/fixtures/cose-wg/README.md). Every ECDSA, EdDSA, HMAC,
+  AES-CBC-MAC and RSASSA-PSS fixture is decoded, rebuilt into its `Sig_structure` or `MAC_structure`, compared with
+  the bytes the working group's generator signed, verified, and signed again; the fixtures the generator broke on
+  purpose are asserted to be rejected. Fixtures for algorithms the library does not implement yet are reported as
+  skipped with the identifier, so `phpunit --display-skipped` lists what is left.
 
 ## Requirements
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -43,6 +43,14 @@ with the missing identifier. Two behaviours changed on the way, both additive:
   `Key::TYPE_NAME_OCT_IANA` name the new forms, `Key::createFromData()` dispatches them, and the new
   `Key::typeIs(Key::TYPE_*)` answers for every form of a key type. `Key::type()` still returns the form supplied.
 
+**New: the AES-CBC-MAC algorithms of RFC 9053 §3.2.** `Cose\Algorithm\Mac\AESMAC128_64` (14), `AESMAC256_64` (15),
+`AESMAC128_128` (25) and `AESMAC256_128` (26), on the `AesCbcMac` base, implement the existing `Mac` interface and
+enforce the key restrictions like every other algorithm. The key must be exactly 16 or 32 bytes long, as the
+identifier says; the tag is compared with `hash_equals()`. The `cbc-mac-examples/` fixtures of cose-wg/Examples
+verify and are reproduced byte for byte. RFC 9053 §3.2.1 makes two demands the classes cannot check — one key per
+message length, and never the key of a CBC encryption — both documented in the README; the `MAC_structure` covers the
+first.
+
 ### 4.7.x to 4.8.x
 
 **The six COSE message classes are deprecated.** `Cose\Signature\CoseSign1Tag`, `Cose\Signature\CoseSignTag`,

--- a/doc/Usage.md
+++ b/doc/Usage.md
@@ -806,7 +806,7 @@ it two parameters for that: `alg` (label 3) pins it to one algorithm — "If the
 object MUST NOT be used to perform the cryptographic operation" — and `key_ops` (label 4) pins it to a set of
 operations, whose values are those of Table 5: `sign` (1), `verify` (2), `MAC create` (9) and `MAC verify` (10) for
 the algorithms this library implements. [RFC 9053](https://www.rfc-editor.org/rfc/rfc9053.html#section-2.1) repeats
-both as a per-algorithm requirement for ECDSA (§2.1), EdDSA (§2.2) and HMAC (§3.1).
+both as a per-algorithm requirement for ECDSA (§2.1), EdDSA (§2.2), HMAC (§3.1) and AES-CBC-MAC (§3.2).
 
 Enforcing them is **opt-in**, so that a key which used to work keeps working. Ask an algorithm — or a whole
 `Manager` — to enforce the restrictions, and it refuses the key with an `InvalidArgumentException` whenever the key
@@ -1093,11 +1093,50 @@ $key = PublicKeyLoader::fromSubjectPublicKeyInfo($spkiDer);
 
 ### MAC Algorithms
 
-- **HMAC**
+- **HMAC** ([RFC 9053 §3.1](https://www.rfc-editor.org/rfc/rfc9053#section-3.1)) — `Cose\Algorithm\Mac\HS256` and siblings
   - HS256 (5): HMAC with SHA-256
   - HS384 (6): HMAC with SHA-384
   - HS512 (7): HMAC with SHA-512
   - HS256/64 (4): HMAC with SHA-256 truncated to 64 bits
+- **AES-CBC-MAC** ([RFC 9053 §3.2](https://www.rfc-editor.org/rfc/rfc9053#section-3.2)) — `Cose\Algorithm\Mac\AESMAC128_64` and siblings
+  - AES-MAC 128/64 (14): AES-128 in CBC mode, 64-bit tag
+  - AES-MAC 256/64 (15): AES-256 in CBC mode, 64-bit tag
+  - AES-MAC 128/128 (25): AES-128 in CBC mode, 128-bit tag
+  - AES-MAC 256/128 (26): AES-256 in CBC mode, 128-bit tag
+
+Every MAC algorithm implements `Cose\Algorithm\Mac\Mac`: `hash()` computes the tag, `verify()` compares it with
+`hash_equals()`, and both take a symmetric `Key`.
+
+```php
+use Cose\Algorithm\Mac\AESMAC128_64;
+use Cose\Key\SymmetricKey;
+use Cose\Mac\Mac0Structure;
+
+$key = SymmetricKey::create([
+    SymmetricKey::TYPE => SymmetricKey::TYPE_OCT,
+    SymmetricKey::DATA_K => random_bytes(16), // exactly 16 bytes for the 128-bit identifiers, 32 for the 256-bit ones
+]);
+$algorithm = AESMAC128_64::create();
+
+$toBeMaced = Mac0Structure::create($protectedHeaderAsBytes, $payload);
+$tag = $algorithm->hash((string) $toBeMaced, $key);                  // 8 bytes
+$isValid = $algorithm->verify((string) $toBeMaced, $key, $tag);
+```
+
+> [!WARNING]
+> AES-CBC-MAC comes with two conditions of its own, stated by
+> [RFC 9053 §3.2.1](https://www.rfc-editor.org/rfc/rfc9053#section-3.2.1), that no class can check for you:
+>
+> - **A key must only authenticate messages of a fixed or known length.** With messages of varying length, two
+>   message/tag pairs let an attacker forge a third. The `MAC_structure` is the mitigation: it is CBOR, so it
+>   encodes the length of every field, and a tag computed over a `Mac0Structure` or `MacStructure` is not exposed.
+>   A tag computed over the bare payload is.
+> - **CBC encryption and CBC-MAC must use different keys.** With a shared key, the last ciphertext block of an
+>   encryption is a valid tag.
+>
+> The construction is the CBC-MAC of ISO/IEC 9797-1 with AES, an all-zero IV, padding method 1 (zero bytes up to
+> the block boundary, none when the message is already a multiple of 16 bytes — what the cose-wg/Examples vectors
+> use) and the last block truncated to the tag length. It is not AES-CMAC (RFC 4493).
 
 ### Validating Symmetric Keys
 
@@ -1105,6 +1144,9 @@ $key = PublicKeyLoader::fromSubjectPublicKeyInfo($spkiDer);
 validating MAC values" to validate the key type, the key length and the algorithm. The first two constraints admit no
 exception and are applied by the MAC algorithms themselves: `hash()` and `verify()` throw an
 `InvalidArgumentException` when the key is not symmetric, or when its `k` is missing, is not a PHP string or is empty.
+The AES-CBC-MAC algorithms add the length: RFC 9053 §3.2 ties it to the identifier, so a `k` that is not exactly
+16 bytes (AES-MAC 128/64 and 128/128) or 32 bytes (AES-MAC 256/64 and 256/128) is refused the same way, before
+OpenSSL is reached.
 `SymmetricKey` applies the same contract at construction time, where the mistake is easiest to attribute. A value
 decoded from CBOR has to be normalized first — a `CBOR\ByteStringObject` is not a byte string.
 
@@ -1177,7 +1219,7 @@ php examples/01-sign1.php
 |---|---|
 | `examples/01-sign1.php` | COSE_Sign1: sign, encode, decode, verify |
 | `examples/02-sign-multiple-signers.php` | COSE_Sign, and why `Signature` carries `sign_protected` |
-| `examples/03-mac0.php` | COSE_Mac0 over the MAC_structure |
+| `examples/03-mac0.php` | COSE_Mac0 over the MAC_structure, with HMAC and AES-CBC-MAC |
 | `examples/04-encrypt0.php` | COSE_Encrypt0 with `Enc_structure` as the AEAD's AAD |
 | `examples/05-encrypt-recipients.php` | COSE_Encrypt: key wrapping, nested recipients, detached ciphertext |
 | `examples/06-headers.php` | The header rules, against what the raw CBOR map answers |

--- a/examples/03-mac0.php
+++ b/examples/03-mac0.php
@@ -18,7 +18,9 @@ use CBOR\MapObject;
 use CBOR\StringStream;
 use CBOR\Tag\CoseMac0Tag;
 use CBOR\UnsignedIntegerObject;
+use Cose\Algorithm\Mac\AESMAC256_64;
 use Cose\Algorithm\Mac\HS256;
+use Cose\Key\SymmetricKey;
 use Cose\Mac\Mac0Structure;
 use Cose\Mac\MacStructure;
 use Cose\Structure\CoseHeaders;
@@ -88,3 +90,41 @@ example_assert(
 );
 example_hex('MAC0 structure', (string) $toBeVerified);
 example_hex('MAC structure', (string) $asMac);
+
+// --- the same message under AES-CBC-MAC ---------------------------------------
+
+// RFC 9053 section 3.2: the AES-MAC identifiers are AES in CBC mode with a zero IV, the last block truncated to the
+// tag length. The key length is part of the identifier -- AES-MAC 256/64 wants exactly 32 bytes -- and the tag is 8
+// bytes: what a constrained device sends.
+echo PHP_EOL;
+$cbcMacKey = SymmetricKey::create([
+    SymmetricKey::TYPE => SymmetricKey::TYPE_OCT,
+    SymmetricKey::DATA_K => random_bytes(32),
+]);
+$cbcMac = AESMAC256_64::create();
+
+$protectedHeader = HeaderMapHelper::encodeProtected(MapObject::create([
+    MapItem::create(UnsignedIntegerObject::create(1), UnsignedIntegerObject::create(AESMAC256_64::identifier())),
+]));
+$toBeMaced = Mac0Structure::create($protectedHeader, $payload);
+$cbcTag = $cbcMac->hash((string) $toBeMaced, $cbcMacKey);
+
+example_hex('AES-MAC 256/64 tag', $cbcTag);
+example_assert(strlen($cbcTag) === 8, 'the tag is 64 bits long');
+example_assert($cbcMac->verify((string) $toBeMaced, $cbcMacKey, $cbcTag), 'the tag verifies over the MAC_structure');
+
+// RFC 9053 section 3.2.1: "A single key must only be used for messages of a fixed or known length." The padding of
+// CBC-MAC appends zero bytes and no length, so two byte strings that differ only by trailing zero bytes up to the
+// block boundary share a tag when they are authenticated bare...
+$bare = 'Data to authenticate';
+example_assert(
+    $cbcMac->hash($bare, $cbcMacKey) === $cbcMac->hash($bare . "\0", $cbcMacKey),
+    'over bare bytes, "Data to authenticate" and the same with a trailing NUL share a tag'
+);
+
+// ...and do not once they are wrapped in a MAC_structure, whose CBOR encoding carries the length of every field.
+$withNul = Mac0Structure::create($protectedHeader, ByteStringObject::create($bare . "\0"));
+example_assert(
+    ! $cbcMac->verify((string) $withNul, $cbcMacKey, $cbcTag),
+    'over the MAC_structure, the payload with a trailing NUL has another tag'
+);

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,7 +18,7 @@ Every CBOR item is printed as hex in full, never truncated, so it can be pasted 
 |---|---|
 | [`01-sign1.php`](01-sign1.php) | COSE_Sign1: sign, encode, decode, verify — and what a swapped payload does |
 | [`02-sign-multiple-signers.php`](02-sign-multiple-signers.php) | COSE_Sign: several signers, and why `Signature` carries `sign_protected` |
-| [`03-mac0.php`](03-mac0.php) | COSE_Mac0: the tag covers the MAC_structure, never the bare payload |
+| [`03-mac0.php`](03-mac0.php) | COSE_Mac0: the tag covers the MAC_structure, never the bare payload — with HMAC, then AES-CBC-MAC |
 | [`04-encrypt0.php`](04-encrypt0.php) | COSE_Encrypt0: `Enc_structure` as the AEAD's additional authenticated data |
 | [`05-encrypt-recipients.php`](05-encrypt-recipients.php) | COSE_Encrypt: key wrapping per recipient, nested recipients, detached ciphertext |
 | [`06-headers.php`](06-headers.php) | The RFC 9052 header rules, each shown against what the raw CBOR map answers |

--- a/src/Algorithm/Mac/AESMAC128_128.php
+++ b/src/Algorithm/Mac/AESMAC128_128.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cose\Algorithm\Mac;
+
+/**
+ * AES-MAC 128/128: AES-CBC-MAC with a 128-bit key and a 128-bit tag (RFC 9053, section 3.2).
+ */
+final class AESMAC128_128 extends AesCbcMac
+{
+    public const ID = 25;
+
+    public static function create(): self
+    {
+        return new self();
+    }
+
+    public static function identifier(): int
+    {
+        return self::ID;
+    }
+
+    protected function getKeyLength(): int
+    {
+        return 128;
+    }
+
+    protected function getTagLength(): int
+    {
+        return 128;
+    }
+}

--- a/src/Algorithm/Mac/AESMAC128_64.php
+++ b/src/Algorithm/Mac/AESMAC128_64.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cose\Algorithm\Mac;
+
+/**
+ * AES-MAC 128/64: AES-CBC-MAC with a 128-bit key and a 64-bit tag (RFC 9053, section 3.2).
+ */
+final class AESMAC128_64 extends AesCbcMac
+{
+    public const ID = 14;
+
+    public static function create(): self
+    {
+        return new self();
+    }
+
+    public static function identifier(): int
+    {
+        return self::ID;
+    }
+
+    protected function getKeyLength(): int
+    {
+        return 128;
+    }
+
+    protected function getTagLength(): int
+    {
+        return 64;
+    }
+}

--- a/src/Algorithm/Mac/AESMAC256_128.php
+++ b/src/Algorithm/Mac/AESMAC256_128.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cose\Algorithm\Mac;
+
+/**
+ * AES-MAC 256/128: AES-CBC-MAC with a 256-bit key and a 128-bit tag (RFC 9053, section 3.2).
+ */
+final class AESMAC256_128 extends AesCbcMac
+{
+    public const ID = 26;
+
+    public static function create(): self
+    {
+        return new self();
+    }
+
+    public static function identifier(): int
+    {
+        return self::ID;
+    }
+
+    protected function getKeyLength(): int
+    {
+        return 256;
+    }
+
+    protected function getTagLength(): int
+    {
+        return 128;
+    }
+}

--- a/src/Algorithm/Mac/AESMAC256_64.php
+++ b/src/Algorithm/Mac/AESMAC256_64.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cose\Algorithm\Mac;
+
+/**
+ * AES-MAC 256/64: AES-CBC-MAC with a 256-bit key and a 64-bit tag (RFC 9053, section 3.2).
+ */
+final class AESMAC256_64 extends AesCbcMac
+{
+    public const ID = 15;
+
+    public static function create(): self
+    {
+        return new self();
+    }
+
+    public static function identifier(): int
+    {
+        return self::ID;
+    }
+
+    protected function getKeyLength(): int
+    {
+        return 256;
+    }
+
+    protected function getTagLength(): int
+    {
+        return 64;
+    }
+}

--- a/src/Algorithm/Mac/AesCbcMac.php
+++ b/src/Algorithm/Mac/AesCbcMac.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cose\Algorithm\Mac;
+
+use Cose\Algorithm\KeyRestrictionAware;
+use Cose\Algorithm\KeyRestrictionEnforcement;
+use Cose\Algorithm\Signature\OpenSslError;
+use Cose\Key\Key;
+use Cose\Key\SymmetricKey;
+use function hash_equals;
+use function intdiv;
+use InvalidArgumentException;
+use function is_string;
+use function openssl_encrypt;
+use const OPENSSL_RAW_DATA;
+use const OPENSSL_ZERO_PADDING;
+use RuntimeException;
+use function sprintf;
+use function str_repeat;
+use function strlen;
+use function substr;
+
+/**
+ * AES Message Authentication Codes (RFC 9053, section 3.2).
+ *
+ * "AES-CBC-MAC is defined in [MAC]" (ISO/IEC 9797-1) and is "the instantiation of the CBC-MAC construction […] using
+ * AES as the block cipher", "with the IV fixed to all zeros" - it is not AES-CMAC (RFC 4493), the section says so.
+ * The message is encrypted with AES in CBC mode under a zero IV and the last ciphertext block, truncated to the
+ * length of the identifier, is the tag. RFC 9053 delegates the padding to ISO/IEC 9797-1 and does not restate the
+ * method; the vectors of cose-wg/Examples, which are what interoperates, use padding method 1: the message is
+ * right-padded with zero bytes up to the block boundary, and left alone when it is already a multiple of 16 bytes.
+ *
+ * RFC 9053, section 3.2.1 lists the weaknesses of the construction, and both are the caller's to handle:
+ *
+ * - "A single key must only be used for messages of a fixed or known length. If this is not the case, then an
+ *   attacker will be able to generate a message with a valid tag given two message and tag pairs." The COSE
+ *   MAC_structure is the mitigation: it encodes the lengths of every field it holds, so a tag computed over a
+ *   Cose\Mac\MacStructure or Cose\Mac\Mac0Structure is not exposed. A tag computed over arbitrary bytes is.
+ * - "Cipher Block Chaining (CBC) encryption and CBC-MAC MUST use different keys." A key that also encrypts anything
+ *   in CBC mode lets the last ciphertext block stand in for the tag.
+ *
+ * Section 3.2 requires that "implementations creating and validating MAC values MUST validate that the key type, key
+ * length, and algorithm are correct and appropriate for the entities involved": the key has to be symmetric, with a
+ * `k` that is a byte string of exactly the length of the identifier - 16 bytes for the 128-bit variants, 32 for the
+ * 256-bit ones - which is checked before OpenSSL is reached. The "alg" and "key_ops" restrictions of the key are
+ * enforced through KeyRestrictionAware.
+ *
+ * The 64-bit tag variants (14 and 15) are the ones constrained devices use, and IANA marks all four identifiers as
+ * recommended: none of them needs an acknowledgement to be created.
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc9053#section-3.2
+ * @see https://www.rfc-editor.org/rfc/rfc9053#section-3.2.1
+ * @see \Cose\Tests\Algorithm\Mac\AesCbcMacTest
+ */
+abstract class AesCbcMac implements Mac, KeyRestrictionAware
+{
+    use KeyRestrictionEnforcement;
+
+    /**
+     * The AES block size, in bytes: the size of the IV, of the padding boundary and of the untruncated tag.
+     */
+    public const BLOCK_SIZE = 16;
+
+    public function hash(string $data, Key $key): string
+    {
+        // RFC 9053, section 3.2: "If the 'key_ops' field is present, it MUST include 'MAC create' when creating an
+        // AES-MAC authentication tag."
+        return $this->compute($data, $this->checkKey($key, Key::OP_MAC_CREATE));
+    }
+
+    public function verify(string $data, Key $key, string $signature): bool
+    {
+        // ... and it MUST include 'MAC verify' when verifying one, so the two operations cannot share a code path.
+        return hash_equals($this->compute($data, $this->checkKey($key, Key::OP_MAC_VERIFY)), $signature);
+    }
+
+    /**
+     * The exact length, in bytes, of the key this algorithm accepts: 16 for AES-128, 32 for AES-256.
+     */
+    public function keyLength(): int
+    {
+        return intdiv($this->getKeyLength(), 8);
+    }
+
+    /**
+     * The length, in bytes, of the tag this algorithm produces: 8 or 16.
+     */
+    public function tagLength(): int
+    {
+        return intdiv($this->getTagLength(), 8);
+    }
+
+    /**
+     * The IANA name of the algorithm, for error messages: "AES-MAC 128/64" and its siblings.
+     */
+    public function name(): string
+    {
+        return sprintf('AES-MAC %d/%d', $this->getKeyLength(), $this->getTagLength());
+    }
+
+    /**
+     * The key length, in bits: 128 or 256.
+     */
+    abstract protected function getKeyLength(): int;
+
+    /**
+     * The tag length, in bits: 64 or 128.
+     */
+    abstract protected function getTagLength(): int;
+
+    private function compute(string $data, string $k): string
+    {
+        // ISO/IEC 9797-1 padding method 1: as few zero bytes as needed to reach a positive multiple of the block
+        // size, so that the empty message becomes one zero block and a full block is left alone.
+        $remainder = strlen($data) % self::BLOCK_SIZE;
+        if ($remainder !== 0 || $data === '') {
+            $data .= str_repeat("\0", self::BLOCK_SIZE - $remainder);
+        }
+
+        // OPENSSL_ZERO_PADDING is OpenSSL's "no padding": the message is already aligned, and PKCS#7 would append a
+        // block the construction does not have.
+        OpenSslError::clear();
+        $ciphertext = openssl_encrypt(
+            $data,
+            sprintf('aes-%d-cbc', $this->getKeyLength()),
+            $k,
+            OPENSSL_RAW_DATA | OPENSSL_ZERO_PADDING,
+            str_repeat("\0", self::BLOCK_SIZE)
+        );
+        if ($ciphertext === false) {
+            throw new RuntimeException('Unable to compute the AES-CBC-MAC tag: ' . OpenSslError::lastMessage());
+        }
+
+        return substr($ciphertext, -self::BLOCK_SIZE, $this->tagLength());
+    }
+
+    /**
+     * @param int $operation the Key::OP_* constant of the operation the key is about to be used for
+     *
+     * @throws InvalidArgumentException when the key cannot be used with this algorithm
+     */
+    private function checkKey(Key $key, int $operation): string
+    {
+        if (! $key->typeIs(Key::TYPE_OCT)) {
+            throw new InvalidArgumentException('Invalid key. Must be of type symmetric');
+        }
+
+        if (! $key->has(SymmetricKey::DATA_K)) {
+            throw new InvalidArgumentException('Invalid key. The value of the key is missing');
+        }
+
+        $k = $key->get(SymmetricKey::DATA_K);
+        if (! is_string($k)) {
+            throw new InvalidArgumentException(
+                'Invalid key. The value of the key must be a byte string (CBOR objects shall be normalized first)'
+            );
+        }
+        if ($k === '') {
+            throw new InvalidArgumentException('Invalid key. The value of the key is empty');
+        }
+
+        // RFC 9053, section 3.2: the key length is part of the identifier, so a key of any other length is the
+        // wrong key rather than a weak one. It is refused before OpenSSL is given anything.
+        if (strlen($k) !== $this->keyLength()) {
+            throw new InvalidArgumentException(sprintf(
+                'Invalid key. %s requires a %d-byte key, %d bytes given',
+                $this->name(),
+                $this->keyLength(),
+                strlen($k)
+            ));
+        }
+
+        $this->checkKeyRestrictions($key, $operation);
+
+        return $k;
+    }
+}

--- a/src/Key/SymmetricKeyValidator.php
+++ b/src/Key/SymmetricKeyValidator.php
@@ -15,8 +15,9 @@ use Throwable;
  *
  * RFC 9053, section 3.1 requires implementations to "validate that the key type, key length, and algorithm are
  * correct and appropriate for the entities involved". The key type and the byte string nature of `k` admit no
- * exception and are therefore applied by the algorithms themselves: Cose\Algorithm\Mac\Hmac rejects a key that is
- * not symmetric, whose `k` is missing, is not a PHP string, or is empty.
+ * exception and are therefore applied by the algorithms themselves: Cose\Algorithm\Mac\Hmac and
+ * Cose\Algorithm\Mac\AesCbcMac reject a key that is not symmetric, whose `k` is missing, is not a PHP string, or is
+ * empty - and AesCbcMac adds the exact length its identifier prescribes, which is not a policy either.
  *
  * The *minimum* key length is the policy choice, and it stays opt-in, exactly like the minimum modulus length of
  * RsaKeyValidator: RFC 2104, section 3 only states that a key shorter than the output of the hash function is

--- a/tests/Algorithm/KeyRestrictionEnforcementTest.php
+++ b/tests/Algorithm/KeyRestrictionEnforcementTest.php
@@ -6,6 +6,8 @@ namespace Cose\Tests\Algorithm;
 
 use function base64_decode;
 use Cose\Algorithm\KeyRestrictionAware;
+use Cose\Algorithm\Mac\AESMAC256_128;
+use Cose\Algorithm\Mac\AESMAC256_64;
 use Cose\Algorithm\Mac\HS256;
 use Cose\Algorithm\Mac\HS256Truncated64;
 use Cose\Algorithm\Mac\HS512;
@@ -39,8 +41,8 @@ use function str_repeat;
 
 /**
  * RFC 9052, section 7.1 restricts a key to one algorithm with "alg" (label 3) and to a set of operations with
- * "key_ops" (label 4). RFC 9053, sections 2.1, 2.2 and 3.1 repeat both as a per-algorithm MUST for ECDSA, EdDSA and
- * HMAC.
+ * "key_ops" (label 4). RFC 9053, sections 2.1, 2.2, 3.1 and 3.2 repeat both as a per-algorithm MUST for ECDSA, EdDSA,
+ * HMAC and AES-MAC.
  *
  * Enforcing them is opt-in: an algorithm ignores both labels until `withKeyRestrictionsEnforced()` is called, so that
  * keys that used to work keep working.
@@ -409,6 +411,38 @@ final class KeyRestrictionEnforcementTest extends TestCase
             Key::OP_MAC_VERIFY,
             'The key does not allow the "MAC verify" operation',
         ];
+        yield 'AES-MAC 256/64 verifies a tag with a key restricted to AES-MAC 256/128' => [
+            AESMAC256_64::create(),
+            self::symmetricKey([
+                Key::ALG => AESMAC256_128::ID,
+            ]),
+            Key::OP_MAC_VERIFY,
+            'The key is restricted to the algorithm 26 and cannot be used with the algorithm 15',
+        ];
+        yield 'AES-MAC 256/128 verifies a tag with a key restricted to HS256' => [
+            AESMAC256_128::create(),
+            self::symmetricKey([
+                Key::ALG => HS256::ID,
+            ]),
+            Key::OP_MAC_VERIFY,
+            'The key is restricted to the algorithm 5 and cannot be used with the algorithm 26',
+        ];
+        yield 'AES-MAC 256/128 creates a tag with a MAC verify only key' => [
+            AESMAC256_128::create(),
+            self::symmetricKey([
+                Key::KEY_OPS => [Key::OP_MAC_VERIFY],
+            ]),
+            Key::OP_MAC_CREATE,
+            'The key does not allow the "MAC create" operation',
+        ];
+        yield 'AES-MAC 256/64 verifies a tag with a MAC create only key' => [
+            AESMAC256_64::create(),
+            self::symmetricKey([
+                Key::KEY_OPS => ['MAC create'],
+            ]),
+            Key::OP_MAC_VERIFY,
+            'The key does not allow the "MAC verify" operation',
+        ];
     }
 
     /**
@@ -486,6 +520,21 @@ final class KeyRestrictionEnforcementTest extends TestCase
         ];
         yield 'HS256 creates a tag with a MAC create only key' => [
             HS256::create(),
+            self::symmetricKey([
+                Key::KEY_OPS => [Key::OP_MAC_CREATE],
+            ]),
+            Key::OP_MAC_CREATE,
+        ];
+        yield 'AES-MAC 256/128 with a key restricted to AES-MAC 256/128' => [
+            AESMAC256_128::create(),
+            self::symmetricKey([
+                Key::ALG => AESMAC256_128::ID,
+                Key::KEY_OPS => [Key::OP_MAC_CREATE, Key::OP_MAC_VERIFY],
+            ]),
+            Key::OP_MAC_VERIFY,
+        ];
+        yield 'AES-MAC 256/64 creates a tag with a MAC create only key' => [
+            AESMAC256_64::create(),
             self::symmetricKey([
                 Key::KEY_OPS => [Key::OP_MAC_CREATE],
             ]),

--- a/tests/Algorithm/Mac/AesCbcMacTest.php
+++ b/tests/Algorithm/Mac/AesCbcMacTest.php
@@ -1,0 +1,560 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cose\Tests\Algorithm\Mac;
+
+use function bin2hex;
+use CBOR\ByteStringObject;
+use CBOR\Decoder;
+use CBOR\OtherObject\OtherObjectManager;
+use CBOR\StringStream;
+use CBOR\Tag\TagManager;
+use function chr;
+use Cose\Algorithm\KeyRestrictionAware;
+use Cose\Algorithm\Mac\AesCbcMac;
+use Cose\Algorithm\Mac\AESMAC128_128;
+use Cose\Algorithm\Mac\AESMAC128_64;
+use Cose\Algorithm\Mac\AESMAC256_128;
+use Cose\Algorithm\Mac\AESMAC256_64;
+use Cose\Algorithm\Mac\Mac;
+use Cose\Algorithms;
+use Cose\Key\Key;
+use Cose\Key\OkpKey;
+use Cose\Key\SymmetricKey;
+use function hex2bin;
+use InvalidArgumentException;
+use function openssl_encrypt;
+use const OPENSSL_RAW_DATA;
+use const OPENSSL_ZERO_PADDING;
+use function ord;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use function str_repeat;
+use function strlen;
+use function substr;
+
+/**
+ * AES-CBC-MAC (RFC 9053, section 3.2): the four identifiers, the construction, the key checks of section 3.2 and
+ * the padding the cose-wg/Examples vectors use.
+ *
+ * The vectors come from two independent sources. FIPS 197 Appendix C gives the AES encryption of one block, which is
+ * exactly the CBC-MAC of a one-block message under a zero IV; and the cose-wg/Examples `cbc-mac-examples/` fixtures
+ * give the tag of a MAC_structure for each of the four identifiers, with messages that need padding (31 and 33
+ * bytes) and messages that do not (32 bytes). The fixtures are also run end to end by
+ * {@see \Cose\Tests\CoseWg\CoseWgFixtureTest}; they are repeated here, on the primitive alone, so that a failure
+ * of the primitive is reported by the test of the primitive.
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc9053#section-3.2
+ * @see https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.197-upd1.pdf Appendix C
+ * @see https://github.com/cose-wg/Examples/tree/master/cbc-mac-examples
+ */
+final class AesCbcMacTest extends TestCase
+{
+    /**
+     * The AES-128 key of FIPS 197 Appendix C.1.
+     */
+    private const FIPS_KEY_128 = '000102030405060708090a0b0c0d0e0f';
+
+    /**
+     * The AES-256 key of FIPS 197 Appendix C.3.
+     */
+    private const FIPS_KEY_256 = '000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f';
+
+    /**
+     * The plaintext block of FIPS 197 Appendix C.
+     */
+    private const FIPS_BLOCK = '00112233445566778899aabbccddeeff';
+
+    #[Test]
+    public function theAlgorithmsHaveTheRegisteredIdentifiers(): void
+    {
+        // Then
+        static::assertSame(Algorithms::COSE_ALGORITHM_AES_MAC_128_64, AESMAC128_64::identifier());
+        static::assertSame(Algorithms::COSE_ALGORITHM_AES_MAC_256_64, AESMAC256_64::identifier());
+        static::assertSame(Algorithms::COSE_ALGORITHM_AES_MAC_128_128, AESMAC128_128::identifier());
+        static::assertSame(Algorithms::COSE_ALGORITHM_AES_MAC_256_128, AESMAC256_128::identifier());
+        static::assertSame(14, AESMAC128_64::ID);
+        static::assertSame(15, AESMAC256_64::ID);
+        static::assertSame(25, AESMAC128_128::ID);
+        static::assertSame(26, AESMAC256_128::ID);
+    }
+
+    #[Test]
+    #[DataProvider('getAlgorithms')]
+    public function theAlgorithmDescribesItsKeyAndTagLengths(
+        AesCbcMac $algorithm,
+        int $keyLength,
+        int $tagLength,
+        string $name
+    ): void {
+        // Then
+        static::assertInstanceOf(Mac::class, $algorithm);
+        static::assertInstanceOf(KeyRestrictionAware::class, $algorithm);
+        static::assertSame($keyLength, $algorithm->keyLength());
+        static::assertSame($tagLength, $algorithm->tagLength());
+        static::assertSame($name, $algorithm->name());
+    }
+
+    #[Test]
+    #[DataProvider('getVectors')]
+    public function theTagIsTheOneOfTheVector(AesCbcMac $algorithm, string $k, string $data, string $tag): void
+    {
+        // Given
+        $key = self::symmetricKey($k);
+
+        // When
+        $computed = $algorithm->hash($data, $key);
+
+        // Then
+        static::assertSame(bin2hex($tag), bin2hex($computed));
+        static::assertSame($algorithm->tagLength(), strlen($computed));
+    }
+
+    #[Test]
+    #[DataProvider('getVectors')]
+    public function theTagOfTheVectorVerifies(AesCbcMac $algorithm, string $k, string $data, string $tag): void
+    {
+        // Given
+        $key = self::symmetricKey($k);
+
+        // Then
+        static::assertTrue($algorithm->verify($data, $key, $tag));
+    }
+
+    /**
+     * The tag is compared with hash_equals(): a tag that differs by one bit, that is truncated, that is padded, or
+     * that is empty is refused, and none of them throws.
+     */
+    #[Test]
+    #[DataProvider('getVectors')]
+    public function aTamperedTagIsRefused(AesCbcMac $algorithm, string $k, string $data, string $tag): void
+    {
+        // Given
+        $key = self::symmetricKey($k);
+        $flipped = $tag;
+        $flipped[0] = chr(ord($flipped[0]) ^ 0x01);
+
+        // Then
+        static::assertFalse($algorithm->verify($data, $key, $flipped));
+        static::assertFalse($algorithm->verify($data, $key, substr($tag, 0, -1)));
+        static::assertFalse($algorithm->verify($data, $key, $tag . "\0"));
+        static::assertFalse($algorithm->verify($data, $key, ''));
+        static::assertFalse($algorithm->verify($data . "\x01", $key, $tag));
+    }
+
+    /**
+     * The 64-bit variant is the 128-bit tag truncated: RFC 9053, section 3.2 defines every identifier as the same
+     * construction with a different tag length.
+     */
+    #[Test]
+    public function theShortTagIsThePrefixOfTheLongOne(): void
+    {
+        // Given
+        $key128 = self::symmetricKey(self::FIPS_KEY_128);
+        $key256 = self::symmetricKey(self::FIPS_KEY_256);
+        $data = 'This is the content.';
+
+        // When
+        $long128 = AESMAC128_128::create()->hash($data, $key128);
+        $short128 = AESMAC128_64::create()->hash($data, $key128);
+        $long256 = AESMAC256_128::create()->hash($data, $key256);
+        $short256 = AESMAC256_64::create()->hash($data, $key256);
+
+        // Then
+        static::assertSame(16, strlen($long128));
+        static::assertSame(8, strlen($short128));
+        static::assertSame(substr($long128, 0, 8), $short128);
+        static::assertSame(16, strlen($long256));
+        static::assertSame(8, strlen($short256));
+        static::assertSame(substr($long256, 0, 8), $short256);
+        static::assertNotSame($long128, $long256);
+    }
+
+    /**
+     * The construction, checked against the block cipher alone: for two blocks P1 || P2 under a zero IV, CBC-MAC is
+     * AES(AES(P1) XOR P2), and a full block gets no padding.
+     */
+    #[Test]
+    #[DataProvider('getKeyedAlgorithms')]
+    public function theTagIsTheLastCbcBlock(AesCbcMac $algorithm, string $k): void
+    {
+        // Given
+        $key = self::symmetricKey($k);
+        $p1 = hex2bin(self::FIPS_BLOCK);
+        $p2 = str_repeat("\x2a", 16);
+        $cipher = 'aes-' . ($algorithm->keyLength() * 8) . '-ecb';
+        $aes = static fn (string $block): string => (string) openssl_encrypt(
+            $block,
+            $cipher,
+            hex2bin($k),
+            OPENSSL_RAW_DATA | OPENSSL_ZERO_PADDING
+        );
+
+        // When
+        $expected = $aes($aes($p1) ^ $p2);
+
+        // Then
+        static::assertSame(
+            bin2hex(substr($expected, 0, $algorithm->tagLength())),
+            bin2hex($algorithm->hash($p1 . $p2, $key))
+        );
+        static::assertSame(
+            bin2hex(substr($aes($p1), 0, $algorithm->tagLength())),
+            bin2hex($algorithm->hash($p1, $key)),
+            'a message of exactly one block is not padded'
+        );
+    }
+
+    /**
+     * ISO/IEC 9797-1 padding method 1 appends zero bytes and no length: a message and the same message followed by
+     * zero bytes up to the block boundary share a tag, and the empty message is one zero block. That is the
+     * weakness RFC 9053, section 3.2.1 warns about, and the reason a tag must be computed over a MAC_structure,
+     * which encodes the length of every field. The test pins the padding the cose-wg fixtures expect.
+     */
+    #[Test]
+    #[DataProvider('getKeyedAlgorithms')]
+    public function thePaddingIsZeroBytesWithoutALength(AesCbcMac $algorithm, string $k): void
+    {
+        // Given
+        $key = self::symmetricKey($k);
+        $short = substr(hex2bin(self::FIPS_BLOCK), 0, 15);
+
+        // Then
+        static::assertSame($algorithm->hash($short, $key), $algorithm->hash($short . "\0", $key));
+        static::assertSame($algorithm->hash('', $key), $algorithm->hash(str_repeat("\0", 16), $key));
+        static::assertNotSame($algorithm->hash($short, $key), $algorithm->hash($short . "\0\0", $key));
+    }
+
+    #[Test]
+    #[DataProvider('getAlgorithms')]
+    public function theKeyTypeIsInvalid(AesCbcMac $algorithm): void
+    {
+        // Then
+        static::expectException(InvalidArgumentException::class);
+        static::expectExceptionMessage('Invalid key. Must be of type symmetric');
+
+        // Given
+        $key = OkpKey::create([
+            OkpKey::TYPE => OkpKey::TYPE_OKP,
+            OkpKey::DATA_CURVE => OkpKey::CURVE_X25519,
+            OkpKey::DATA_X => str_repeat("\0", 32),
+        ]);
+
+        // When
+        $algorithm->hash('data', $key);
+    }
+
+    #[Test]
+    #[DataProvider('getAlgorithms')]
+    public function theKeyValueIsMissing(AesCbcMac $algorithm): void
+    {
+        // Then
+        static::expectException(InvalidArgumentException::class);
+        static::expectExceptionMessage('Invalid key. The value of the key is missing');
+
+        // Given
+        $key = Key::create([
+            Key::TYPE => Key::TYPE_OCT,
+        ]);
+
+        // When
+        $algorithm->hash('data', $key);
+    }
+
+    #[Test]
+    #[DataProvider('getInvalidKeyValues')]
+    public function theKeyValueIsNotAByteString(mixed $k): void
+    {
+        // Then
+        static::expectException(InvalidArgumentException::class);
+        static::expectExceptionMessage('Invalid key. The value of the key must be a byte string');
+
+        // Given
+        $key = Key::create([
+            Key::TYPE => Key::TYPE_OCT,
+            SymmetricKey::DATA_K => $k,
+        ]);
+
+        // When
+        AESMAC128_64::create()->hash('data', $key);
+    }
+
+    #[Test]
+    #[DataProvider('getAlgorithms')]
+    public function theKeyValueIsEmpty(AesCbcMac $algorithm): void
+    {
+        // Then
+        static::expectException(InvalidArgumentException::class);
+        static::expectExceptionMessage('Invalid key. The value of the key is empty');
+
+        // Given
+        $key = Key::create([
+            Key::TYPE => Key::TYPE_OCT,
+            SymmetricKey::DATA_K => '',
+        ]);
+
+        // When
+        $algorithm->verify('data', $key, str_repeat("\0", 8));
+    }
+
+    /**
+     * RFC 9053, section 3.2 ties the key length to the identifier: a key of any other length is refused, whether it
+     * is shorter, longer, or the length of the sibling identifier.
+     */
+    #[Test]
+    #[DataProvider('getWrongKeyLengths')]
+    public function aKeyOfTheWrongLengthIsRefused(AesCbcMac $algorithm, int $length, string $message): void
+    {
+        // Then
+        static::expectException(InvalidArgumentException::class);
+        static::expectExceptionMessage($message);
+
+        // Given
+        $key = self::symmetricKey(bin2hex(str_repeat("\x2a", $length)));
+
+        // When
+        $algorithm->hash('data', $key);
+    }
+
+    #[Test]
+    #[DataProvider('getWrongKeyLengths')]
+    public function theVerificationRefusesAKeyOfTheWrongLengthAsWell(
+        AesCbcMac $algorithm,
+        int $length,
+        string $message
+    ): void {
+        // Then
+        static::expectException(InvalidArgumentException::class);
+        static::expectExceptionMessage($message);
+
+        // Given
+        $key = self::symmetricKey(bin2hex(str_repeat("\x2a", $length)));
+
+        // When
+        $algorithm->verify('data', $key, str_repeat("\0", $algorithm->tagLength()));
+    }
+
+    /**
+     * A symmetric COSE_Key decoded from CBOR carries a numeric string as its key type; it reaches the algorithm
+     * through each of the three entry points a caller has.
+     */
+    #[Test]
+    #[DataProvider('getDecodedKeys')]
+    public function aKeyDecodedFromCborCanComputeAndVerifyATag(Key $key): void
+    {
+        // Given
+        $algorithm = AESMAC128_128::create();
+
+        // When
+        $tag = $algorithm->hash('This is the content.', $key);
+
+        // Then
+        static::assertTrue($algorithm->verify('This is the content.', $key, $tag));
+    }
+
+    /**
+     * @return iterable<string, array{0: AesCbcMac, 1: int, 2: int, 3: string}>
+     */
+    public static function getAlgorithms(): iterable
+    {
+        yield 'AES-MAC 128/64' => [AESMAC128_64::create(), 16, 8, 'AES-MAC 128/64'];
+        yield 'AES-MAC 256/64' => [AESMAC256_64::create(), 32, 8, 'AES-MAC 256/64'];
+        yield 'AES-MAC 128/128' => [AESMAC128_128::create(), 16, 16, 'AES-MAC 128/128'];
+        yield 'AES-MAC 256/128' => [AESMAC256_128::create(), 32, 16, 'AES-MAC 256/128'];
+    }
+
+    /**
+     * Each algorithm with a key of its length, as hex.
+     *
+     * @return iterable<string, array{0: AesCbcMac, 1: string}>
+     */
+    public static function getKeyedAlgorithms(): iterable
+    {
+        yield 'AES-MAC 128/64' => [AESMAC128_64::create(), self::FIPS_KEY_128];
+        yield 'AES-MAC 256/64' => [AESMAC256_64::create(), self::FIPS_KEY_256];
+        yield 'AES-MAC 128/128' => [AESMAC128_128::create(), self::FIPS_KEY_128];
+        yield 'AES-MAC 256/128' => [AESMAC256_128::create(), self::FIPS_KEY_256];
+    }
+
+    /**
+     * The key and data as hex, the tag as bytes.
+     *
+     * @return iterable<string, array{0: AesCbcMac, 1: string, 2: string, 3: string}>
+     */
+    public static function getVectors(): iterable
+    {
+        // FIPS 197 Appendix C.1 and C.3: the AES encryption of one block is the CBC-MAC of that block under a zero
+        // IV, and the 64-bit tag is its first half.
+        yield 'FIPS 197 C.1 with AES-MAC 128/128' => [
+            AESMAC128_128::create(),
+            self::FIPS_KEY_128,
+            hex2bin(self::FIPS_BLOCK),
+            hex2bin('69c4e0d86a7b0430d8cdb78070b4c55a'),
+        ];
+        yield 'FIPS 197 C.1 with AES-MAC 128/64' => [
+            AESMAC128_64::create(),
+            self::FIPS_KEY_128,
+            hex2bin(self::FIPS_BLOCK),
+            hex2bin('69c4e0d86a7b0430'),
+        ];
+        yield 'FIPS 197 C.3 with AES-MAC 256/128' => [
+            AESMAC256_128::create(),
+            self::FIPS_KEY_256,
+            hex2bin(self::FIPS_BLOCK),
+            hex2bin('8ea2b7ca516745bfeafc49904b496089'),
+        ];
+        yield 'FIPS 197 C.3 with AES-MAC 256/64' => [
+            AESMAC256_64::create(),
+            self::FIPS_KEY_256,
+            hex2bin(self::FIPS_BLOCK),
+            hex2bin('8ea2b7ca516745bf'),
+        ];
+
+        // cose-wg/Examples cbc-mac-examples: the ToMac intermediate, the CEK and the tag of each fixture. The
+        // messages of cbc-mac-01 and cbc-mac-03 are 31 bytes long and padded to 32; those of cbc-mac-enc-02 and
+        // cbc-mac-enc-04 are 33 bytes long and padded to 48; the four others are 32 bytes long and not padded.
+        $cek128 = '849b57219dae48de646d07dbb533566e';
+        $cek256 = '849b57219dae48de646d07dbb533566e976686457c1491be3a76dcea6c427188';
+        $macStructure = static fn (int $identifier): string => hex2bin(
+            '84634d4143' . ($identifier < 24 ? '43a1010' . dechex($identifier) : '44a10118' . dechex($identifier))
+            . '4054546869732069732074686520636f6e74656e742e'
+        );
+        $mac0Structure = static fn (int $identifier): string => hex2bin(
+            '84644d414330' . ($identifier < 24 ? '43a1010' . dechex($identifier) : '44a10118' . dechex($identifier))
+            . '4054546869732069732074686520636f6e74656e742e'
+        );
+        yield 'cbc-mac-01: AES-MAC 128/64 over a 31-byte MAC_structure' => [
+            AESMAC128_64::create(),
+            $cek128,
+            $macStructure(14),
+            hex2bin('c1ca820e6e247089'),
+        ];
+        yield 'cbc-mac-02: AES-MAC 128/128 over a 32-byte MAC_structure' => [
+            AESMAC128_128::create(),
+            $cek128,
+            $macStructure(25),
+            hex2bin('b242d2a935feb4d66ff8334ac95bf72b'),
+        ];
+        yield 'cbc-mac-03: AES-MAC 256/64 over a 31-byte MAC_structure' => [
+            AESMAC256_64::create(),
+            $cek256,
+            $macStructure(15),
+            hex2bin('9e1226ba1f81b848'),
+        ];
+        yield 'cbc-mac-04: AES-MAC 256/128 over a 32-byte MAC_structure' => [
+            AESMAC256_128::create(),
+            $cek256,
+            $macStructure(26),
+            hex2bin('db9c7598a0751c5ff3366b6205bd2aa9'),
+        ];
+        yield 'cbc-mac-enc-01: AES-MAC 128/64 over a 32-byte MAC0 structure' => [
+            AESMAC128_64::create(),
+            $cek128,
+            $mac0Structure(14),
+            hex2bin('8584dbf007fdc69f'),
+        ];
+        yield 'cbc-mac-enc-02: AES-MAC 128/128 over a 33-byte MAC0 structure' => [
+            AESMAC128_128::create(),
+            $cek128,
+            $mac0Structure(25),
+            hex2bin('f0c295e78f3091e95513fa0427adbe25'),
+        ];
+        yield 'cbc-mac-enc-03: AES-MAC 256/64 over a 32-byte MAC0 structure' => [
+            AESMAC256_64::create(),
+            $cek256,
+            $mac0Structure(15),
+            hex2bin('726043745027214f'),
+        ];
+        yield 'cbc-mac-enc-04: AES-MAC 256/128 over a 33-byte MAC0 structure' => [
+            AESMAC256_128::create(),
+            $cek256,
+            $mac0Structure(26),
+            hex2bin('403152cc208c1d501e1dc2a789ae49e4'),
+        ];
+    }
+
+    /**
+     * @return iterable<string, array{0: AesCbcMac, 1: int, 2: string}>
+     */
+    public static function getWrongKeyLengths(): iterable
+    {
+        yield 'AES-MAC 128/64 with a 15-byte key' => [
+            AESMAC128_64::create(),
+            15,
+            'Invalid key. AES-MAC 128/64 requires a 16-byte key, 15 bytes given',
+        ];
+        yield 'AES-MAC 128/64 with a 17-byte key' => [
+            AESMAC128_64::create(),
+            17,
+            'Invalid key. AES-MAC 128/64 requires a 16-byte key, 17 bytes given',
+        ];
+        yield 'AES-MAC 128/64 with the 32-byte key of AES-MAC 256/64' => [
+            AESMAC128_64::create(),
+            32,
+            'Invalid key. AES-MAC 128/64 requires a 16-byte key, 32 bytes given',
+        ];
+        yield 'AES-MAC 128/128 with a 24-byte key' => [
+            AESMAC128_128::create(),
+            24,
+            'Invalid key. AES-MAC 128/128 requires a 16-byte key, 24 bytes given',
+        ];
+        yield 'AES-MAC 256/64 with the 16-byte key of AES-MAC 128/64' => [
+            AESMAC256_64::create(),
+            16,
+            'Invalid key. AES-MAC 256/64 requires a 32-byte key, 16 bytes given',
+        ];
+        yield 'AES-MAC 256/128 with a 31-byte key' => [
+            AESMAC256_128::create(),
+            31,
+            'Invalid key. AES-MAC 256/128 requires a 32-byte key, 31 bytes given',
+        ];
+        yield 'AES-MAC 256/128 with a 33-byte key' => [
+            AESMAC256_128::create(),
+            33,
+            'Invalid key. AES-MAC 256/128 requires a 32-byte key, 33 bytes given',
+        ];
+    }
+
+    /**
+     * @return iterable<string, array{0: mixed}>
+     */
+    public static function getInvalidKeyValues(): iterable
+    {
+        yield 'null' => [null];
+        yield 'array' => [[
+            'k' => str_repeat("\x2a", 16),
+        ]];
+        yield 'integer' => [123];
+        yield 'false' => [false];
+        yield 'true' => [true];
+        yield 'float' => [1.5];
+        yield 'CBOR object' => [ByteStringObject::create(str_repeat("\x2a", 16))];
+    }
+
+    /**
+     * The CBOR map {1: 4, -1: k}, as spomky-labs/cbor-php normalises it, through each of the entry points.
+     *
+     * @return iterable<string, array{0: Key}>
+     */
+    public static function getDecodedKeys(): iterable
+    {
+        $k = hex2bin(self::FIPS_KEY_128);
+        $decoded = (new Decoder(new TagManager(), new OtherObjectManager()))
+            ->decode(new StringStream("\xa2\x01\x04\x20\x50" . $k))
+            ->normalize();
+
+        yield 'through Key::createFromData()' => [Key::createFromData($decoded)];
+        yield 'through SymmetricKey::create()' => [SymmetricKey::create($decoded)];
+        yield 'through the generic Key::create()' => [Key::create($decoded)];
+    }
+
+    private static function symmetricKey(string $hex): SymmetricKey
+    {
+        return SymmetricKey::create([
+            SymmetricKey::TYPE => SymmetricKey::TYPE_OCT,
+            SymmetricKey::DATA_K => hex2bin($hex),
+        ]);
+    }
+}

--- a/tests/CoseWg/CoseWgAlgorithms.php
+++ b/tests/CoseWg/CoseWgAlgorithms.php
@@ -5,6 +5,10 @@ declare(strict_types=1);
 namespace Cose\Tests\CoseWg;
 
 use function array_search;
+use Cose\Algorithm\Mac\AESMAC128_128;
+use Cose\Algorithm\Mac\AESMAC128_64;
+use Cose\Algorithm\Mac\AESMAC256_128;
+use Cose\Algorithm\Mac\AESMAC256_64;
 use Cose\Algorithm\Mac\HS256;
 use Cose\Algorithm\Mac\HS256Truncated64;
 use Cose\Algorithm\Mac\HS384;
@@ -167,6 +171,10 @@ final class CoseWgAlgorithms
             HS256::create(),
             HS384::create(),
             HS512::create(),
+            AESMAC128_64::create(),
+            AESMAC256_64::create(),
+            AESMAC128_128::create(),
+            AESMAC256_128::create(),
         );
         if (Ed448::isSupported()) {
             $manager->add(Ed448::create());


### PR DESCRIPTION
Closes #200. Part of #202.

The four AES-MAC identifiers of RFC 9053 §3.2 — `AES-MAC 128/64` (14), `256/64` (15), `128/128` (25), `256/128` (26) — get an implementation. They were constants in `Algorithms` without a class; the `Mac` interface, the key-restriction machinery and the cose-wg harness are all reused as they are.

## What changed

**1. `Cose\Algorithm\Mac\AesCbcMac`** (abstract base) and the four final classes `AESMAC128_64`, `AESMAC256_64`, `AESMAC128_128`, `AESMAC256_128`, each with `ID`, `create()` and `identifier()` like the HMAC siblings.

- The construction is what §3.2 says and not more: "the instantiation of the CBC-MAC construction (defined in [MAC]) using AES as the block cipher", "with the IV fixed to all zeros", i.e. `openssl_encrypt('aes-{128,256}-cbc', OPENSSL_RAW_DATA | OPENSSL_ZERO_PADDING, iv: 16 zero bytes)`, last block kept, truncated to 8 or 16 bytes. Not AES-CMAC, and the docblock says so.
- Padding: RFC 9053 delegates to ISO/IEC 9797-1 without restating the method. The `cbc-mac-examples/` vectors use **padding method 1** (zero bytes to the block boundary, none when already aligned, one zero block for the empty message) — confirmed on all 8 fixtures: the 31-byte and 33-byte `ToMac` intermediates are padded, the 32-byte ones are not, and every tag reproduces.
- Key checks (§3.2 "MUST validate that the key type, key length, and algorithm are correct"): `kty` symmetric, `k` present / byte string / non-empty (same messages as `Hmac`), then **exactly** 16 or 32 bytes — `Invalid key. AES-MAC 128/64 requires a 16-byte key, 32 bytes given` — all before any OpenSSL call. `alg` / `key_ops` (`MAC create` on `hash()`, `MAC verify` on `verify()`) go through `KeyRestrictionEnforcement`, opt-in like everywhere else.
- `verify()` compares with `hash_equals()`.
- Public accessors `keyLength()` (16 / 32), `tagLength()` (8 / 16) and `name()` (`AES-MAC 256/64`, for messages). No acknowledgement flag: all four are *Recommended: Yes* at IANA, as #200 asks.

**2. The cose-wg harness** — `CoseWgAlgorithms::manager()` registers the four classes. The 8 `cbc-mac-examples/` fixtures (4 × `COSE_Mac`, 4 × `COSE_Mac0`) turn from skipped into run: the `MAC_structure` is rebuilt byte for byte, the tag verifies, and `hash()` reproduces the fixture tag. (#200 names `mac-tests/` and `mac0-tests/`; upstream keeps the AES-MAC vectors in `cbc-mac-examples/`, which is what the fixtures README already lists.)

**3. Documentation** — `README.md` (feature list, MAC table, a usage snippet, a warning block with the two §3.2.1 conditions and the padding, "The AES-CBC-MAC Key"), `doc/Usage.md` (MAC algorithms with RFC references, the same warning, the key-length rule under "Validating Symmetric Keys", §3.2 added to the key-restriction paragraph), `examples/03-mac0.php` (a second half under AES-MAC 256/64 that *shows* the §3.2.1 weakness: over bare bytes, a payload and the same payload with a trailing NUL share a tag; over the `MAC_structure` they do not), `RELEASES.md` (4.8.x → 4.9.x, "New: the AES-CBC-MAC algorithms").

The two §3.2.1 conditions are in the README and Usage.md prose, not in a footnote: a single key for messages of fixed or known length (the `MAC_structure` is the mitigation, because CBOR encodes every length), and never the key of a CBC encryption.

## Compatibility

Purely additive: five new classes, one docblock touch in `SymmetricKeyValidator`. No existing class, method, constant or message changes. No new dependency (`ext-openssl` is already required).

## Tests

1735 → 1831 tests; green on PHP 8.2 (lowest deps), 8.4 and 8.5. ECS, Rector, PHPStan (level max, no new baseline entry), Deptrac, parallel-lint, `--strict-psr` and `composer validate --strict` clean.

- `tests/Algorithm/Mac/AesCbcMacTest.php` (86 tests):
  - identifiers 14 / 15 / 25 / 26 against `Algorithms`, key and tag lengths, names;
  - **FIPS 197 Appendix C.1 and C.3** — the AES encryption of one block *is* the CBC-MAC of that block under a zero IV, so `69c4e0d8…` and `8ea2b7ca…` are the tags, and their first 8 bytes the 64-bit ones;
  - the 8 cose-wg vectors on the primitive alone (`ToMac_hex`, `CEK_hex`, tag), so a primitive failure is reported by the primitive's test;
  - the construction against `aes-*-ecb`: two blocks give `AES(AES(P1) ⊕ P2)`, one block is not padded;
  - padding method 1 pinned: `m` and `m‖0x00` share a tag below the boundary, `''` equals one zero block, two extra NULs across the boundary do not;
  - `hash_equals()` path: a flipped bit, a truncated, a padded and an empty tag are refused, none throws;
  - 64-bit tag is the prefix of the 128-bit one;
  - key type, missing / non-string (7 shapes) / empty `k`; wrong length on both `hash()` and `verify()` (15, 17, 24, 31, 33 bytes, and the sibling's length);
  - a key decoded from CBOR (numeric-string `kty`) through the three entry points.
- `KeyRestrictionEnforcementTest`: 6 AES-MAC cases (restricted to the sibling identifier, restricted to HS256, `MAC verify`-only key creating, `MAC create`-only key verifying, and the allowed counterparts).
- `CoseWgFixtureTest`: the 8 `cbc-mac-examples/` fixtures now run (16 cases with the wire check).
- `ExamplesTest` runs the extended `03-mac0.php`.

## Not in this PR

- `direct+HKDF-AES-128/256` (-12, -13) use AES-MAC 128/128 and 256/128 as the PRF — that is #201, which now has its primitive.
- The insecure-algorithm acknowledgement pattern is untouched: none of the four identifiers is *Deprecated* or *Filter Only*.
