### PR TITLE
feat(headers): typ (RFC 9596) and CWT Claims (RFC 9597) header parameters (#198)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ This library implements:
 - **[RFC 9052](https://datatracker.ietf.org/doc/html/rfc9052)** - COSE: Structures and Process
 - **[RFC 9053](https://datatracker.ietf.org/doc/html/rfc9053)** - COSE: Initial Algorithms
 - **[RFC 9864](https://www.rfc-editor.org/rfc/rfc9864.html)** - COSE: Fully-Specified Algorithms
+- **[RFC 9596](https://www.rfc-editor.org/rfc/rfc9596.html)** - COSE "typ" (type) Header Parameter
+- **[RFC 9597](https://www.rfc-editor.org/rfc/rfc9597.html)** - CWT Claims in COSE Headers
 
 ## Features
 
@@ -27,6 +29,12 @@ This library implements:
   protected bucket are not, and the protected value wins a combined lookup
 - `CoseSignature` and `CoseRecipient` are the checked views over the `signatures` and `recipients` lists (`[+ ...]`)
 - Works on the COSE message classes of spomky-labs/cbor-php 3.4.0
+
+✅ **Header Parameters** ([RFC 9596](https://www.rfc-editor.org/rfc/rfc9596.html), [RFC 9597](https://www.rfc-editor.org/rfc/rfc9597.html))
+- `typ` (16): `getTyp()` reads the type of the COSE object as a CoAP Content-Format number or a media type name,
+  from the protected bucket only, and rejects a message carrying it in the unprotected one (RFC 9596 §2)
+- `CWT Claims` (15): `getCwtClaims()` reads the claims map carried in the header, and rejects it when it appears in
+  both buckets (RFC 9597 §2); see [`typ` and `CWT Claims`](doc/Usage.md#typ-and-cwt-claims)
 
 ✅ **COSE Tag Support** (via [spomky-labs/cbor-php](https://github.com/Spomky-Labs/cbor-php) 3.4.0)
 - `CBOR\Tag\CoseSign1Tag` (18), `CoseSignTag` (98), `CoseEncrypt0Tag` (16), `CoseEncryptTag` (96),

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -43,6 +43,15 @@ with the missing identifier. Two behaviours changed on the way, both additive:
   `Key::TYPE_NAME_OCT_IANA` name the new forms, `Key::createFromData()` dispatches them, and the new
   `Key::typeIs(Key::TYPE_*)` answers for every form of a key type. `Key::type()` still returns the form supplied.
 
+**The `typ` (RFC 9596) and `CWT Claims` (RFC 9597) header parameters have typed accessors.** `CoseHeaders::getTyp()`
+returns the type of the COSE object as an `int` (a CoAP Content-Format number) or a `string` (a media type name),
+from the protected bucket only, and throws when a message carries the label in the unprotected bucket, which
+RFC 9596 §2 forbids. `CoseHeaders::getCwtClaims()` returns the claims map carried in the header, protected bucket
+first, and throws when the parameter appears in both buckets (RFC 9597 §2). The labels are `CoseHeaders::LABEL_TYP`
+(16) and `CoseHeaders::LABEL_CWT_CLAIMS` (15); the value checks are `HeaderMapHelper::assertContentTypeValue()` and
+`HeaderMapHelper::assertValidClaimLabels()`. Nothing existing changes: the raw lookups still hand both labels back
+unchecked. See [doc/Usage.md](doc/Usage.md#typ-and-cwt-claims).
+
 ### 4.7.x to 4.8.x
 
 **The six COSE message classes are deprecated.** `Cose\Signature\CoseSign1Tag`, `Cose\Signature\CoseSignTag`,

--- a/doc/Usage.md
+++ b/doc/Usage.md
@@ -12,6 +12,7 @@ Content encryption itself is not implemented: the encryption tags carry a cipher
 - [COSE Tags](#cose-tags)
 - [Cryptographic Structures](#cryptographic-structures)
 - [Reading Headers](#reading-headers)
+  - [`typ` and `CWT Claims`](#typ-and-cwt-claims)
 - [Signature Operations](#signature-operations)
   - [COSE_Sign1 (Single Signer)](#cose_sign1-single-signer)
   - [COSE_Sign (Multiple Signers)](#cose_sign-multiple-signers)
@@ -171,6 +172,56 @@ levels of nesting. Pass your own `Decoder` when a header carries custom CBOR tag
 ```php
 $headers = CoseHeaders::fromMessage($coseSign1, $customDecoder);
 ```
+
+### `typ` and `CWT Claims`
+
+Two header parameters have a typed accessor, because each comes with a rule of its own that a raw lookup cannot
+apply:
+
+| Name | Label | Type | Reference | Accessor |
+|---|---|---|---|---|
+| `typ` (type) | 16 (`CoseHeaders::LABEL_TYP`) | `uint / tstr` | [RFC 9596](https://www.rfc-editor.org/rfc/rfc9596) | `getTyp(): int\|string\|null` |
+| `CWT Claims` | 15 (`CoseHeaders::LABEL_CWT_CLAIMS`) | `map` | [RFC 9597](https://www.rfc-editor.org/rfc/rfc9597) | `getCwtClaims(): ?MapObject` |
+
+```php
+use Cose\Structure\CoseHeaders;
+use Cose\Structure\HeaderMapHelper;
+
+$headers = CoseHeaders::fromMessage($coseSign1);
+
+$typ = $headers->getTyp();                 // "application/cwt", 61, or null — protected bucket only
+$claims = $headers->getCwtClaims();        // MapObject or null — protected bucket first
+$issuer = $claims === null ? null : HeaderMapHelper::findLabel($claims, 1)?->normalize();
+```
+
+**`typ`** names the whole COSE object, as opposed to `content type` (label 3), which names its payload. An unsigned
+integer is a CoAP Content-Format identifier (0–65535, [RFC 7252 §12.3](https://www.rfc-editor.org/rfc/rfc7252#section-12.3));
+a text string is a media type name, `<type-name>/<subtype-name>` per
+[RFC 6838 §4.2](https://www.rfc-editor.org/rfc/rfc6838#section-4.2) with no leading or trailing whitespace — the
+syntax of `content type` in [RFC 9052 §3.1](https://datatracker.ietf.org/doc/html/rfc9052#section-3.1), which
+[RFC 9596 §2](https://www.rfc-editor.org/rfc/rfc9596#section-2) adopts — and "MAY include media type parameters".
+`"application/cwt"` and `61` both say CWT; a bare `"cwt"` is rejected, because unlike JOSE, RFC 9596 defines no
+`application/` shorthand to expand it with.
+
+RFC 9596 §2: "The 'typ' parameter MUST NOT be present in unprotected headers." `getTyp()` reads the protected bucket
+only and throws when the label is found in the unprotected one, whatever the protected bucket says. The raw
+`getProtectedHeaderParameter(CoseHeaders::LABEL_TYP)` is the lenient form: it never looks at the unprotected bucket
+and hands the value back unchecked. What to do with the value — typically, compare it with the media type the
+application expects and refuse anything else — is left to the application by the RFC.
+
+**`CWT Claims`** carries CWT claims ([RFC 8392](https://datatracker.ietf.org/doc/html/rfc8392)) in the header, so
+that they can be read without decoding the payload, or when there is no payload to carry them in. The accessor hands
+back the map as it travels, with every key checked to be a `Claim-Label` (`int / text`, the same rule as a header
+label) and nothing read into the claims themselves. It looks in the protected bucket first, then in the unprotected
+one — [RFC 9597 §2](https://www.rfc-editor.org/rfc/rfc9597#section-2) only *recommends* the protected bucket, "to
+avoid the contents being malleable" — and throws when the parameter appears in both: "The header parameter MUST only
+occur once in either the protected or unprotected header of a COSE structure."
+
+> [!IMPORTANT]
+> RFC 9597 §2: when a claim is present both in the header and in the payload, "an application receiving such a
+> structure MUST verify that their values are identical". The library cannot do this for you — the payload is opaque
+> to it — so the comparison is yours to make once the signature has been verified;
+> [`examples/08-cwt.php`](../examples/08-cwt.php) shows it claim by claim.
 
 ## Signature Operations
 
@@ -560,6 +611,25 @@ $expiresAt = isset($claims[4]) ? (int) $claims[4] : null;
 > [!IMPORTANT]
 > Verify before you read. A claims map decoded from an unverified payload is attacker-controlled input, and `exp` or
 > `iss` read from it means nothing.
+
+A token can also name itself and repeat claims in its protected header — `typ` ([RFC 9596](https://www.rfc-editor.org/rfc/rfc9596))
+and `CWT Claims` ([RFC 9597](https://www.rfc-editor.org/rfc/rfc9597)), read through `getTyp()` and
+`getCwtClaims()`; see [`typ` and `CWT Claims`](#typ-and-cwt-claims). Header claims are readable before the signature
+is checked, which is what they are for (routing to the right key, say), but they are no more trustworthy than the
+payload until it is; and a claim carried in both places has to be verified identical by the application.
+
+```php
+$headers = CoseHeaders::fromMessage($message);
+if ($headers->getTyp() !== 'application/cwt') {
+    throw new RuntimeException('Not a CWT');
+}
+$headerClaims = $headers->getCwtClaims(); // ?MapObject, protected bucket first
+
+// ... verify the signature, decode the payload claims, then:
+foreach ($headerClaims ?? [] as $claim) {
+    // RFC 9597 §2: a claim in both the header and the payload MUST have identical values
+}
+```
 
 ## Detached Content
 

--- a/examples/08-cwt.php
+++ b/examples/08-cwt.php
@@ -10,6 +10,12 @@ declare(strict_types=1);
  *
  * The point to take away: verify, then read. A claims map decoded from an unverified payload is attacker-controlled
  * input, and an "exp" read from it means nothing.
+ *
+ * Two header parameters travel with the token here: "typ" (RFC 9596), which names what the whole COSE object is, and
+ * "CWT Claims" (RFC 9597), which repeats claims in the protected header so that they can be read without decoding the
+ * payload. RFC 9597 section 2: when a claim appears in both, "an application receiving such a structure MUST verify
+ * that their values are identical" -- the payload is opaque to the library, so that comparison is done below, by the
+ * application.
  */
 
 use CBOR\ByteStringObject;
@@ -49,8 +55,17 @@ $claims = MapObject::create([
     MapItem::create(UnsignedIntegerObject::create(6), UnsignedIntegerObject::create($issuedAt)),
 ]);
 
+// RFC 9596 section 2: "typ" says what the COSE object is -- "application/cwt", or its CoAP Content-Format 61. It
+// MUST NOT be in the unprotected header. RFC 9597 section 2: "CWT Claims" is a map of claims, in the protected header
+// by recommendation; here "iss" and "exp" are repeated so that a consumer can route on them before verifying.
+$headerClaims = MapObject::create([
+    MapItem::create(UnsignedIntegerObject::create(1), TextStringObject::create('coap://as.example.com')),
+    MapItem::create(UnsignedIntegerObject::create(4), UnsignedIntegerObject::create($expiresAt)),
+]);
 $protectedHeader = HeaderMapHelper::encodeProtected(MapObject::create([
     MapItem::create(UnsignedIntegerObject::create(1), NegativeIntegerObject::create(ES256::identifier())),
+    MapItem::create(UnsignedIntegerObject::create(CoseHeaders::LABEL_TYP), TextStringObject::create('application/cwt')),
+    MapItem::create(UnsignedIntegerObject::create(CoseHeaders::LABEL_CWT_CLAIMS), $headerClaims),
 ]));
 
 // The claims set is the payload: opaque bytes as far as COSE is concerned.
@@ -91,6 +106,18 @@ example_assert(
 );
 example_line('kid', (string) $headers->getHeaderParameter(4)?->getValue());
 
+// The type: an application expecting a CWT refuses anything else (RFC 9596 section 2 leaves that check to it).
+// getTyp() reads the protected bucket only and rejects a message carrying "typ" in the unprotected one.
+$typ = $headers->getTyp();
+example_line('typ', (string) $typ);
+example_assert($typ === 'application/cwt' || $typ === 61, 'the token says it is a CWT');
+
+// The header claims are readable now, before the signature is checked: enough to pick the issuer's key, not
+// enough to trust. getCwtClaims() rejects the parameter when it appears in both buckets (RFC 9597 section 2).
+$claimsInHeader = $headers->getCwtClaims();
+example_assert($claimsInHeader !== null, 'the protected header carries CWT Claims');
+example_line('iss (header)', (string) HeaderMapHelper::findLabel($claimsInHeader, 1)?->normalize());
+
 // 2. Verify.
 $toBeVerified = Signature1::create($token->getProtectedHeader(), $token->getPayload());
 example_assert(
@@ -111,3 +138,20 @@ example_assert(is_string($decodedClaims[4]), 'the timestamps come back as numeri
 $expiry = (int) $decodedClaims[4];
 example_line('exp', sprintf('%d (%s)', $expiry, gmdate('Y-m-d H:i:s\Z', $expiry)));
 example_assert($expiry === $expiresAt, 'the expiry round-trips once cast');
+
+// 4. RFC 9597 section 2: a claim present in both the header and the payload MUST have identical values. The library
+// cannot do this for you -- it never decodes the payload -- so compare the encoded values claim by claim.
+$payloadClaims = Decoder::create()
+    ->decode(StringStream::create($token->getPayload()->getValue()));
+example_assert($payloadClaims instanceof MapObject, 'the payload is a claims map');
+foreach ($claimsInHeader as $claim) {
+    $key = $claim->getKey();
+    $label = $key instanceof UnsignedIntegerObject || $key instanceof NegativeIntegerObject
+        ? (int) $key->normalize()
+        : (string) $key->normalize();
+    $inPayload = HeaderMapHelper::findLabel($payloadClaims, $label);
+    example_assert(
+        $inPayload !== null && (string) $inPayload === (string) $claim->getValue(),
+        sprintf('header claim %s matches the payload', $label)
+    );
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -23,7 +23,7 @@ Every CBOR item is printed as hex in full, never truncated, so it can be pasted 
 | [`05-encrypt-recipients.php`](05-encrypt-recipients.php) | COSE_Encrypt: key wrapping per recipient, nested recipients, detached ciphertext |
 | [`06-headers.php`](06-headers.php) | The RFC 9052 header rules, each shown against what the raw CBOR map answers |
 | [`07-detached-and-external-aad.php`](07-detached-and-external-aad.php) | Detached content, and binding context that never travels |
-| [`08-cwt.php`](08-cwt.php) | CBOR Web Tokens: verify first, then read the claims |
+| [`08-cwt.php`](08-cwt.php) | CBOR Web Tokens: verify first, then read the claims; `typ` and `CWT Claims` in the header |
 | [`09-migration.php`](09-migration.php) | Moving off the deprecated `Cose\...Tag` classes |
 
 ## What the library does and does not do

--- a/src/Structure/CoseHeaders.php
+++ b/src/Structure/CoseHeaders.php
@@ -11,6 +11,8 @@ use CBOR\IndefiniteLengthByteStringObject;
 use CBOR\IndefiniteLengthMapObject;
 use CBOR\MapObject;
 use CBOR\Tag\AbstractCoseTag;
+use InvalidArgumentException;
+use function sprintf;
 
 /**
  * The two header buckets of a COSE message, read the way RFC 9052 defines them.
@@ -29,17 +31,33 @@ use CBOR\Tag\AbstractCoseTag;
  *
  * $alg = $headers->getProtectedHeaderParameter(1);   // never answered by the text string "1"
  * $kid = $headers->getHeaderParameter(4);            // protected bucket first
+ * $typ = $headers->getTyp();                         // RFC 9596: "application/cwt" or 61, protected bucket only
+ * $claims = $headers->getCwtClaims();                // RFC 9597: the claims map, or null
  * ```
  *
  * The protected bucket is decoded once, on first use.
  *
  * @see https://www.rfc-editor.org/rfc/rfc9052#section-3
+ * @see https://www.rfc-editor.org/rfc/rfc9596#section-2
+ * @see https://www.rfc-editor.org/rfc/rfc9597#section-2
  * @see https://github.com/web-auth/cose-lib/issues/166
  * @see \Cose\Tests\Structure\CoseHeadersTest
  */
 final class CoseHeaders
 {
     public const DEFAULT_PROTECTED_HEADER_MAX_DEPTH = HeaderMapHelper::DEFAULT_PROTECTED_HEADER_MAX_DEPTH;
+
+    /**
+     * The "CWT Claims" header parameter of RFC 9597: a map of CWT claims, so that they can be read before the
+     * payload is decrypted or when there is no payload to carry them in.
+     */
+    public const LABEL_CWT_CLAIMS = 15;
+
+    /**
+     * The "typ" (type) header parameter of RFC 9596: the type of the whole COSE object, as opposed to "content type"
+     * (label 3), which is the type of its payload.
+     */
+    public const LABEL_TYP = 16;
 
     private ?MapObject $decodedProtectedHeader = null;
 
@@ -147,5 +165,75 @@ final class CoseHeaders
     public function getHeaderParameter(int|string $label): ?CBORObject
     {
         return $this->getProtectedHeaderParameter($label) ?? $this->getUnprotectedHeaderParameter($label);
+    }
+
+    /**
+     * The "typ" header parameter (RFC 9596), or null when the message does not declare one.
+     *
+     * An unsigned integer is a CoAP Content-Format identifier, and a text string a media type name that "MAY include
+     * media type parameters" (section 2) -- "application/cwt" or 61 both say CWT. The syntax is the one of "content
+     * type" (RFC 9052 section 3.1): a text value without the "<type-name>/<subtype-name>" shape is rejected. RFC 9596
+     * defines no "application/" shorthand, unlike JOSE, so a bare "cwt" is malformed rather than something to expand.
+     *
+     * Section 2: "The 'typ' parameter MUST NOT be present in unprotected headers." This accessor reads the protected
+     * bucket only and rejects a message that carries the label in the unprotected one, wherever else it appears.
+     * The raw lookup, getProtectedHeaderParameter(CoseHeaders::LABEL_TYP), is the lenient form: it never looks at
+     * the unprotected bucket and hands the value back unchecked.
+     *
+     * What the value means is the application's business: RFC 9596 section 2 leaves any processing, such as comparing
+     * it with an expected media type, to "application-specific processing rules".
+     *
+     * @see https://www.rfc-editor.org/rfc/rfc9596#section-2
+     */
+    public function getTyp(): int|string|null
+    {
+        $typ = $this->getProtectedHeaderParameter(self::LABEL_TYP);
+        if (HeaderMapHelper::findLabel($this->unprotectedHeader, self::LABEL_TYP) !== null) {
+            throw new InvalidArgumentException(
+                'Invalid "typ" header parameter. It shall not be present in the unprotected header (RFC 9596 section 2).'
+            );
+        }
+
+        return $typ === null ? null : HeaderMapHelper::assertContentTypeValue($typ, 'typ');
+    }
+
+    /**
+     * The "CWT Claims" header parameter (RFC 9597), or null when the message does not carry one.
+     *
+     * The value is the claims map as it travels, "{ * Claim-Label => any }" with "Claim-Label = int / text": every
+     * key is checked to be a label, nothing is read into the claims themselves. RFC 8392 defines the registered
+     * ones (1 = iss, 2 = sub, 3 = aud, 4 = exp, 5 = nbf, 6 = iat, 7 = cti); what to do with them is left to the
+     * application, as is the rule of RFC 9597 section 2 that a claim carried both here and in the payload "MUST" have
+     * identical values -- the payload is opaque to this library.
+     *
+     * The parameter is looked up in the protected bucket first, then in the unprotected one; section 2 only
+     * recommends the protected bucket ("RECOMMENDED ... to avoid the contents being malleable"), so neither is
+     * refused. What is refused is the parameter appearing in both: "The header parameter MUST only occur once in
+     * either the protected or unprotected header of a COSE structure."
+     *
+     * @see https://www.rfc-editor.org/rfc/rfc9597#section-2
+     */
+    public function getCwtClaims(): ?MapObject
+    {
+        $protected = $this->getProtectedHeaderParameter(self::LABEL_CWT_CLAIMS);
+        $unprotected = $this->getUnprotectedHeaderParameter(self::LABEL_CWT_CLAIMS);
+        if ($protected !== null && $unprotected !== null) {
+            throw new InvalidArgumentException(
+                'Invalid "CWT Claims" header parameter. It shall occur once, in either the protected or the unprotected header, not in both (RFC 9597 section 2).'
+            );
+        }
+
+        $claims = $protected ?? $unprotected;
+        if ($claims === null) {
+            return null;
+        }
+        if (! $claims instanceof MapObject && ! $claims instanceof IndefiniteLengthMapObject) {
+            throw new InvalidArgumentException(sprintf(
+                'Invalid "CWT Claims" header parameter. The value shall be a map of claims (RFC 9597 section 2), got "%s".',
+                $claims::class
+            ));
+        }
+
+        return HeaderMapHelper::assertValidClaimLabels($claims);
     }
 }

--- a/src/Structure/HeaderMapHelper.php
+++ b/src/Structure/HeaderMapHelper.php
@@ -23,8 +23,10 @@ use function in_array;
 use InvalidArgumentException;
 use function is_int;
 use function ord;
+use function preg_match;
 use function sprintf;
 use function strlen;
+use function trim;
 
 /**
  * The RFC 9052 rules that sit above the CBOR shape of a COSE message: how a protected bucket is encoded and decoded,
@@ -53,6 +55,19 @@ final class HeaderMapHelper
      * to nest thousands of levels is rejected instead of being walked.
      */
     public const DEFAULT_PROTECTED_HEADER_MAX_DEPTH = 32;
+
+    /**
+     * The largest CoAP Content-Format identifier: RFC 7252 section 12.3 registers "the numeric identifier in the
+     * range 0-65535".
+     */
+    public const COAP_CONTENT_FORMAT_MAX = 65535;
+
+    /**
+     * "<type-name>/<subtype-name>" as RFC 9052 section 3.1 defines a textual content type, each name being a
+     * restricted-name of RFC 6838 section 4.2 (a letter or a digit, then up to 126 of [A-Za-z0-9!#$&^_.+-]), followed
+     * by the optional media type parameters of RFC 9110 section 8.3.1 ("*( OWS ";" OWS [ parameter ] )").
+     */
+    private const CONTENT_TYPE_PATTERN = '/^[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]{0,126}\/[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]{0,126}(?:[ \t]*;.*)?$/D';
 
     /**
      * Decode the protected bucket, strictly.
@@ -126,19 +141,78 @@ final class HeaderMapHelper
      */
     public static function assertValidLabels(MapObject|IndefiniteLengthMapObject $header): MapObject
     {
-        $checked = MapObject::create();
-        foreach ($header as $item) {
-            $key = $item->getKey();
-            if (! self::isLabel($key)) {
+        return self::assertIntOrTextKeys(
+            $header,
+            'Invalid header label. A label shall be an integer or a text string, got "%s" (RFC 9052 section 1.5).'
+        );
+    }
+
+    /**
+     * The same rule for a CWT claims map, and the same reason.
+     *
+     * RFC 9597 section 2 writes the value of the "CWT Claims" header parameter as "{ * Claim-Label => any }" with
+     * "Claim-Label = int / text" -- the label rule of RFC 9052 section 1.5, applied to claims. The check stops at
+     * the keys: what a claim means is left to the application (RFC 8392), so the values are handed back as carried.
+     *
+     * @see https://www.rfc-editor.org/rfc/rfc9597#section-2
+     */
+    public static function assertValidClaimLabels(MapObject|IndefiniteLengthMapObject $claims): MapObject
+    {
+        return self::assertIntOrTextKeys(
+            $claims,
+            'Invalid CWT claim label. A Claim-Label shall be an integer or a text string, got "%s" (RFC 9597 section 2).'
+        );
+    }
+
+    /**
+     * The value of a content-type-shaped header parameter: "content type" (label 3) and "typ" (label 16).
+     *
+     * RFC 9052 section 3.1 types "content type" as "tstr / uint" -- an unsigned integer "from the 'CoAP
+     * Content-Formats' IANA registry table", or a text value that follows "the syntax of '<type-name>/<subtype-name>',
+     * where <type-name> and <subtype-name> are defined in Section 4.2 of [RFC6838]. Leading and trailing whitespace
+     * is not permitted." RFC 9596 section 2 gives "typ" that same syntax, and adds that a text value "MAY include
+     * media type parameters".
+     *
+     * An integer is therefore bounded to the registry, 0 to 65535 (RFC 7252 section 12.3), and a text value has to
+     * carry the slash: neither RFC defines the "application/" shorthand of JOSE, so a bare "cwt" is not a media type
+     * name here, and there is nothing to expand it into.
+     *
+     * @param string $parameter the name of the parameter, for the error messages
+     */
+    public static function assertContentTypeValue(CBORObject $value, string $parameter): int|string
+    {
+        if ($value instanceof UnsignedIntegerObject) {
+            $number = $value->getValue();
+            if (strlen($number) > 5 || (int) $number > self::COAP_CONTENT_FORMAT_MAX) {
                 throw new InvalidArgumentException(sprintf(
-                    'Invalid header label. A label shall be an integer or a text string, got "%s" (RFC 9052 section 1.5).',
-                    $key::class
+                    'Invalid "%s" header parameter. An integer value shall be a CoAP Content-Format identifier, in the range 0-%d (RFC 7252 section 12.3), got %s.',
+                    $parameter,
+                    self::COAP_CONTENT_FORMAT_MAX,
+                    $number
                 ));
             }
-            $checked->add($key, $item->getValue());
+
+            return (int) $number;
         }
 
-        return $checked;
+        if ($value instanceof TextStringObject || $value instanceof IndefiniteLengthTextStringObject) {
+            $text = $value->getValue();
+            if (trim($text) !== $text || preg_match(self::CONTENT_TYPE_PATTERN, $text) !== 1) {
+                throw new InvalidArgumentException(sprintf(
+                    'Invalid "%s" header parameter. A text value shall be a media type name of the form "<type-name>/<subtype-name>" (RFC 9052 section 3.1, RFC 6838 section 4.2), got "%s".',
+                    $parameter,
+                    $text
+                ));
+            }
+
+            return $text;
+        }
+
+        throw new InvalidArgumentException(sprintf(
+            'Invalid "%s" header parameter. The value shall be an unsigned integer or a text string (RFC 9052 section 3.1), got "%s".',
+            $parameter,
+            $value::class
+        ));
     }
 
     /**
@@ -286,6 +360,24 @@ final class HeaderMapHelper
     private static function isByteString(CBORObject $object): bool
     {
         return $object instanceof ByteStringObject || $object instanceof IndefiniteLengthByteStringObject;
+    }
+
+    /**
+     * Rebuild a map as a definite-length one, refusing any key that is neither an integer nor a text string; $message
+     * is the sprintf() template of the error, with the class of the offending key as its argument.
+     */
+    private static function assertIntOrTextKeys(MapObject|IndefiniteLengthMapObject $map, string $message): MapObject
+    {
+        $checked = MapObject::create();
+        foreach ($map as $item) {
+            $key = $item->getKey();
+            if (! self::isLabel($key)) {
+                throw new InvalidArgumentException(sprintf($message, $key::class));
+            }
+            $checked->add($key, $item->getValue());
+        }
+
+        return $checked;
     }
 
     private static function isLabel(CBORObject $key): bool

--- a/tests/Structure/CoseHeadersTest.php
+++ b/tests/Structure/CoseHeadersTest.php
@@ -7,6 +7,8 @@ namespace Cose\Tests\Structure;
 use CBOR\ByteStringObject;
 use CBOR\CBORObject;
 use CBOR\Decoder;
+use CBOR\IndefiniteLengthMapObject;
+use CBOR\IndefiniteLengthTextStringObject;
 use CBOR\ListObject;
 use CBOR\MapItem;
 use CBOR\MapObject;
@@ -22,6 +24,7 @@ use CBOR\Tag\CoseSignTag;
 use CBOR\TextStringObject;
 use CBOR\UnsignedIntegerObject;
 use Cose\Structure\CoseHeaders;
+use Cose\Structure\HeaderMapHelper;
 use Cose\Tests\CoseInnerLists;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -34,8 +37,14 @@ use PHPUnit\Framework\TestCase;
  * The point of running one body against all six is that RFC 9052 defines the two header buckets once, for every
  * message type; the reader has to answer the same way whether the message is a COSE_Sign1 or a COSE_Encrypt.
  *
+ * The two typed accessors of RFC 9596 ("typ") and RFC 9597 ("CWT Claims") are tested here as well, since both are
+ * header parameters and nothing more.
+ *
  * @see https://www.rfc-editor.org/rfc/rfc9052#section-3
+ * @see https://www.rfc-editor.org/rfc/rfc9596#section-2
+ * @see https://www.rfc-editor.org/rfc/rfc9597#section-2
  * @see https://github.com/web-auth/cose-lib/issues/166
+ * @see https://github.com/web-auth/cose-lib/issues/198
  */
 final class CoseHeadersTest extends TestCase
 {
@@ -247,6 +256,347 @@ final class CoseHeadersTest extends TestCase
 
         // Then
         static::assertSame($headers->getProtectedHeaderAsMap(), $headers->getProtectedHeaderAsMap());
+    }
+
+    /**
+     * The labels of RFC 9596 and RFC 9597 as IANA registers them.
+     */
+    #[Test]
+    public function theLabelsAreTheRegisteredOnes(): void
+    {
+        static::assertSame(15, CoseHeaders::LABEL_CWT_CLAIMS);
+        static::assertSame(16, CoseHeaders::LABEL_TYP);
+    }
+
+    /**
+     * A protected header carrying both parameters is written by HeaderMapHelper::encodeProtected() and read back
+     * by the typed accessors, on every message type.
+     *
+     * @param class-string<AbstractCoseTag> $class
+     */
+    #[Test]
+    #[DataProvider('getMessageClasses')]
+    public function typAndCwtClaimsRoundTripThroughTheProtectedHeader(string $class): void
+    {
+        // Given: {1: -7, 16: "application/cwt", 15: {1: "coap://as.example.com", 4: 1443944944}}
+        $claims = MapObject::create([
+            MapItem::create(UnsignedIntegerObject::create(1), TextStringObject::create('coap://as.example.com')),
+            MapItem::create(UnsignedIntegerObject::create(4), UnsignedIntegerObject::create(1443944944)),
+        ]);
+        $protectedHeader = HeaderMapHelper::encodeProtected(MapObject::create([
+            MapItem::create(UnsignedIntegerObject::create(1), NegativeIntegerObject::create(-7)),
+            MapItem::create(UnsignedIntegerObject::create(CoseHeaders::LABEL_TYP), TextStringObject::create('application/cwt')),
+            MapItem::create(UnsignedIntegerObject::create(CoseHeaders::LABEL_CWT_CLAIMS), $claims),
+        ]));
+
+        // When: the message travels as bytes and is decoded again
+        $message = Decoder::create()
+            ->decode(StringStream::create((string) self::message($class, $protectedHeader)));
+        static::assertInstanceOf(AbstractCoseTag::class, $message);
+        $headers = CoseHeaders::fromMessage($message);
+
+        // Then
+        static::assertSame('application/cwt', $headers->getTyp());
+        $readClaims = $headers->getCwtClaims();
+        static::assertNotNull($readClaims);
+        static::assertSame((string) $claims, (string) $readClaims);
+        static::assertSame(
+            'coap://as.example.com',
+            HeaderMapHelper::findLabel($readClaims, 1)?->normalize()
+        );
+        static::assertSame('1443944944', HeaderMapHelper::findLabel($readClaims, 4)?->normalize());
+        static::assertNull($headers->getUnprotectedHeaderParameter(CoseHeaders::LABEL_TYP));
+        static::assertNull($headers->getUnprotectedHeaderParameter(CoseHeaders::LABEL_CWT_CLAIMS));
+    }
+
+    /**
+     * A message without either parameter answers null, not an exception.
+     */
+    #[Test]
+    public function absentTypAndCwtClaimsAreNull(): void
+    {
+        // Given: {1: -7}
+        $header = MapObject::create([
+            MapItem::create(UnsignedIntegerObject::create(1), NegativeIntegerObject::create(-7)),
+        ]);
+        $headers = CoseHeaders::fromMessage(
+            self::message(CoseSign1Tag::class, ByteStringObject::create((string) $header))
+        );
+
+        // Then
+        static::assertNull($headers->getTyp());
+        static::assertNull($headers->getCwtClaims());
+    }
+
+    /**
+     * RFC 9596 section 2: "typ" is "either an unsigned integer as registered in the 'CoAP Content-Formats' registry
+     * or a string content type value", which "MAY include media type parameters".
+     *
+     * @param int|string $expected what the accessor answers
+     */
+    #[Test]
+    #[DataProvider('getValidTypValues')]
+    public function aWellFormedTypIsRead(CBORObject $value, int|string $expected): void
+    {
+        // Given
+        $header = MapObject::create([
+            MapItem::create(UnsignedIntegerObject::create(CoseHeaders::LABEL_TYP), $value),
+        ]);
+        $headers = CoseHeaders::fromMessage(
+            self::message(CoseSign1Tag::class, ByteStringObject::create((string) $header))
+        );
+
+        // Then
+        static::assertSame($expected, $headers->getTyp());
+    }
+
+    /**
+     * @return iterable<string, array{CBORObject, int|string}>
+     */
+    public static function getValidTypValues(): iterable
+    {
+        yield 'the media type name "application/cwt"' => [TextStringObject::create('application/cwt'), 'application/cwt'];
+        yield 'the CoAP Content-Format 61 (application/cwt)' => [UnsignedIntegerObject::create(61), 61];
+        yield 'the CoAP Content-Format 0 (text/plain; charset=utf-8)' => [UnsignedIntegerObject::create(0), 0];
+        yield 'the largest CoAP Content-Format, 65535' => [UnsignedIntegerObject::create(65535), 65535];
+        yield 'a media type with parameters' => [
+            TextStringObject::create('application/sd-cwt; version=1'),
+            'application/sd-cwt; version=1',
+        ];
+        yield 'a structured syntax suffix' => [TextStringObject::create('application/cose+cbor'), 'application/cose+cbor'];
+        yield 'an indefinite-length text string' => [
+            IndefiniteLengthTextStringObject::create('application/', 'cwt'),
+            'application/cwt',
+        ];
+    }
+
+    /**
+     * RFC 9052 section 3.1, which RFC 9596 section 2 refers to for the syntax: a text value follows
+     * "<type-name>/<subtype-name>" and "Leading and trailing whitespace is not permitted"; an integer is a CoAP
+     * Content-Format identifier, hence 0-65535 (RFC 7252 section 12.3). A bare "cwt" is the case the issue names:
+     * RFC 9596 defines no "application/" shorthand, so it is malformed, not something to expand.
+     */
+    #[Test]
+    #[DataProvider('getInvalidTypValues')]
+    public function aMalformedTypIsRejected(CBORObject $value, string $message): void
+    {
+        // Given
+        $header = MapObject::create([
+            MapItem::create(UnsignedIntegerObject::create(CoseHeaders::LABEL_TYP), $value),
+        ]);
+        $headers = CoseHeaders::fromMessage(
+            self::message(CoseSign1Tag::class, ByteStringObject::create((string) $header))
+        );
+
+        // Then: the raw lookup still answers, the typed accessor does not
+        static::assertNotNull($headers->getProtectedHeaderParameter(CoseHeaders::LABEL_TYP));
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage($message);
+        $headers->getTyp();
+    }
+
+    /**
+     * @return iterable<string, array{CBORObject, string}>
+     */
+    public static function getInvalidTypValues(): iterable
+    {
+        yield 'a bare "cwt"' => [TextStringObject::create('cwt'), 'shall be a media type name'];
+        yield 'an empty text string' => [TextStringObject::create(''), 'shall be a media type name'];
+        yield 'a missing type name' => [TextStringObject::create('/cwt'), 'shall be a media type name'];
+        yield 'a missing subtype name' => [TextStringObject::create('application/'), 'shall be a media type name'];
+        yield 'leading whitespace' => [TextStringObject::create(' application/cwt'), 'shall be a media type name'];
+        yield 'trailing whitespace' => [TextStringObject::create('application/cwt '), 'shall be a media type name'];
+        yield 'a character outside RFC 6838' => [TextStringObject::create('application/c wt'), 'shall be a media type name'];
+        yield 'an integer beyond the CoAP registry' => [UnsignedIntegerObject::create(65536), 'in the range 0-65535'];
+        yield 'a very large integer' => [UnsignedIntegerObject::createFromString('18446744073709551615'), 'in the range 0-65535'];
+        yield 'a negative integer' => [NegativeIntegerObject::create(-1), 'shall be an unsigned integer or a text string'];
+        yield 'a byte string' => [ByteStringObject::create('application/cwt'), 'shall be an unsigned integer or a text string'];
+        yield 'a map' => [MapObject::create(), 'shall be an unsigned integer or a text string'];
+    }
+
+    /**
+     * RFC 9596 section 2: "The 'typ' parameter MUST NOT be present in unprotected headers."
+     *
+     * @param class-string<AbstractCoseTag> $class
+     */
+    #[Test]
+    #[DataProvider('getMessageClasses')]
+    public function aTypInTheUnprotectedBucketIsRejectedByTheTypedAccessor(string $class): void
+    {
+        // Given: {} protected, {16: "application/cwt"} unprotected
+        $unprotectedHeader = MapObject::create([
+            MapItem::create(UnsignedIntegerObject::create(CoseHeaders::LABEL_TYP), TextStringObject::create('application/cwt')),
+        ]);
+        $headers = CoseHeaders::fromMessage(self::message($class, ByteStringObject::create(''), $unprotectedHeader));
+
+        // Then: the lenient lookup ignores it, the typed accessor refuses the message
+        static::assertNull($headers->getProtectedHeaderParameter(CoseHeaders::LABEL_TYP));
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('shall not be present in the unprotected header (RFC 9596 section 2)');
+        $headers->getTyp();
+    }
+
+    /**
+     * The unprotected copy makes the message malformed even when the protected bucket carries a valid "typ": the
+     * rule is on the presence of the label, not on which value would win.
+     */
+    #[Test]
+    public function aTypInBothBucketsIsRejectedByTheTypedAccessor(): void
+    {
+        // Given: {16: 61} protected, {16: 61} unprotected
+        $header = MapObject::create([
+            MapItem::create(UnsignedIntegerObject::create(CoseHeaders::LABEL_TYP), UnsignedIntegerObject::create(61)),
+        ]);
+        $headers = CoseHeaders::fromMessage(
+            self::message(CoseSign1Tag::class, ByteStringObject::create((string) $header), $header)
+        );
+
+        // Then
+        static::assertSame('61', $headers->getProtectedHeaderParameter(CoseHeaders::LABEL_TYP)?->normalize());
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('shall not be present in the unprotected header');
+        $headers->getTyp();
+    }
+
+    /**
+     * RFC 9597 section 2 only recommends the protected bucket, so a claims map in the unprotected one is read.
+     *
+     * @param class-string<AbstractCoseTag> $class
+     */
+    #[Test]
+    #[DataProvider('getMessageClasses')]
+    public function cwtClaimsInTheUnprotectedBucketAreRead(string $class): void
+    {
+        // Given: {} protected, {15: {2: "erikw"}} unprotected
+        $claims = MapObject::create([
+            MapItem::create(UnsignedIntegerObject::create(2), TextStringObject::create('erikw')),
+        ]);
+        $unprotectedHeader = MapObject::create([
+            MapItem::create(UnsignedIntegerObject::create(CoseHeaders::LABEL_CWT_CLAIMS), $claims),
+        ]);
+        $headers = CoseHeaders::fromMessage(self::message($class, ByteStringObject::create(''), $unprotectedHeader));
+
+        // Then
+        static::assertSame('erikw', HeaderMapHelper::findLabel($headers->getCwtClaims() ?? MapObject::create(), 2)?->normalize());
+    }
+
+    /**
+     * RFC 9597 section 2: "The header parameter MUST only occur once in either the protected or unprotected header
+     * of a COSE structure."
+     *
+     * @param class-string<AbstractCoseTag> $class
+     */
+    #[Test]
+    #[DataProvider('getMessageClasses')]
+    public function cwtClaimsInBothBucketsAreRejected(string $class): void
+    {
+        // Given: the same {15: {2: "erikw"}} in both buckets
+        $header = MapObject::create([
+            MapItem::create(UnsignedIntegerObject::create(CoseHeaders::LABEL_CWT_CLAIMS), MapObject::create([
+                MapItem::create(UnsignedIntegerObject::create(2), TextStringObject::create('erikw')),
+            ])),
+        ]);
+        $headers = CoseHeaders::fromMessage(
+            self::message($class, ByteStringObject::create((string) $header), $header)
+        );
+
+        // Then: the raw lookups answer for each bucket, the typed accessor refuses the message
+        static::assertNotNull($headers->getProtectedHeaderParameter(CoseHeaders::LABEL_CWT_CLAIMS));
+        static::assertNotNull($headers->getUnprotectedHeaderParameter(CoseHeaders::LABEL_CWT_CLAIMS));
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('not in both (RFC 9597 section 2)');
+        $headers->getCwtClaims();
+    }
+
+    /**
+     * The values of the claims are handed back as carried: a nested "cnf" (RFC 8747) map is neither read nor
+     * checked, and an indefinite-length claims map is accepted as any other CBOR map is.
+     */
+    #[Test]
+    public function theClaimsAreHandedBackAsCarried(): void
+    {
+        // Given: {15: {_ 8: {1: {1: 2, -1: 1}}, "custom": h'00'}}
+        $confirmation = MapObject::create([
+            MapItem::create(UnsignedIntegerObject::create(1), MapObject::create([
+                MapItem::create(UnsignedIntegerObject::create(1), UnsignedIntegerObject::create(2)),
+                MapItem::create(NegativeIntegerObject::create(-1), UnsignedIntegerObject::create(1)),
+            ])),
+        ]);
+        $claims = IndefiniteLengthMapObject::create()
+            ->add(UnsignedIntegerObject::create(8), $confirmation)
+            ->add(TextStringObject::create('custom'), ByteStringObject::create("\x00"));
+        $header = MapObject::create([
+            MapItem::create(UnsignedIntegerObject::create(CoseHeaders::LABEL_CWT_CLAIMS), $claims),
+        ]);
+        $headers = CoseHeaders::fromMessage(
+            self::message(CoseSign1Tag::class, ByteStringObject::create((string) $header))
+        );
+
+        // When
+        $read = $headers->getCwtClaims();
+
+        // Then
+        static::assertNotNull($read);
+        static::assertCount(2, $read);
+        static::assertSame((string) $confirmation, (string) HeaderMapHelper::findLabel($read, 8));
+        static::assertSame("\x00", HeaderMapHelper::findLabel($read, 'custom')?->getValue());
+        static::assertNull(HeaderMapHelper::findLabel($read, 'nope'));
+    }
+
+    /**
+     * RFC 9597 section 2 types the parameter as a map: anything else is malformed.
+     */
+    #[Test]
+    #[DataProvider('getNonMapClaims')]
+    public function cwtClaimsThatAreNotAMapAreRejected(CBORObject $value): void
+    {
+        // Given
+        $header = MapObject::create([
+            MapItem::create(UnsignedIntegerObject::create(CoseHeaders::LABEL_CWT_CLAIMS), $value),
+        ]);
+        $headers = CoseHeaders::fromMessage(
+            self::message(CoseSign1Tag::class, ByteStringObject::create((string) $header))
+        );
+
+        // Then
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('shall be a map of claims (RFC 9597 section 2)');
+        $headers->getCwtClaims();
+    }
+
+    /**
+     * @return iterable<string, array{CBORObject}>
+     */
+    public static function getNonMapClaims(): iterable
+    {
+        yield 'a byte string' => [ByteStringObject::create("\xa0")];
+        yield 'a text string' => [TextStringObject::create('{}')];
+        yield 'a list' => [ListObject::create()];
+        yield 'an integer' => [UnsignedIntegerObject::create(1)];
+    }
+
+    /**
+     * RFC 9597 section 2: "Claim-Label = int / text". A byte-string key normalizes to the same offset as an
+     * integer or a text string, which is the reason the header-label rule exists; it applies to the claims too.
+     */
+    #[Test]
+    public function aByteStringClaimLabelIsRejected(): void
+    {
+        // Given: {15: {h'31': "coap://as.example.com"}}
+        $claims = MapObject::create([
+            MapItem::create(ByteStringObject::create('1'), TextStringObject::create('coap://as.example.com')),
+        ]);
+        $header = MapObject::create([
+            MapItem::create(UnsignedIntegerObject::create(CoseHeaders::LABEL_CWT_CLAIMS), $claims),
+        ]);
+        $headers = CoseHeaders::fromMessage(
+            self::message(CoseSign1Tag::class, ByteStringObject::create((string) $header))
+        );
+
+        // Then
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid CWT claim label');
+        $headers->getCwtClaims();
     }
 
     /**

--- a/tests/Structure/CwtTest.php
+++ b/tests/Structure/CwtTest.php
@@ -18,10 +18,12 @@ use CBOR\UnsignedIntegerObject;
 use Cose\Algorithm\Signature\ECDSA\ES256;
 use Cose\Key\Ec2Key;
 use Cose\Signature\Signature1;
+use Cose\Structure\CoseHeaders;
 use Cose\Structure\HeaderMapHelper;
 use const OPENSSL_KEYTYPE_EC;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use function sprintf;
 use function str_pad;
 use const STR_PAD_LEFT;
 
@@ -32,7 +34,11 @@ use const STR_PAD_LEFT;
  * about the COSE verification changes -- the payload is opaque bytes until the signature checks out -- which is
  * exactly what the documented order of operations is about.
  *
+ * The header side of a CWT is covered too: "typ" (RFC 9596) names the token, and "CWT Claims" (RFC 9597) carries
+ * claims in the protected header, next to the payload.
+ *
  * @see https://datatracker.ietf.org/doc/html/rfc8392#section-6
+ * @see https://www.rfc-editor.org/rfc/rfc9597#section-2
  */
 final class CwtTest extends TestCase
 {
@@ -108,9 +114,51 @@ final class CwtTest extends TestCase
     }
 
     /**
-     * A COSE_Sign1 carrying a CWT claims set as its payload.
+     * RFC 9597 section 2: "In cases where CWT claims are present both in the payload and the header of a CWT, an
+     * application receiving such a structure MUST verify that their values are identical". The library reads the
+     * header side; the payload is opaque to it, so the comparison is the application's, and this is what it looks
+     * like. "typ" (RFC 9596) travels in the same protected bucket.
      */
-    private static function signedToken(Ec2Key $key): CoseSign1Tag
+    #[Test]
+    public function theHeaderClaimsAreCheckedAgainstThePayload(): void
+    {
+        // Given: a token whose protected header repeats "iss" and names the type
+        $key = self::signingKey();
+        $encoded = (string) self::signedToken($key, withHeaderClaims: true);
+        $message = Decoder::create()
+            ->decode(StringStream::create($encoded));
+        static::assertInstanceOf(CoseSign1Tag::class, $message);
+        $headers = CoseHeaders::fromMessage($message);
+
+        // Then: the header side is readable before the signature is checked, and says what the token is
+        static::assertSame('application/cwt', $headers->getTyp());
+        $headerClaims = $headers->getCwtClaims();
+        static::assertNotNull($headerClaims);
+        static::assertSame(self::ISSUER, HeaderMapHelper::findLabel($headerClaims, 1)?->normalize());
+
+        // When: verified, then the payload claims are decoded
+        static::assertTrue(self::verify($message, $key->toPublic()));
+        $payloadClaims = Decoder::create()
+            ->decode(StringStream::create($message->getPayload()->getValue()));
+        static::assertInstanceOf(MapObject::class, $payloadClaims);
+
+        // Then: every claim the header carries is byte-identical in the payload
+        foreach ($headerClaims as $item) {
+            $key = $item->getKey();
+            $label = $key instanceof UnsignedIntegerObject || $key instanceof NegativeIntegerObject
+                ? (int) $key->normalize()
+                : (string) $key->normalize();
+            $inPayload = HeaderMapHelper::findLabel($payloadClaims, $label);
+            static::assertNotNull($inPayload, sprintf('claim %s is missing from the payload', $label));
+            static::assertSame((string) $item->getValue(), (string) $inPayload);
+        }
+    }
+
+    /**
+     * A COSE_Sign1 carrying a CWT claims set as its payload, and optionally "typ" and a copy of "iss" in its
+     * protected header.
+     */
+    private static function signedToken(Ec2Key $key, bool $withHeaderClaims = false): CoseSign1Tag
     {
         // RFC 8392 §3.1: 1 = iss, 6 = iat
         $claims = MapObject::create([
@@ -124,6 +172,13 @@ final class CwtTest extends TestCase
                 NegativeIntegerObject::create(ES256::identifier())
             ),
         ]);
+        if ($withHeaderClaims) {
+            $protectedHeader
+                ->add(UnsignedIntegerObject::create(CoseHeaders::LABEL_TYP), TextStringObject::create('application/cwt'))
+                ->add(UnsignedIntegerObject::create(CoseHeaders::LABEL_CWT_CLAIMS), MapObject::create([
+                    MapItem::create(UnsignedIntegerObject::create(1), TextStringObject::create(self::ISSUER)),
+                ]));
+        }
         $protectedHeaderAsBytes = HeaderMapHelper::encodeProtected($protectedHeader);
         $payload = ByteStringObject::create((string) $claims);
 

--- a/tests/Structure/HeaderMapHelperTest.php
+++ b/tests/Structure/HeaderMapHelperTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Cose\Tests\Structure;
 
 use CBOR\ByteStringObject;
+use CBOR\CBORObject;
 use CBOR\IndefiniteLengthByteStringObject;
+use CBOR\IndefiniteLengthMapObject;
 use CBOR\ListObject;
 use CBOR\MapItem;
 use CBOR\MapObject;
@@ -181,6 +183,72 @@ final class HeaderMapHelperTest extends TestCase
             MapItem::create(UnsignedIntegerObject::create(1), NegativeIntegerObject::create(-8)),
         ]);
         HeaderMapHelper::encodeProtected($duplicate);
+    }
+
+    /**
+     * RFC 9597 section 2: "Claim-Label = int / text". The claims map is rebuilt as a definite-length one with its
+     * values untouched, and the message names the claims, not the header.
+     */
+    #[Test]
+    public function claimLabelsAreCheckedTheWayHeaderLabelsAre(): void
+    {
+        // Given: {_ 1: "coap://as.example.com", "custom": [1]}
+        $list = ListObject::create([UnsignedIntegerObject::create(1)]);
+        $claims = IndefiniteLengthMapObject::create()
+            ->add(UnsignedIntegerObject::create(1), TextStringObject::create('coap://as.example.com'))
+            ->add(TextStringObject::create('custom'), $list);
+
+        // When
+        $checked = HeaderMapHelper::assertValidClaimLabels($claims);
+
+        // Then
+        static::assertSame(MapObject::class, $checked::class);
+        static::assertCount(2, $checked);
+        static::assertSame('coap://as.example.com', HeaderMapHelper::findLabel($checked, 1)?->normalize());
+        static::assertSame($list, HeaderMapHelper::findLabel($checked, 'custom'));
+
+        // Then: {h'31': "x"} is refused, with the claims rule named
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid CWT claim label. A Claim-Label shall be an integer or a text string, got "CBOR\\ByteStringObject" (RFC 9597 section 2).');
+        HeaderMapHelper::assertValidClaimLabels(MapObject::create([
+            MapItem::create(ByteStringObject::create('1'), TextStringObject::create('x')),
+        ]));
+    }
+
+    /**
+     * RFC 9052 section 3.1 types "content type" as an unsigned integer of the CoAP Content-Formats registry or a
+     * "<type-name>/<subtype-name>" text; RFC 9596 section 2 gives "typ" the same syntax. One primitive serves both,
+     * and the parameter name it is given is the one the error carries.
+     */
+    #[Test]
+    #[DataProvider('getContentTypeValues')]
+    public function aContentTypeShapedValueIsDecoded(CBORObject $value, int|string|null $expected): void
+    {
+        if ($expected === null) {
+            // Then
+            $this->expectException(InvalidArgumentException::class);
+            $this->expectExceptionMessage('Invalid "content type" header parameter.');
+        }
+
+        // When
+        $decoded = HeaderMapHelper::assertContentTypeValue($value, 'content type');
+
+        // Then
+        static::assertSame($expected, $decoded);
+    }
+
+    /**
+     * @return iterable<string, array{CBORObject, int|string|null}>
+     */
+    public static function getContentTypeValues(): iterable
+    {
+        yield 'CoAP Content-Format 50 (application/json)' => [UnsignedIntegerObject::create(50), 50];
+        yield 'the registry bound, 65535' => [UnsignedIntegerObject::create(HeaderMapHelper::COAP_CONTENT_FORMAT_MAX), 65535];
+        yield 'just past the registry bound' => [UnsignedIntegerObject::create(65536), null];
+        yield 'text/plain; charset=utf-8' => [TextStringObject::create('text/plain; charset=utf-8'), 'text/plain; charset=utf-8'];
+        yield 'a name without a slash' => [TextStringObject::create('json'), null];
+        yield 'a negative integer' => [NegativeIntegerObject::create(-1), null];
+        yield 'nil' => [NullObject::create(), null];
     }
 
     /**


### PR DESCRIPTION
Target branch: 4.9.x
Resolves issue #198

- [ ] It is a Bug fix
- [x] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

Closes #198. Part of #202 (no dependency on the other issues of the batch).

Two header-only specifications, no cryptography involved: `typ` (label 16, [RFC 9596](https://www.rfc-editor.org/rfc/rfc9596)) and `CWT Claims` (label 15, [RFC 9597](https://www.rfc-editor.org/rfc/rfc9597)), both required by SD-CWT and mdoc. Everything is additive: two accessors, two constants, two helper primitives. No existing API changes, and the raw lookups (`getProtectedHeaderParameter(16)`, `getHeaderParameter(15)`, …) keep handing both labels back unchecked.

## What changed

**1. `CoseHeaders::getTyp(): int|string|null`** (`src/Structure/CoseHeaders.php`)

- Reads the **protected bucket only**. RFC 9596 §2: *"The 'typ' parameter MUST NOT be present in unprotected headers."* A message carrying label 16 in the unprotected bucket is rejected, whatever the protected bucket says. The lenient form is the existing raw lookup `getProtectedHeaderParameter(CoseHeaders::LABEL_TYP)`: it never looks at the unprotected bucket and returns the value unchecked — the "strict / lenient" split the issue asks for, on the pattern `CoseHeaders` already has.
- `uint` → CoAP Content-Format number, bounded to 0–65535: RFC 9596 §2 says an integer is *"an unsigned integer as registered in the 'CoAP Content-Formats' registry"*, and RFC 7252 §12.3 registers *"the numeric identifier in the range 0-65535"*.
- `tstr` → media type name. RFC 9596 §2 gives `typ` *"the same [syntax] as the content type header parameter defined in Section 3.1 of [RFC9052]"*, i.e. *"'<type-name>/<subtype-name>', where <type-name> and <subtype-name> are defined in Section 4.2 of [RFC6838]. Leading and trailing whitespace is not permitted."* — and adds that it *"MAY include media type parameters"*. So `"application/cwt"`, `61`, `"application/sd-cwt; version=1"` and `"application/cose+cbor"` are accepted; a bare `"cwt"`, `"/cwt"`, `" application/cwt"` and `65536` are rejected. RFC 9596 defines no `application/` shorthand (unlike JOSE), so `"cwt"` is malformed, not something to expand.
- What the value *means* is left to the application, as §2 says (*"application-specific processing rules"*).

**2. `CoseHeaders::getCwtClaims(): ?MapObject`**

- Protected bucket first, then unprotected. RFC 9597 §2 only *recommends* the protected bucket (*"RECOMMENDED … to avoid the contents being malleable"*), so neither is refused; documented, not enforced, as the issue asks.
- The parameter in **both** buckets is rejected: *"The header parameter MUST only occur once in either the protected or unprotected header of a COSE structure."*
- The value must be a map, and every key a `Claim-Label` (`int / text`, RFC 9597 §2 CDDL) — the label rule of RFC 9052 §1.5 applied to the claims, for the same reason (a `bstr` key `h'31'` normalizes to the offset of the integer 1 in cbor-php). Nothing is read into the claims themselves; the values come back as carried, an indefinite-length map is accepted.

**3. Constants and helpers.** `CoseHeaders::LABEL_TYP` (16) and `CoseHeaders::LABEL_CWT_CLAIMS` (15). In `HeaderMapHelper`: `assertContentTypeValue(CBORObject, string $parameter): int|string` — the `tstr / uint` rule of RFC 9052 §3.1, written once so that it also serves `content type` (label 3) — and `assertValidClaimLabels()`, sharing its implementation with `assertValidLabels()` (whose message is unchanged); `COAP_CONTENT_FORMAT_MAX` (65535).

**4. What the library cannot do, said explicitly.** RFC 9597 §2: when a claim is present both in the header and in the payload, *"an application receiving such a structure MUST verify that their values are identical"*. The payload is opaque to this library, so `doc/Usage.md` says the comparison is the application's, and `examples/08-cwt.php` now signs a token with `typ = "application/cwt"` and `iss`/`exp` repeated in the protected header, reads both before verifying, verifies, then compares every header claim with the payload claim by claim.

## Compatibility

No API removed or changed. New: two public methods and two constants on `CoseHeaders`, two public static methods and one constant on `HeaderMapHelper`. `assertValidLabels()` behaves exactly as before. `RELEASES.md` gains a paragraph in the "4.8.x to 4.9.x" section; `README.md` lists RFC 9596 and RFC 9597 and the two accessors; `doc/Usage.md` has a new *`typ` and `CWT Claims`* subsection under *Reading Headers* and a pointer from the CWT section.

## Tests

1735 → 1796 tests, all green on PHP 8.5; the touched classes also run green on PHP 8.2. ECS, Rector, PHPStan (level max), Deptrac and parallel-lint clean.

Acceptance criteria of #198, each in `CoseHeadersTest`:

- **A protected header carrying both parameters round-trips** — `typAndCwtClaimsRoundTripThroughTheProtectedHeader`, encoded with `HeaderMapHelper::encodeProtected()`, serialized, decoded again, on each of the six message types.
- **`"application/cwt"` and `61` are accepted, `"cwt"` is rejected** — `aWellFormedTypIsRead` (7 cases, parameters and `+suffix` and indefinite-length text included) and `aMalformedTypIsRejected` (12 cases: bare `"cwt"`, empty, missing type or subtype, leading/trailing whitespace, a space inside a name, 65536, 2⁶⁴−1, a negative integer, a byte string, a map).
- **`typ` in the unprotected bucket is rejected by the strict accessor** — `aTypInTheUnprotectedBucketIsRejectedByTheTypedAccessor` (six message types; the raw lookup answers `null`) and `aTypInBothBucketsIsRejectedByTheTypedAccessor`.
- **`CWT Claims` in both buckets is rejected** — `cwtClaimsInBothBucketsAreRejected` (six message types); plus `cwtClaimsInTheUnprotectedBucketAreRead`, `theClaimsAreHandedBackAsCarried` (nested `cnf`, indefinite-length map, text label), `cwtClaimsThatAreNotAMapAreRejected` (4 cases) and `aByteStringClaimLabelIsRejected`.

`HeaderMapHelperTest` covers the two primitives on their own (`claimLabelsAreCheckedTheWayHeaderLabelsAre`, `aContentTypeShapedValueIsDecoded` with the `content type` name in the message). `CwtTest::theHeaderClaimsAreCheckedAgainstThePayload` is the documented flow end to end with a real ES256 signature, and `ExamplesTest` runs the updated `examples/08-cwt.php`.
