### PR TITLE
docs: declare RFC 8230 and RFC 8812 coverage and reference the defining RFC in every table (#193)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,15 @@
 
 This library implements:
 - **[RFC 9052](https://datatracker.ietf.org/doc/html/rfc9052)** - COSE: Structures and Process
-- **[RFC 9053](https://datatracker.ietf.org/doc/html/rfc9053)** - COSE: Initial Algorithms
+- **[RFC 9053](https://datatracker.ietf.org/doc/html/rfc9053)** - COSE: Initial Algorithms (signatures, HMAC and the
+  key types)
+- **[RFC 8230](https://datatracker.ietf.org/doc/html/rfc8230)** - RSASSA-PSS (PS256, PS384, PS512) and the RSA key type
+- **[RFC 8812](https://datatracker.ietf.org/doc/html/rfc8812)** - RSASSA-PKCS1-v1_5 (RS256, RS384, RS512, RS1) and
+  ECDSA with secp256k1 (ES256K)
 - **[RFC 9864](https://www.rfc-editor.org/rfc/rfc9864.html)** - COSE: Fully-Specified Algorithms
+
+Every algorithm and key type table below carries a *Reference* column naming the RFC and the section that define the
+row, so that a shipped identifier can be traced to its specification without leaving this page.
 
 ## Features
 
@@ -202,6 +209,11 @@ $encoded = (string) $coseSign1;
 - **[Usage Guide](doc/Usage.md)** - Complete documentation with examples
 - **[RFC 9052](https://datatracker.ietf.org/doc/html/rfc9052)** - COSE Structures
 - **[RFC 9053](https://datatracker.ietf.org/doc/html/rfc9053)** - COSE Algorithms
+- **[RFC 8230](https://datatracker.ietf.org/doc/html/rfc8230)** - RSASSA-PSS and RSA keys for COSE
+- **[RFC 8812](https://datatracker.ietf.org/doc/html/rfc8812)** - RSASSA-PKCS1-v1_5 and secp256k1 for COSE
+- **[RFC 9864](https://www.rfc-editor.org/rfc/rfc9864.html)** - Fully-Specified Algorithms
+- **[IANA COSE Registry](https://www.iana.org/assignments/cose/cose.xhtml)** - The algorithm, key type and curve
+  registries every identifier of this library is checked against
 
 ## Use Cases
 
@@ -217,40 +229,44 @@ This library is perfect for:
 
 ### Signature Algorithms
 
-| Algorithm | Identifier | Description |
-|-----------|------------|-------------|
-| ES256 | -7 | ECDSA with SHA-256 |
-| ES384 | -35 | ECDSA with SHA-384 |
-| ES512 | -36 | ECDSA with SHA-512 |
-| ES256K | -47 | ECDSA with secp256k1 |
-| EdDSA | -8 | EdDSA |
-| Ed25519 | -8 | Alias of EdDSA (Curve25519); see -19 below for the fully-specified form |
-| Ed256 | -260 | Ed25519 over a SHA-256 digest — non-standard, see below |
-| Ed512 | -261 | Ed25519 over a SHA-512 digest — non-standard, see below |
-| RS256 | -257 | RSASSA-PKCS1-v1_5 with SHA-256 |
-| RS384 | -258 | RSASSA-PKCS1-v1_5 with SHA-384 |
-| RS512 | -259 | RSASSA-PKCS1-v1_5 with SHA-512 |
-| PS256 | -37 | RSASSA-PSS with SHA-256 |
-| PS384 | -38 | RSASSA-PSS with SHA-384 |
-| PS512 | -39 | RSASSA-PSS with SHA-512 |
-| RS1 | -65535 | RSASSA-PKCS1-v1_5 with SHA-1 — legacy only, see below |
+| Algorithm | Identifier | Description | Reference |
+|-----------|------------|-------------|-----------|
+| ES256 | -7 | ECDSA with SHA-256 | [RFC 9053 §2.1](https://www.rfc-editor.org/rfc/rfc9053#section-2.1) |
+| ES384 | -35 | ECDSA with SHA-384 | [RFC 9053 §2.1](https://www.rfc-editor.org/rfc/rfc9053#section-2.1) |
+| ES512 | -36 | ECDSA with SHA-512 | [RFC 9053 §2.1](https://www.rfc-editor.org/rfc/rfc9053#section-2.1) |
+| ES256K | -47 | ECDSA with secp256k1 | [RFC 8812 §3.2](https://www.rfc-editor.org/rfc/rfc8812#section-3.2) |
+| EdDSA | -8 | EdDSA | [RFC 9053 §2.2](https://www.rfc-editor.org/rfc/rfc9053#section-2.2) |
+| Ed25519 | -8 | Alias of EdDSA (Curve25519); see -19 below for the fully-specified form | [RFC 9053 §2.2](https://www.rfc-editor.org/rfc/rfc9053#section-2.2) |
+| Ed256 | -260 | Ed25519 over a SHA-256 digest — non-standard, see below | — |
+| Ed512 | -261 | Ed25519 over a SHA-512 digest — non-standard, see below | — |
+| RS256 | -257 | RSASSA-PKCS1-v1_5 with SHA-256 | [RFC 8812 §2](https://www.rfc-editor.org/rfc/rfc8812#section-2) |
+| RS384 | -258 | RSASSA-PKCS1-v1_5 with SHA-384 | [RFC 8812 §2](https://www.rfc-editor.org/rfc/rfc8812#section-2) |
+| RS512 | -259 | RSASSA-PKCS1-v1_5 with SHA-512 | [RFC 8812 §2](https://www.rfc-editor.org/rfc/rfc8812#section-2) |
+| PS256 | -37 | RSASSA-PSS with SHA-256 | [RFC 8230 §2](https://www.rfc-editor.org/rfc/rfc8230#section-2) |
+| PS384 | -38 | RSASSA-PSS with SHA-384 | [RFC 8230 §2](https://www.rfc-editor.org/rfc/rfc8230#section-2) |
+| PS512 | -39 | RSASSA-PSS with SHA-512 | [RFC 8230 §2](https://www.rfc-editor.org/rfc/rfc8230#section-2) |
+| RS1 | -65535 | RSASSA-PKCS1-v1_5 with SHA-1 — legacy only, see below | [RFC 8812 §2](https://www.rfc-editor.org/rfc/rfc8812#section-2) |
+
+The IANA registry marks ES256, ES384, ES512 and EdDSA *Deprecated* since RFC 9864, in favour of the fully-specified
+identifiers below. They stay first-class here: WebAuthn still requires ES256 and EdDSA, and no acknowledgement is
+asked for them. Ed256 and Ed512 are defined by no specification, hence the empty reference; see the warning below.
 
 #### Fully-Specified Algorithms ([RFC 9864](https://www.rfc-editor.org/rfc/rfc9864.html))
 
 These identifiers determine the curve and the hash on their own, instead of leaving them to the other parameters of
 the key. They live in the `Cose\Algorithm\Signature\FullySpecified` namespace.
 
-| Algorithm | Identifier | Description |
-|-----------|------------|-------------|
-| ESP256 | -9 | ECDSA with the P-256 curve and SHA-256 |
-| ESP384 | -51 | ECDSA with the P-384 curve and SHA-384 |
-| ESP512 | -52 | ECDSA with the P-521 curve and SHA-512 |
-| ESB256 | -265 | ECDSA with the brainpoolP256r1 curve and SHA-256 |
-| ESB320 | -266 | ECDSA with the brainpoolP320r1 curve and SHA-384 |
-| ESB384 | -267 | ECDSA with the brainpoolP384r1 curve and SHA-384 |
-| ESB512 | -268 | ECDSA with the brainpoolP512r1 curve and SHA-512 |
-| Ed25519 | -19 | EdDSA with the Ed25519 parameter set |
-| Ed448 | -53 | EdDSA with the Ed448 parameter set — requires PHP 8.4 or later |
+| Algorithm | Identifier | Description | Reference |
+|-----------|------------|-------------|-----------|
+| ESP256 | -9 | ECDSA with the P-256 curve and SHA-256 | [RFC 9864 §2.1](https://www.rfc-editor.org/rfc/rfc9864#section-2.1) |
+| ESP384 | -51 | ECDSA with the P-384 curve and SHA-384 | [RFC 9864 §2.1](https://www.rfc-editor.org/rfc/rfc9864#section-2.1) |
+| ESP512 | -52 | ECDSA with the P-521 curve and SHA-512 | [RFC 9864 §2.1](https://www.rfc-editor.org/rfc/rfc9864#section-2.1) |
+| ESB256 | -265 | ECDSA with the brainpoolP256r1 curve and SHA-256 | [RFC 9864 §2.1](https://www.rfc-editor.org/rfc/rfc9864#section-2.1) |
+| ESB320 | -266 | ECDSA with the brainpoolP320r1 curve and SHA-384 | [RFC 9864 §2.1](https://www.rfc-editor.org/rfc/rfc9864#section-2.1) |
+| ESB384 | -267 | ECDSA with the brainpoolP384r1 curve and SHA-384 | [RFC 9864 §2.1](https://www.rfc-editor.org/rfc/rfc9864#section-2.1) |
+| ESB512 | -268 | ECDSA with the brainpoolP512r1 curve and SHA-512 | [RFC 9864 §2.1](https://www.rfc-editor.org/rfc/rfc9864#section-2.1) |
+| Ed25519 | -19 | EdDSA with the Ed25519 parameter set | [RFC 9864 §2.2](https://www.rfc-editor.org/rfc/rfc9864#section-2.2) |
+| Ed448 | -53 | EdDSA with the Ed448 parameter set — requires PHP 8.4 or later | [RFC 9864 §2.2](https://www.rfc-editor.org/rfc/rfc9864#section-2.2) |
 
 > [!NOTE]
 > `Cose\Algorithm\Signature\FullySpecified\Ed25519` (-19) and `Cose\Algorithm\Signature\EdDSA\Ed25519` (-8)
@@ -304,12 +320,12 @@ the key. They live in the `Cose\Algorithm\Signature\FullySpecified` namespace.
 
 ### MAC Algorithms
 
-| Algorithm | Identifier | Description |
-|-----------|------------|-------------|
-| HS256 | 5 | HMAC with SHA-256 |
-| HS384 | 6 | HMAC with SHA-384 |
-| HS512 | 7 | HMAC with SHA-512 |
-| HS256/64 | 4 | HMAC with SHA-256 truncated to 64 bits |
+| Algorithm | Identifier | Description | Reference |
+|-----------|------------|-------------|-----------|
+| HS256 | 5 | HMAC with SHA-256 (IANA name `HMAC 256/256`) | [RFC 9053 §3.1](https://www.rfc-editor.org/rfc/rfc9053#section-3.1) |
+| HS384 | 6 | HMAC with SHA-384 (`HMAC 384/384`) | [RFC 9053 §3.1](https://www.rfc-editor.org/rfc/rfc9053#section-3.1) |
+| HS512 | 7 | HMAC with SHA-512 (`HMAC 512/512`) | [RFC 9053 §3.1](https://www.rfc-editor.org/rfc/rfc9053#section-3.1) |
+| HS256/64 | 4 | HMAC with SHA-256 truncated to 64 bits (`HMAC 256/64`) | [RFC 9053 §3.1](https://www.rfc-editor.org/rfc/rfc9053#section-3.1) |
 
 #### The HMAC Key
 
@@ -350,6 +366,41 @@ if (! SymmetricKeyValidator::create()->isValid($key)) {
     // reject the key
 }
 ```
+
+### Key Types
+
+The `Cose\Key` classes cover the four key types of the IANA
+[COSE Key Types](https://www.iana.org/assignments/cose/cose.xhtml#key-type) registry that the algorithms above use.
+`Key::createFromData()` picks the class from `kty` (label 1); the parameter labels are the `DATA_*` constants of each
+class.
+
+| Key type | `kty` | Class | Parameters | Reference |
+|----------|-------|-------|------------|-----------|
+| OKP | 1 | `Cose\Key\OkpKey` | `crv` (-1), `x` (-2), `d` (-4) | [RFC 9053 §7.2](https://www.rfc-editor.org/rfc/rfc9053#section-7.2) |
+| EC2 | 2 | `Cose\Key\Ec2Key` | `crv` (-1), `x` (-2), `y` (-3), `d` (-4) | [RFC 9053 §7.1.1](https://www.rfc-editor.org/rfc/rfc9053#section-7.1.1) |
+| RSA | 3 | `Cose\Key\RsaKey` | `n` (-1), `e` (-2), `d` (-3), `p` (-4), `q` (-5), `dP` (-6), `dQ` (-7), `qInv` (-8), `other` (-9), `r_i` (-10), `d_i` (-11), `t_i` (-12) | [RFC 8230 §4](https://www.rfc-editor.org/rfc/rfc8230#section-4) |
+| Symmetric | 4 | `Cose\Key\SymmetricKey` | `k` (-1) | [RFC 9053 §7.3](https://www.rfc-editor.org/rfc/rfc9053#section-7.3) |
+
+The curves an `OkpKey` or an `Ec2Key` may carry in `crv`, with the `CURVE_*` constant naming each value:
+
+| Curve | `crv` | Key type | Constant | Reference |
+|-------|-------|----------|----------|-----------|
+| P-256 | 1 | EC2 | `Ec2Key::CURVE_P256` | [RFC 9053 §7.1](https://www.rfc-editor.org/rfc/rfc9053#section-7.1) |
+| P-384 | 2 | EC2 | `Ec2Key::CURVE_P384` | [RFC 9053 §7.1](https://www.rfc-editor.org/rfc/rfc9053#section-7.1) |
+| P-521 | 3 | EC2 | `Ec2Key::CURVE_P521` | [RFC 9053 §7.1](https://www.rfc-editor.org/rfc/rfc9053#section-7.1) |
+| X25519 | 4 | OKP | `OkpKey::CURVE_X25519` | [RFC 9053 §7.1](https://www.rfc-editor.org/rfc/rfc9053#section-7.1) |
+| X448 | 5 | OKP | `OkpKey::CURVE_X448` | [RFC 9053 §7.1](https://www.rfc-editor.org/rfc/rfc9053#section-7.1) |
+| Ed25519 | 6 | OKP | `OkpKey::CURVE_ED25519` | [RFC 9053 §7.1](https://www.rfc-editor.org/rfc/rfc9053#section-7.1) |
+| Ed448 | 7 | OKP | `OkpKey::CURVE_ED448` | [RFC 9053 §7.1](https://www.rfc-editor.org/rfc/rfc9053#section-7.1) |
+| secp256k1 | 8 | EC2 | `Ec2Key::CURVE_P256K` | [RFC 8812 §4.2](https://www.rfc-editor.org/rfc/rfc8812#section-4.2) |
+| brainpoolP256r1 | 256 | EC2 | `Ec2Key::CURVE_BP256` | [ISO/IEC 18013-5:2021 §9.1.5.2](https://www.iana.org/assignments/cose/cose.xhtml#elliptic-curves) |
+| brainpoolP320r1 | 257 | EC2 | `Ec2Key::CURVE_BP320` | [ISO/IEC 18013-5:2021 §9.1.5.2](https://www.iana.org/assignments/cose/cose.xhtml#elliptic-curves) |
+| brainpoolP384r1 | 258 | EC2 | `Ec2Key::CURVE_BP384` | [ISO/IEC 18013-5:2021 §9.1.5.2](https://www.iana.org/assignments/cose/cose.xhtml#elliptic-curves) |
+| brainpoolP512r1 | 259 | EC2 | `Ec2Key::CURVE_BP512` | [ISO/IEC 18013-5:2021 §9.1.5.2](https://www.iana.org/assignments/cose/cose.xhtml#elliptic-curves) |
+
+X25519 and X448 are registered "for use w/ ECDH only": an `OkpKey` accepts them, but no algorithm of this library
+uses them yet. The brainpool curves are registered at IANA by ISO/IEC 18013-5 rather than by an RFC; the link goes to
+the registry entry.
 
 ## Signature Verification Contract
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -42,6 +42,11 @@ with the missing identifier. Two behaviours changed on the way, both additive:
   `Symmetric`; only the JOSE spellings `EC` and `oct` were accepted. `Key::TYPE_NAME_EC2_IANA` and
   `Key::TYPE_NAME_OCT_IANA` name the new forms, `Key::createFromData()` dispatches them, and the new
   `Key::typeIs(Key::TYPE_*)` answers for every form of a key type. `Key::type()` still returns the form supplied.
+- **The documentation names every RFC the library implements.** RFC 8230 (RSASSA-PSS, RSA keys) and RFC 8812
+  (RSASSA-PKCS1-v1_5, secp256k1) join RFC 9052, RFC 9053 and RFC 9864 in the README and in `doc/Usage.md`; every
+  algorithm, key type and curve table carries a *Reference* column pointing at the defining section, and
+  `tests/RfcReferencesTest.php` keeps those tables in step with the classes and with the IANA registry. The
+  `keywords` of `composer.json` replace the obsolete `RFC8152` with the five RFCs implemented. No code changed.
 
 ### 4.7.x to 4.8.x
 

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,12 @@
     "type": "library",
     "keywords": [
         "COSE",
-        "RFC8152"
+        "CBOR",
+        "RFC9052",
+        "RFC9053",
+        "RFC8230",
+        "RFC8812",
+        "RFC9864"
     ],
     "authors": [
         {

--- a/doc/Usage.md
+++ b/doc/Usage.md
@@ -1,6 +1,6 @@
 # How to Use COSE Library
 
-This library implements COSE (CBOR Object Signing and Encryption) as defined in [RFC 9052](https://datatracker.ietf.org/doc/html/rfc9052) and [RFC 9053](https://datatracker.ietf.org/doc/html/rfc9053): the COSE key types, the signature and MAC algorithms, the cryptographic structures a signature or a MAC is computed over, and the header rules that decide what a message says.
+This library implements COSE (CBOR Object Signing and Encryption) as defined in [RFC 9052](https://datatracker.ietf.org/doc/html/rfc9052) and [RFC 9053](https://datatracker.ietf.org/doc/html/rfc9053): the COSE key types, the signature and MAC algorithms, the cryptographic structures a signature or a MAC is computed over, and the header rules that decide what a message says. It also implements the algorithms and the key type that [RFC 8230](https://datatracker.ietf.org/doc/html/rfc8230) (RSASSA-PSS, RSA keys), [RFC 8812](https://datatracker.ietf.org/doc/html/rfc8812) (RSASSA-PKCS1-v1_5, secp256k1) and [RFC 9864](https://www.rfc-editor.org/rfc/rfc9864.html) (fully-specified identifiers) add to COSE. Every algorithm and key type table of this guide carries a *Reference* column naming the RFC and the section that define the row.
 
 The six COSE message types themselves come from [spomky-labs/cbor-php](https://github.com/Spomky-Labs/cbor-php) 3.4.0 or later, as `CBOR\Tag\CoseSign1Tag` and its siblings. The `Cose\...Tag` classes this library used to ship are deprecated since 4.8.0 and removed in 5.0.0 — see [Upgrading from the Cose\...Tag classes](#upgrading-from-the-cosetag-classes).
 
@@ -29,6 +29,7 @@ Content encryption itself is not implemented: the encryption tags carry a cipher
   - [Fully-Specified Algorithms](#fully-specified-algorithms)
   - [Signature Verification Contract](#signature-verification-contract)
   - [Key Restrictions (alg and key_ops)](#key-restrictions-alg-and-key_ops)
+  - [Key Types](#key-types)
   - [Ed25519 Private Keys](#ed25519-private-keys)
   - [Key Parameter Forms](#key-parameter-forms)
   - [Validating RSA Keys](#validating-rsa-keys)
@@ -649,29 +650,47 @@ replacement and the reverse. What the migration has to handle:
 
 ### Signature Algorithms
 
-- **ECDSA**
-  - ES256 (-7): ECDSA with SHA-256
-  - ES384 (-35): ECDSA with SHA-384
-  - ES512 (-36): ECDSA with SHA-512
-  - ES256K (-47): ECDSA with secp256k1 curve
+The *Reference* column names the section of the RFC that defines the identifier; every value was checked against
+the IANA [COSE Algorithms](https://www.iana.org/assignments/cose/cose.xhtml#algorithms) registry.
 
-- **EdDSA** (`Cose\Algorithm\Signature\EdDSA`) — Ed25519 keys only, whatever the class
-  - EdDSA (-8): Edwards-curve Digital Signature Algorithm. The IANA COSE Algorithms registry marks -8 deprecated in
-    favour of the fully-specified Ed25519 (-19) and Ed448 (-53) below
-  - Ed25519 (-8): the same algorithm under its own class name; identical signatures, identical identifier
-  - Ed256 (-260) and Ed512 (-261): **non-standard**. They sign a SHA-256 or SHA-512 digest of the message with
-    Ed25519. They are not EdDSA identifiers and are registered nowhere — IANA assigns -260 to WalnutDSA and -261 to
-    TurboSHAKE128 — and neither of them supports Curve448. Kept for the authenticators that already produce them, and
-    only against an explicit acknowledgement (see below); EdDSA with Curve448 is `FullySpecified\Ed448` (-53)
+**ECDSA** (`Cose\Algorithm\Signature\ECDSA`)
 
-- **RSA**
-  - RS256 (-257): RSASSA-PKCS1-v1_5 with SHA-256
-  - RS384 (-258): RSASSA-PKCS1-v1_5 with SHA-384
-  - RS512 (-259): RSASSA-PKCS1-v1_5 with SHA-512
-  - PS256 (-37): RSASSA-PSS with SHA-256
-  - PS384 (-38): RSASSA-PSS with SHA-384
-  - PS512 (-39): RSASSA-PSS with SHA-512
-  - RS1 (-65535): RSASSA-PKCS1-v1_5 with SHA-1 — **not secure**, kept only for legacy authenticators
+| Algorithm | Identifier | Description | Reference |
+|-----------|------------|-------------|-----------|
+| ES256 | -7 | ECDSA with SHA-256 | [RFC 9053 §2.1](https://www.rfc-editor.org/rfc/rfc9053#section-2.1) |
+| ES384 | -35 | ECDSA with SHA-384 | [RFC 9053 §2.1](https://www.rfc-editor.org/rfc/rfc9053#section-2.1) |
+| ES512 | -36 | ECDSA with SHA-512 | [RFC 9053 §2.1](https://www.rfc-editor.org/rfc/rfc9053#section-2.1) |
+| ES256K | -47 | ECDSA with the secp256k1 curve and SHA-256 | [RFC 8812 §3.2](https://www.rfc-editor.org/rfc/rfc8812#section-3.2) |
+
+**EdDSA** (`Cose\Algorithm\Signature\EdDSA`) — Ed25519 keys only, whatever the class
+
+| Algorithm | Identifier | Description | Reference |
+|-----------|------------|-------------|-----------|
+| EdDSA | -8 | Edwards-curve Digital Signature Algorithm | [RFC 9053 §2.2](https://www.rfc-editor.org/rfc/rfc9053#section-2.2) |
+| Ed25519 | -8 | The same algorithm under its own class name; identical signatures, identical identifier | [RFC 9053 §2.2](https://www.rfc-editor.org/rfc/rfc9053#section-2.2) |
+| Ed256 | -260 | Ed25519 over a SHA-256 digest — **non-standard**, see below | — |
+| Ed512 | -261 | Ed25519 over a SHA-512 digest — **non-standard**, see below | — |
+
+The IANA registry marks -8 *Deprecated* in favour of the fully-specified Ed25519 (-19) and Ed448 (-53) of
+[RFC 9864](#fully-specified-algorithms), as it does ES256, ES384 and ES512. All four stay first-class here, without
+any acknowledgement: WebAuthn still requires ES256 and EdDSA.
+
+Ed256 and Ed512 sign a SHA-256 or SHA-512 digest of the message with Ed25519. They are not EdDSA identifiers and are
+registered nowhere — IANA assigns -260 to WalnutDSA and -261 to TurboSHAKE128 — hence the empty reference, and
+neither of them supports Curve448. Kept for the authenticators that already produce them, and only against an
+explicit acknowledgement (see below); EdDSA with Curve448 is `FullySpecified\Ed448` (-53).
+
+**RSA** (`Cose\Algorithm\Signature\RSA`)
+
+| Algorithm | Identifier | Description | Reference |
+|-----------|------------|-------------|-----------|
+| RS256 | -257 | RSASSA-PKCS1-v1_5 with SHA-256 | [RFC 8812 §2](https://www.rfc-editor.org/rfc/rfc8812#section-2) |
+| RS384 | -258 | RSASSA-PKCS1-v1_5 with SHA-384 | [RFC 8812 §2](https://www.rfc-editor.org/rfc/rfc8812#section-2) |
+| RS512 | -259 | RSASSA-PKCS1-v1_5 with SHA-512 | [RFC 8812 §2](https://www.rfc-editor.org/rfc/rfc8812#section-2) |
+| PS256 | -37 | RSASSA-PSS with SHA-256 | [RFC 8230 §2](https://www.rfc-editor.org/rfc/rfc8230#section-2) |
+| PS384 | -38 | RSASSA-PSS with SHA-384 | [RFC 8230 §2](https://www.rfc-editor.org/rfc/rfc8230#section-2) |
+| PS512 | -39 | RSASSA-PSS with SHA-512 | [RFC 8230 §2](https://www.rfc-editor.org/rfc/rfc8230#section-2) |
+| RS1 | -65535 | RSASSA-PKCS1-v1_5 with SHA-1 — **not secure**, kept only for legacy authenticators | [RFC 8812 §2](https://www.rfc-editor.org/rfc/rfc8812#section-2) |
 
 PS256, PS384 and PS512 sign with a private key, so the exponentiation is a side-channel target. A two-prime key
 carrying the full CRT quintuple — the shape almost every key store produces — is exponentiated by OpenSSL, which
@@ -728,18 +747,17 @@ their own, instead of leaving them to the other parameters of the key. WebAuthn 
 party may receive a credential whose `alg` carries one of these values. They live in the
 `Cose\Algorithm\Signature\FullySpecified` namespace.
 
-- **ECDSA**
-  - ESP256 (-9): ECDSA with the P-256 curve and SHA-256
-  - ESP384 (-51): ECDSA with the P-384 curve and SHA-384
-  - ESP512 (-52): ECDSA with the P-521 curve and SHA-512
-  - ESB256 (-265): ECDSA with the brainpoolP256r1 curve and SHA-256
-  - ESB320 (-266): ECDSA with the brainpoolP320r1 curve and SHA-384
-  - ESB384 (-267): ECDSA with the brainpoolP384r1 curve and SHA-384
-  - ESB512 (-268): ECDSA with the brainpoolP512r1 curve and SHA-512
-
-- **EdDSA**
-  - Ed25519 (-19): EdDSA with the Ed25519 parameter set
-  - Ed448 (-53): EdDSA with the Ed448 parameter set
+| Algorithm | Identifier | Description | Reference |
+|-----------|------------|-------------|-----------|
+| ESP256 | -9 | ECDSA with the P-256 curve and SHA-256 | [RFC 9864 §2.1](https://www.rfc-editor.org/rfc/rfc9864#section-2.1) |
+| ESP384 | -51 | ECDSA with the P-384 curve and SHA-384 | [RFC 9864 §2.1](https://www.rfc-editor.org/rfc/rfc9864#section-2.1) |
+| ESP512 | -52 | ECDSA with the P-521 curve and SHA-512 | [RFC 9864 §2.1](https://www.rfc-editor.org/rfc/rfc9864#section-2.1) |
+| ESB256 | -265 | ECDSA with the brainpoolP256r1 curve and SHA-256 | [RFC 9864 §2.1](https://www.rfc-editor.org/rfc/rfc9864#section-2.1) |
+| ESB320 | -266 | ECDSA with the brainpoolP320r1 curve and SHA-384 | [RFC 9864 §2.1](https://www.rfc-editor.org/rfc/rfc9864#section-2.1) |
+| ESB384 | -267 | ECDSA with the brainpoolP384r1 curve and SHA-384 | [RFC 9864 §2.1](https://www.rfc-editor.org/rfc/rfc9864#section-2.1) |
+| ESB512 | -268 | ECDSA with the brainpoolP512r1 curve and SHA-512 | [RFC 9864 §2.1](https://www.rfc-editor.org/rfc/rfc9864#section-2.1) |
+| Ed25519 | -19 | EdDSA with the Ed25519 parameter set | [RFC 9864 §2.2](https://www.rfc-editor.org/rfc/rfc9864#section-2.2) |
+| Ed448 | -53 | EdDSA with the Ed448 parameter set — requires PHP 8.4 or later | [RFC 9864 §2.2](https://www.rfc-editor.org/rfc/rfc9864#section-2.2) |
 
 ```php
 use Cose\Algorithm\Manager;
@@ -867,6 +885,42 @@ Two details are worth knowing:
 `Key::alg()` is strict about the value it reads: an `alg` that is not an integer — the text `'RS256'`, for instance —
 throws instead of being cast to `0`, an identifier no algorithm is registered under. An integer written as a string
 (`'-7'`) is accepted, as the key constructors do for `kty` and `crv`.
+
+### Key Types
+
+The `Cose\Key` classes cover the four key types of the IANA
+[COSE Key Types](https://www.iana.org/assignments/cose/cose.xhtml#key-type) registry that the algorithms above use.
+`Key::createFromData()` picks the class from `kty` (label 1), and the parameter labels are the `DATA_*` constants of
+each class — `Ec2Key::DATA_X` is -2, `RsaKey::DATA_N` is -1, and so on.
+
+| Key type | `kty` | Class | Parameters | Reference |
+|----------|-------|-------|------------|-----------|
+| OKP | 1 | `Cose\Key\OkpKey` | `crv` (-1), `x` (-2), `d` (-4) | [RFC 9053 §7.2](https://www.rfc-editor.org/rfc/rfc9053#section-7.2) |
+| EC2 | 2 | `Cose\Key\Ec2Key` | `crv` (-1), `x` (-2), `y` (-3), `d` (-4) | [RFC 9053 §7.1.1](https://www.rfc-editor.org/rfc/rfc9053#section-7.1.1) |
+| RSA | 3 | `Cose\Key\RsaKey` | `n` (-1), `e` (-2), `d` (-3), `p` (-4), `q` (-5), `dP` (-6), `dQ` (-7), `qInv` (-8), `other` (-9), `r_i` (-10), `d_i` (-11), `t_i` (-12) | [RFC 8230 §4](https://www.rfc-editor.org/rfc/rfc8230#section-4) |
+| Symmetric | 4 | `Cose\Key\SymmetricKey` | `k` (-1) | [RFC 9053 §7.3](https://www.rfc-editor.org/rfc/rfc9053#section-7.3) |
+
+The curves an `OkpKey` or an `Ec2Key` may carry in `crv`, with the `CURVE_*` constant naming each value:
+
+| Curve | `crv` | Key type | Constant | Reference |
+|-------|-------|----------|----------|-----------|
+| P-256 | 1 | EC2 | `Ec2Key::CURVE_P256` | [RFC 9053 §7.1](https://www.rfc-editor.org/rfc/rfc9053#section-7.1) |
+| P-384 | 2 | EC2 | `Ec2Key::CURVE_P384` | [RFC 9053 §7.1](https://www.rfc-editor.org/rfc/rfc9053#section-7.1) |
+| P-521 | 3 | EC2 | `Ec2Key::CURVE_P521` | [RFC 9053 §7.1](https://www.rfc-editor.org/rfc/rfc9053#section-7.1) |
+| X25519 | 4 | OKP | `OkpKey::CURVE_X25519` | [RFC 9053 §7.1](https://www.rfc-editor.org/rfc/rfc9053#section-7.1) |
+| X448 | 5 | OKP | `OkpKey::CURVE_X448` | [RFC 9053 §7.1](https://www.rfc-editor.org/rfc/rfc9053#section-7.1) |
+| Ed25519 | 6 | OKP | `OkpKey::CURVE_ED25519` | [RFC 9053 §7.1](https://www.rfc-editor.org/rfc/rfc9053#section-7.1) |
+| Ed448 | 7 | OKP | `OkpKey::CURVE_ED448` | [RFC 9053 §7.1](https://www.rfc-editor.org/rfc/rfc9053#section-7.1) |
+| secp256k1 | 8 | EC2 | `Ec2Key::CURVE_P256K` | [RFC 8812 §4.2](https://www.rfc-editor.org/rfc/rfc8812#section-4.2) |
+| brainpoolP256r1 | 256 | EC2 | `Ec2Key::CURVE_BP256` | [ISO/IEC 18013-5:2021 §9.1.5.2](https://www.iana.org/assignments/cose/cose.xhtml#elliptic-curves) |
+| brainpoolP320r1 | 257 | EC2 | `Ec2Key::CURVE_BP320` | [ISO/IEC 18013-5:2021 §9.1.5.2](https://www.iana.org/assignments/cose/cose.xhtml#elliptic-curves) |
+| brainpoolP384r1 | 258 | EC2 | `Ec2Key::CURVE_BP384` | [ISO/IEC 18013-5:2021 §9.1.5.2](https://www.iana.org/assignments/cose/cose.xhtml#elliptic-curves) |
+| brainpoolP512r1 | 259 | EC2 | `Ec2Key::CURVE_BP512` | [ISO/IEC 18013-5:2021 §9.1.5.2](https://www.iana.org/assignments/cose/cose.xhtml#elliptic-curves) |
+
+X25519 and X448 are registered "for use w/ ECDH only": an `OkpKey` accepts them, but no algorithm of this library
+uses them yet. The brainpool curves are registered at IANA by ISO/IEC 18013-5 rather than by an RFC; the link goes
+to the registry entry. The names a key may carry instead of these numbers are listed under
+[Key Parameter Forms](#key-parameter-forms).
 
 ### Ed25519 Private Keys
 
@@ -1093,11 +1147,14 @@ $key = PublicKeyLoader::fromSubjectPublicKeyInfo($spkiDer);
 
 ### MAC Algorithms
 
-- **HMAC**
-  - HS256 (5): HMAC with SHA-256
-  - HS384 (6): HMAC with SHA-384
-  - HS512 (7): HMAC with SHA-512
-  - HS256/64 (4): HMAC with SHA-256 truncated to 64 bits
+**HMAC** (`Cose\Algorithm\Mac`)
+
+| Algorithm | Identifier | Description | Reference |
+|-----------|------------|-------------|-----------|
+| HS256 | 5 | HMAC with SHA-256 (IANA name `HMAC 256/256`) | [RFC 9053 §3.1](https://www.rfc-editor.org/rfc/rfc9053#section-3.1) |
+| HS384 | 6 | HMAC with SHA-384 (`HMAC 384/384`) | [RFC 9053 §3.1](https://www.rfc-editor.org/rfc/rfc9053#section-3.1) |
+| HS512 | 7 | HMAC with SHA-512 (`HMAC 512/512`) | [RFC 9053 §3.1](https://www.rfc-editor.org/rfc/rfc9053#section-3.1) |
+| HS256/64 | 4 | HMAC with SHA-256 truncated to 64 bits (`HMAC 256/64`), class `HS256Truncated64` | [RFC 9053 §3.1](https://www.rfc-editor.org/rfc/rfc9053#section-3.1) |
 
 ### Validating Symmetric Keys
 
@@ -1201,4 +1258,7 @@ The test suite is the rest of the examples, and every one of them is executed on
 
 - [RFC 9052 - CBOR Object Signing and Encryption (COSE): Structures and Process](https://datatracker.ietf.org/doc/html/rfc9052)
 - [RFC 9053 - CBOR Object Signing and Encryption (COSE): Initial Algorithms](https://datatracker.ietf.org/doc/html/rfc9053)
+- [RFC 8230 - Using RSA Algorithms with CBOR Object Signing and Encryption (COSE) Messages](https://datatracker.ietf.org/doc/html/rfc8230)
+- [RFC 8812 - CBOR Object Signing and Encryption (COSE) and JSON Object Signing and Encryption (JOSE) Registrations for Web Authentication (WebAuthn) Algorithms](https://datatracker.ietf.org/doc/html/rfc8812)
+- [RFC 9864 - Fully-Specified Algorithms for JOSE and COSE](https://www.rfc-editor.org/rfc/rfc9864.html)
 - [IANA COSE Registry](https://www.iana.org/assignments/cose/cose.xhtml)

--- a/tests/RfcReferencesTest.php
+++ b/tests/RfcReferencesTest.php
@@ -1,0 +1,609 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cose\Tests;
+
+use const ARRAY_FILTER_USE_BOTH;
+use function array_keys;
+use function array_map;
+use function array_slice;
+use function basename;
+use function class_exists;
+use Cose\Algorithm\Algorithm;
+use Cose\Key\Ec2Key;
+use Cose\Key\Key;
+use Cose\Key\OkpKey;
+use Cose\Key\RsaKey;
+use Cose\Key\SymmetricKey;
+use function count;
+use function explode;
+use function file_get_contents;
+use function glob;
+use const GLOB_BRACE;
+use function implode;
+use function in_array;
+use function is_array;
+use function is_int;
+use function is_string;
+use function json_decode;
+use const JSON_THROW_ON_ERROR;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use function preg_match;
+use function preg_split;
+use ReflectionClass;
+use function sprintf;
+use function str_contains;
+use function str_starts_with;
+use function strlen;
+use function substr;
+use function trim;
+
+/**
+ * Every algorithm, key type and curve the library ships is traceable, from the README and from the usage guide, to
+ * the RFC and the section that define it — and the reference written there is the one the IANA COSE registry gives.
+ *
+ * The expectations below were checked against <https://www.iana.org/assignments/cose/cose.xhtml> on 2026-09-11. The
+ * tables are parsed, not searched, so a row that loses its Reference cell, an identifier that drifts from the class
+ * constant, or a new algorithm class that nobody documented all fail here.
+ *
+ * @see https://github.com/web-auth/cose-lib/issues/193
+ */
+final class RfcReferencesTest extends TestCase
+{
+    private const ROOT = __DIR__ . '/..';
+
+    private const DOCUMENTS = ['README.md', 'doc/Usage.md'];
+
+    /**
+     * The RFCs the library implements, as the README and composer.json have to declare them.
+     */
+    private const IMPLEMENTED_RFCS = [9052, 9053, 8230, 8812, 9864];
+
+    /**
+     * Identifier => [documented name, RFC number, section]. The section is the one the RFC itself defines the
+     * identifier in, which is what a reader needs; the IANA registry only names the RFC (plus the section for
+     * RFC 9864).
+     *
+     * Ed256 and Ed512 are absent on purpose: they are defined by no specification, see NON_STANDARD.
+     */
+    private const ALGORITHM_REFERENCES = [
+        -7 => ['ES256', 9053, '2.1'],
+        -35 => ['ES384', 9053, '2.1'],
+        -36 => ['ES512', 9053, '2.1'],
+        -47 => ['ES256K', 8812, '3.2'],
+        -8 => ['EdDSA', 9053, '2.2'],
+        -257 => ['RS256', 8812, '2'],
+        -258 => ['RS384', 8812, '2'],
+        -259 => ['RS512', 8812, '2'],
+        -65535 => ['RS1', 8812, '2'],
+        -37 => ['PS256', 8230, '2'],
+        -38 => ['PS384', 8230, '2'],
+        -39 => ['PS512', 8230, '2'],
+        -9 => ['ESP256', 9864, '2.1'],
+        -51 => ['ESP384', 9864, '2.1'],
+        -52 => ['ESP512', 9864, '2.1'],
+        -265 => ['ESB256', 9864, '2.1'],
+        -266 => ['ESB320', 9864, '2.1'],
+        -267 => ['ESB384', 9864, '2.1'],
+        -268 => ['ESB512', 9864, '2.1'],
+        -19 => ['Ed25519', 9864, '2.2'],
+        -53 => ['Ed448', 9864, '2.2'],
+        4 => ['HS256/64', 9053, '3.1'],
+        5 => ['HS256', 9053, '3.1'],
+        6 => ['HS384', 9053, '3.1'],
+        7 => ['HS512', 9053, '3.1'],
+    ];
+
+    /**
+     * Identifiers registered nowhere: their Reference cell must be the em dash, not a made-up RFC.
+     */
+    private const NON_STANDARD = [
+        -260 => 'Ed256',
+        -261 => 'Ed512',
+    ];
+
+    /**
+     * Class short name => documented name, where the two differ.
+     */
+    private const DOCUMENTED_NAMES = [
+        'HS256Truncated64' => 'HS256/64',
+    ];
+
+    /**
+     * kty => [name, class, RFC number, section].
+     */
+    private const KEY_TYPE_REFERENCES = [
+        Key::TYPE_OKP => ['OKP', OkpKey::class, 9053, '7.2'],
+        Key::TYPE_EC2 => ['EC2', Ec2Key::class, 9053, '7.1.1'],
+        Key::TYPE_RSA => ['RSA', RsaKey::class, 8230, '4'],
+        Key::TYPE_OCT => ['Symmetric', SymmetricKey::class, 9053, '7.3'],
+    ];
+
+    /**
+     * crv => [name, constant, reference text]. The brainpool curves are registered by ISO/IEC 18013-5, not by an
+     * RFC, so their reference is the registry entry.
+     */
+    private const CURVE_REFERENCES = [
+        1 => ['P-256', 'Ec2Key::CURVE_P256', 'RFC 9053 §7.1'],
+        2 => ['P-384', 'Ec2Key::CURVE_P384', 'RFC 9053 §7.1'],
+        3 => ['P-521', 'Ec2Key::CURVE_P521', 'RFC 9053 §7.1'],
+        4 => ['X25519', 'OkpKey::CURVE_X25519', 'RFC 9053 §7.1'],
+        5 => ['X448', 'OkpKey::CURVE_X448', 'RFC 9053 §7.1'],
+        6 => ['Ed25519', 'OkpKey::CURVE_ED25519', 'RFC 9053 §7.1'],
+        7 => ['Ed448', 'OkpKey::CURVE_ED448', 'RFC 9053 §7.1'],
+        8 => ['secp256k1', 'Ec2Key::CURVE_P256K', 'RFC 8812 §4.2'],
+        256 => ['brainpoolP256r1', 'Ec2Key::CURVE_BP256', 'ISO/IEC 18013-5:2021 §9.1.5.2'],
+        257 => ['brainpoolP320r1', 'Ec2Key::CURVE_BP320', 'ISO/IEC 18013-5:2021 §9.1.5.2'],
+        258 => ['brainpoolP384r1', 'Ec2Key::CURVE_BP384', 'ISO/IEC 18013-5:2021 §9.1.5.2'],
+        259 => ['brainpoolP512r1', 'Ec2Key::CURVE_BP512', 'ISO/IEC 18013-5:2021 §9.1.5.2'],
+    ];
+
+    /**
+     * The shape of a Reference cell: "[RFC 9053 §2.1](https://www.rfc-editor.org/rfc/rfc9053#section-2.1)", with the
+     * RFC number and the section of the link matching the text.
+     */
+    private const RFC_REFERENCE_PATTERN = '/^\[RFC (\d{4}) §([\d.]+)\]\(https:\/\/www\.rfc-editor\.org\/rfc\/rfc\1#section-\2\)$/';
+
+    /**
+     * The same, or the registry entry of a curve that no RFC defines.
+     */
+    private const ANY_REFERENCE_PATTERN = '/^(?:\[RFC (\d{4}) §([\d.]+)\]\(https:\/\/www\.rfc-editor\.org\/rfc\/rfc\1#section-\2\)|\[ISO\/IEC 18013-5:2021 §9\.1\.5\.2\]\(https:\/\/www\.iana\.org\/assignments\/cose\/cose\.xhtml#elliptic-curves\))$/';
+
+    /**
+     * Every concrete Algorithm class of the library has a row, in each document, with its identifier and a reference
+     * to the RFC section that defines it.
+     */
+    #[Test]
+    #[DataProvider('getAlgorithmClasses')]
+    public function everyShippedAlgorithmIsDocumentedWithItsReference(string $class): void
+    {
+        // Given
+        $identifier = $class::identifier();
+        $shortName = substr($class, strrpos($class, '\\') + 1);
+        $name = self::DOCUMENTED_NAMES[$shortName] ?? $shortName;
+
+        if (isset(self::NON_STANDARD[$identifier])) {
+            $expectedReference = '—';
+        } else {
+            static::assertArrayHasKey(
+                $identifier,
+                self::ALGORITHM_REFERENCES,
+                sprintf('%s (%d) is not in the reference list of this test; add it, checked against IANA', $class, $identifier)
+            );
+            [$expectedName, $rfc, $section] = self::ALGORITHM_REFERENCES[$identifier];
+            // The "EdDSA" and "Ed25519" classes share -8: the row is looked up by name, the reference by identifier.
+            if ($expectedName !== $name) {
+                static::assertSame(-8, $identifier, sprintf('%s documents %d under the name %s', $class, $identifier, $name));
+            }
+            $expectedReference = self::rfcReference($rfc, $section);
+        }
+
+        foreach (self::DOCUMENTS as $document) {
+            // When
+            $row = self::findRow(self::algorithmRows($document), 'Algorithm', $name, 'Identifier', (string) $identifier);
+
+            // Then
+            static::assertNotNull($row, sprintf('%s has no row for %s (%d)', $document, $name, $identifier));
+            static::assertSame(
+                $expectedReference,
+                $row['Reference'],
+                sprintf('%s: the reference of %s (%d) is not the one IANA gives', $document, $name, $identifier)
+            );
+        }
+    }
+
+    /**
+     * @return iterable<string, array{class-string<Algorithm>}>
+     */
+    public static function getAlgorithmClasses(): iterable
+    {
+        $files = glob(self::ROOT . '/src/Algorithm/{*,*/*,*/*/*}.php', GLOB_BRACE);
+        static::assertNotFalse($files);
+        static::assertNotSame([], $files, 'No algorithm class found');
+
+        foreach ($files as $file) {
+            $relative = substr($file, strlen(self::ROOT . '/src/'));
+            $class = 'Cose\\' . str_replace('/', '\\', substr($relative, 0, -4));
+            if (! class_exists($class)) {
+                continue;
+            }
+            $reflection = new ReflectionClass($class);
+            if (! $reflection->isInstantiable() || ! $reflection->implementsInterface(Algorithm::class)) {
+                continue;
+            }
+            yield $class => [$class];
+        }
+    }
+
+    /**
+     * The other direction: nothing is documented that the library does not ship, and no documented identifier has
+     * drifted from the class constant. The two documents also agree with each other.
+     */
+    #[Test]
+    #[DataProvider('getDocuments')]
+    public function everyDocumentedAlgorithmIsShipped(string $document): void
+    {
+        // Given
+        $shipped = [];
+        foreach (self::getAlgorithmClasses() as [$class]) {
+            $shortName = substr($class, strrpos($class, '\\') + 1);
+            $shipped[(self::DOCUMENTED_NAMES[$shortName] ?? $shortName) . ' ' . $class::identifier()] = $class;
+        }
+
+        // When
+        $rows = self::algorithmRows($document);
+
+        // Then
+        static::assertCount(
+            count(self::ALGORITHM_REFERENCES) + count(self::NON_STANDARD) + 1, // +1: EdDSA and Ed25519 share -8
+            $rows,
+            $document . ' does not document the expected number of algorithms'
+        );
+        foreach ($rows as $row) {
+            $key = $row['Algorithm'] . ' ' . $row['Identifier'];
+            static::assertArrayHasKey($key, $shipped, sprintf('%s documents %s, which no class ships', $document, $key));
+        }
+    }
+
+    #[Test]
+    public function theReadmeAndTheUsageGuideDocumentTheSameAlgorithms(): void
+    {
+        $project = static fn (array $row): string => implode(' | ', [$row['Algorithm'], $row['Identifier'], $row['Reference']]);
+        $readme = array_map($project, self::algorithmRows('README.md'));
+        $usage = array_map($project, self::algorithmRows('doc/Usage.md'));
+        sort($readme);
+        sort($usage);
+
+        static::assertSame($readme, $usage);
+    }
+
+    /**
+     * Every Reference cell of every table, in both documents, links the RFC and the section it names, so that a
+     * reader following the link lands on the defining text rather than on the front page of the RFC.
+     */
+    #[Test]
+    #[DataProvider('getDocuments')]
+    public function everyReferenceCellIsALinkToTheSectionItNames(string $document): void
+    {
+        // Given
+        $tables = self::tablesWithColumn($document, 'Reference');
+        static::assertGreaterThanOrEqual(4, count($tables), $document . ' has fewer reference tables than expected');
+
+        foreach ($tables as $rows) {
+            foreach ($rows as $row) {
+                $reference = $row['Reference'];
+                $label = implode(' | ', array_slice(array_values($row), 0, 2));
+
+                // Then
+                if ($reference === '—') {
+                    $identifier = (int) ($row['Identifier'] ?? 0);
+                    static::assertArrayHasKey(
+                        $identifier,
+                        self::NON_STANDARD,
+                        sprintf('%s: "%s" has no reference but is not one of the non-standard identifiers', $document, $label)
+                    );
+                    continue;
+                }
+                static::assertMatchesRegularExpression(
+                    self::ANY_REFERENCE_PATTERN,
+                    $reference,
+                    sprintf('%s: the reference of "%s" is not a link to an RFC section', $document, $label)
+                );
+                if (preg_match(self::RFC_REFERENCE_PATTERN, $reference, $matches) === 1) {
+                    static::assertContains(
+                        (int) $matches[1],
+                        self::IMPLEMENTED_RFCS,
+                        sprintf('%s: "%s" refers to RFC %s, which the library does not declare', $document, $label, $matches[1])
+                    );
+                }
+            }
+        }
+    }
+
+    /**
+     * Every Key::TYPE_* constant has a row in the key-type table, with the class that handles it and the section of
+     * the RFC that defines its parameters.
+     */
+    #[Test]
+    #[DataProvider('getDocuments')]
+    public function everyKeyTypeIsDocumentedWithItsReference(string $document): void
+    {
+        // Given
+        $constants = (new ReflectionClass(Key::class))->getConstants();
+        $types = array_filter($constants, static fn ($value, string $name): bool => str_starts_with($name, 'TYPE_') && is_int($value), ARRAY_FILTER_USE_BOTH);
+        static::assertCount(count(self::KEY_TYPE_REFERENCES), $types);
+
+        $rows = self::tableWithColumns($document, ['Key type', 'kty', 'Class', 'Parameters', 'Reference']);
+        static::assertCount(count(self::KEY_TYPE_REFERENCES), $rows, $document . ': the key-type table has the wrong number of rows');
+
+        foreach ($types as $kty) {
+            [$name, $class, $rfc, $section] = self::KEY_TYPE_REFERENCES[$kty];
+
+            // When
+            $row = self::findRow($rows, 'kty', (string) $kty, 'Key type', $name);
+
+            // Then
+            static::assertNotNull($row, sprintf('%s has no row for key type %s (%d)', $document, $name, $kty));
+            static::assertSame('`' . $class . '`', $row['Class']);
+            static::assertSame(self::rfcReference($rfc, $section), $row['Reference']);
+            static::assertTrue(class_exists($class));
+        }
+    }
+
+    /**
+     * The RSA row lists the twelve parameters of RFC 8230 section 4 with the labels RsaKey uses; the other rows
+     * likewise, so that the table answers "which label is p" without opening the class.
+     */
+    #[Test]
+    #[DataProvider('getDocuments')]
+    public function theKeyTypeTableListsTheParameterLabelsOfEachClass(string $document): void
+    {
+        $rows = self::tableWithColumns($document, ['Key type', 'kty', 'Class', 'Parameters', 'Reference']);
+        $expected = [
+            'OKP' => [
+                'crv' => OkpKey::DATA_CURVE,
+                'x' => OkpKey::DATA_X,
+                'd' => OkpKey::DATA_D,
+            ],
+            'EC2' => [
+                'crv' => Ec2Key::DATA_CURVE,
+                'x' => Ec2Key::DATA_X,
+                'y' => Ec2Key::DATA_Y,
+                'd' => Ec2Key::DATA_D,
+            ],
+            'RSA' => [
+                'n' => RsaKey::DATA_N,
+                'e' => RsaKey::DATA_E,
+                'd' => RsaKey::DATA_D,
+                'p' => RsaKey::DATA_P,
+                'q' => RsaKey::DATA_Q,
+                'dP' => RsaKey::DATA_DP,
+                'dQ' => RsaKey::DATA_DQ,
+                'qInv' => RsaKey::DATA_QI,
+                'other' => RsaKey::DATA_OTHER,
+                'r_i' => RsaKey::DATA_RI,
+                'd_i' => RsaKey::DATA_DI,
+                't_i' => RsaKey::DATA_TI,
+            ],
+            'Symmetric' => [
+                'k' => SymmetricKey::DATA_K,
+            ],
+        ];
+
+        foreach ($expected as $type => $parameters) {
+            $row = self::findRow($rows, 'Key type', $type);
+            static::assertNotNull($row);
+            $documented = implode(', ', array_map(
+                static fn (string $name, int $label): string => sprintf('`%s` (%d)', $name, $label),
+                array_keys($parameters),
+                $parameters
+            ));
+            static::assertSame($documented, $row['Parameters'], sprintf('%s: the parameters of %s', $document, $type));
+        }
+    }
+
+    /**
+     * Every integer CURVE_* constant of Ec2Key and OkpKey has a row in the curve table, under the constant that
+     * names it and with the reference the IANA registry gives.
+     */
+    #[Test]
+    #[DataProvider('getDocuments')]
+    public function everyCurveIsDocumentedWithItsReference(string $document): void
+    {
+        // Given
+        $constants = [];
+        foreach ([Ec2Key::class, OkpKey::class] as $class) {
+            $short = substr($class, strrpos($class, '\\') + 1);
+            foreach ((new ReflectionClass($class))->getConstants() as $name => $value) {
+                if (str_starts_with($name, 'CURVE_') && is_int($value)) {
+                    $constants[$value] = $short . '::' . $name;
+                }
+            }
+        }
+        static::assertCount(count(self::CURVE_REFERENCES), $constants);
+
+        $rows = self::tableWithColumns($document, ['Curve', 'crv', 'Key type', 'Constant', 'Reference']);
+        static::assertCount(count(self::CURVE_REFERENCES), $rows, $document . ': the curve table has the wrong number of rows');
+
+        foreach (self::CURVE_REFERENCES as $crv => [$name, $constant, $reference]) {
+            // When
+            $row = self::findRow($rows, 'crv', (string) $crv, 'Curve', $name);
+
+            // Then
+            static::assertNotNull($row, sprintf('%s has no row for curve %s (%d)', $document, $name, $crv));
+            static::assertSame('`' . $constant . '`', $row['Constant']);
+            static::assertSame($constant, $constants[$crv], sprintf('The constant of curve %d is not %s', $crv, $constant));
+            static::assertSame($reference, self::linkText($row['Reference']));
+            static::assertSame(str_starts_with($constant, 'Ec2Key') ? 'EC2' : 'OKP', $row['Key type']);
+        }
+    }
+
+    /**
+     * The "This library implements" list and the "Documentation" section of the README, and the introduction and
+     * "References" section of the usage guide, name every RFC the tables refer to.
+     */
+    #[Test]
+    public function theImplementedRfcsAreDeclared(): void
+    {
+        // Given
+        $readme = self::read('README.md');
+        $usage = self::read('doc/Usage.md');
+
+        $implements = self::section($readme, 'This library implements:', "\n## ");
+        $documentation = self::section($readme, '## Documentation', "\n## ");
+        $introduction = self::section($usage, '# How to Use COSE Library', "\n## ");
+        $references = self::section($usage, '## References', "\n## ");
+
+        // Then
+        foreach (self::IMPLEMENTED_RFCS as $rfc) {
+            $link = sprintf('(https://datatracker.ietf.org/doc/html/rfc%d)', $rfc);
+            $alternative = sprintf('(https://www.rfc-editor.org/rfc/rfc%d.html)', $rfc);
+            foreach ([
+                'README "This library implements"' => $implements,
+                'README "Documentation"' => $documentation,
+                'Usage.md introduction' => $introduction,
+                'Usage.md "References"' => $references,
+            ] as $where => $text) {
+                static::assertTrue(
+                    str_contains($text, $link) || str_contains($text, $alternative),
+                    sprintf('%s does not link RFC %d', $where, $rfc)
+                );
+            }
+        }
+    }
+
+    /**
+     * RFC 8152 is obsoleted by RFC 9052 and RFC 9053; the package keywords name what is implemented today.
+     */
+    #[Test]
+    public function theComposerKeywordsNameTheImplementedRfcs(): void
+    {
+        // Given
+        $composer = json_decode(self::read('composer.json'), true, 512, JSON_THROW_ON_ERROR);
+        static::assertTrue(is_array($composer));
+        $keywords = $composer['keywords'] ?? [];
+        static::assertTrue(is_array($keywords));
+
+        // Then
+        static::assertNotContains('RFC8152', $keywords);
+        static::assertContains('COSE', $keywords);
+        foreach (self::IMPLEMENTED_RFCS as $rfc) {
+            static::assertContains('RFC' . $rfc, $keywords, sprintf('RFC %d is implemented but not a keyword', $rfc));
+        }
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function getDocuments(): iterable
+    {
+        foreach (self::DOCUMENTS as $document) {
+            yield basename($document) => [$document];
+        }
+    }
+
+    private static function rfcReference(int $rfc, string $section): string
+    {
+        return sprintf('[RFC %d §%s](https://www.rfc-editor.org/rfc/rfc%d#section-%s)', $rfc, $section, $rfc, $section);
+    }
+
+    private static function linkText(string $cell): string
+    {
+        static::assertSame(1, preg_match('/^\[([^\]]+)\]\(/', $cell, $matches), 'Not a link: ' . $cell);
+
+        return $matches[1];
+    }
+
+    /**
+     * The rows of every algorithm table of the document, i.e. the tables headed Algorithm | Identifier | … | Reference.
+     *
+     * @return list<array<string, string>>
+     */
+    private static function algorithmRows(string $document): array
+    {
+        $rows = [];
+        foreach (self::tablesWithColumn($document, 'Reference') as $table) {
+            if (isset($table[0]['Algorithm'], $table[0]['Identifier'])) {
+                $rows = [...$rows, ...$table];
+            }
+        }
+        static::assertNotSame([], $rows, $document . ' has no algorithm table');
+
+        return $rows;
+    }
+
+    /**
+     * @param list<string> $columns
+     * @return list<array<string, string>>
+     */
+    private static function tableWithColumns(string $document, array $columns): array
+    {
+        foreach (self::tablesWithColumn($document, $columns[0]) as $table) {
+            if (array_keys($table[0]) === $columns) {
+                return $table;
+            }
+        }
+        static::fail(sprintf('%s has no table with the columns %s', $document, implode(' | ', $columns)));
+    }
+
+    /**
+     * @param list<array<string, string>> $rows
+     * @return array<string, string>|null
+     */
+    private static function findRow(array $rows, string $column, string $value, ?string $otherColumn = null, ?string $otherValue = null): ?array
+    {
+        foreach ($rows as $row) {
+            if ($row[$column] === $value && ($otherColumn === null || $row[$otherColumn] === $otherValue)) {
+                return $row;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * A minimal parser for the GitHub-flavoured Markdown tables of the documentation: a header line, a delimiter
+     * line, then one row per line until a blank line. Returns every table whose header has the given column, as a
+     * list of rows keyed by column name.
+     *
+     * @return list<list<array<string, string>>>
+     */
+    private static function tablesWithColumn(string $document, string $column): array
+    {
+        $lines = explode("\n", self::read($document));
+        $tables = [];
+        $count = count($lines);
+        for ($i = 0; $i < $count - 1; $i++) {
+            if (! str_starts_with($lines[$i], '|') || preg_match('/^\|[\s:-]+\|[\s|:-]*$/', $lines[$i + 1]) !== 1) {
+                continue;
+            }
+            $header = self::cells($lines[$i]);
+            $rows = [];
+            for ($j = $i + 2; $j < $count && str_starts_with($lines[$j], '|'); $j++) {
+                $cells = self::cells($lines[$j]);
+                static::assertCount(count($header), $cells, sprintf('%s line %d: the row does not fit the table header', $document, $j + 1));
+                $rows[] = array_combine(array_map(static fn (string $cell): string => trim($cell, '` '), $header), $cells);
+            }
+            $i = $j;
+            if (in_array($column, array_keys($rows[0] ?? []), true)) {
+                $tables[] = $rows;
+            }
+        }
+
+        return $tables;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function cells(string $line): array
+    {
+        $cells = preg_split('/(?<!\\\\)\|/', trim($line));
+        static::assertNotFalse($cells);
+        // The leading and trailing pipes give an empty first and last cell.
+        array_shift($cells);
+        array_pop($cells);
+
+        return array_map(static fn (string $cell): string => trim(str_replace('\\|', '|', $cell)), $cells);
+    }
+
+    private static function section(string $text, string $from, string $until): string
+    {
+        $start = strpos($text, $from);
+        static::assertNotFalse($start, 'Section not found: ' . $from);
+        $end = strpos($text, $until, $start + strlen($from));
+
+        return $end === false ? substr($text, $start) : substr($text, $start, $end - $start);
+    }
+
+    private static function read(string $path): string
+    {
+        $content = file_get_contents(self::ROOT . '/' . $path);
+        static::assertTrue(is_string($content), 'Cannot read ' . $path);
+
+        return $content;
+    }
+}


### PR DESCRIPTION
Target branch: 4.9.x
Resolves issue #193

- [ ] It is a Bug fix
- [x] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

Closes #193. Part of #202 (the "no dependency" batch).

The README named RFC 9052, RFC 9053 and RFC 9864 only, while the library ships PS256/384/512 and the RSA key type ([RFC 8230](https://datatracker.ietf.org/doc/html/rfc8230)), RS256/384/512, RS1 and ES256K with secp256k1 ([RFC 8812](https://datatracker.ietf.org/doc/html/rfc8812)) and cited both in passing. A reader could not map a shipped identifier to its specification without leaving the page. This PR is documentation, packaging metadata and one test; no source file changes.

## What changed

**1. The RFCs the library implements are declared** — `README.md` ("This library implements", "Documentation") and `doc/Usage.md` (introduction, "References") list RFC 9052, RFC 9053, RFC 8230, RFC 8812 and RFC 9864, each with what it contributes. The IANA COSE registry joins the README "Documentation" section.

**2. A *Reference* column in every algorithm table.** Signature, fully-specified and MAC tables of the README point at the section that defines each row, as a link to that section (`[RFC 8812 §3.2](…/rfc8812#section-3.2)`). `doc/Usage.md` had bullet lists; they become the same tables (ECDSA, EdDSA, RSA, fully-specified, HMAC). The references were checked against the [IANA registry](https://www.iana.org/assignments/cose/cose.xhtml):

| Rows | Reference |
|---|---|
| ES256, ES384, ES512 | RFC 9053 §2.1 |
| EdDSA, Ed25519 (-8) | RFC 9053 §2.2 |
| ES256K | RFC 8812 §3.2 |
| RS256, RS384, RS512, RS1 | RFC 8812 §2 |
| PS256, PS384, PS512 | RFC 8230 §2 |
| ESP256/384/512, ESB256/320/384/512 | RFC 9864 §2.1 |
| Ed25519 (-19), Ed448 | RFC 9864 §2.2 |
| HS256, HS384, HS512, HS256/64 | RFC 9053 §3.1 |
| Ed256, Ed512 | — (defined by no specification; the existing warning stays) |

A short paragraph under the signature table says that IANA marks ES256/ES384/ES512/EdDSA *Deprecated* since RFC 9864 and that they stay first-class here without any acknowledgement, as #202 rules (WebAuthn still requires them).

**3. A key-type table and a curve table** in both documents (new `### Key Types` section; the README had none):

- key types: `kty`, the `Cose\Key` class, the parameter labels (`n` (-1) … `t_i` (-12) for RSA), and the section — RFC 9053 §7.2 (OKP), §7.1.1 (EC2), §7.3 (Symmetric), RFC 8230 §4 (RSA);
- curves: `crv`, key type, the `CURVE_*` constant, and the reference — RFC 9053 §7.1 for 1–7, RFC 8812 §4.2 for secp256k1, and the IANA entry for the four brainpool curves, which are registered by ISO/IEC 18013-5 rather than by an RFC.

**4. `composer.json` keywords**: `RFC8152` (obsolete) → `RFC9052`, `RFC9053`, `RFC8230`, `RFC8812`, `RFC9864`, plus `CBOR`.

**5. `RELEASES.md`**: one bullet in "4.8.x to 4.9.x".

## Tests

`tests/RfcReferencesTest.php` (48 cases) parses the Markdown tables of both documents rather than grepping them, and holds the IANA expectations as data:

- every concrete `Algorithm` class under `src/Algorithm/` (found by reflection, so a future class cannot be added undocumented) has a row in each document with its `identifier()` and the reference IANA gives; Ed256/Ed512 must carry the em dash;
- nothing is documented that no class ships, and the README and the usage guide document the same set of (name, identifier, reference) rows;
- every Reference cell of every table links the RFC and section it names, and only RFCs the library declares;
- every `Key::TYPE_*` constant has its row with the right class, parameter labels (checked against the `DATA_*` constants) and section; every integer `CURVE_*` constant of `Ec2Key` and `OkpKey` has its row under its own name;
- the four "implements" lists link the five RFCs, and the composer keywords name them and no longer `RFC8152`.

Checked by mutation: changing `§3.2` to `§3.1` on the ES256K row fails `everyShippedAlgorithmIsDocumentedWithItsReference` and the README/Usage agreement test; dropping a Reference cell fails the row-shape assertion.

Full suite: 1776 tests, 15676 assertions, 249 skipped (the cose-wg fixtures of #203), 0 failures on PHP 8.5; ECS, Rector, PHPStan, parallel-lint and `composer validate --strict` clean.

## Compatibility

No BC break: no PHP source file is touched. The only non-documentation change is the `keywords` array of `composer.json`.
